### PR TITLE
fix: remove invalid colon from full.yml

### DIFF
--- a/examples/full.yml
+++ b/examples/full.yml
@@ -103,7 +103,7 @@ settings:
             limit: 25
         # It's possible to filter by collection. 
         # Checkout https://github.com/lostb1t/jellyfin-plugin-collection-import to create collections from external lists
-        - title: My collection:
+        - title: My collection
           items:
             # parentID is the collection id. You can find it in the url on the web collection page
             parentId: ab7b2bcacafa97a2ad7d72d86eb1b408


### PR DESCRIPTION
the original full.yml had a line with 
- title: My collection: this second : seemed to be a problem for streamyfin