### PR TITLE
fix: base URL-aware import using ApiClient.getUrl()

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Pages/Application/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Application/index.js
@@ -76,7 +76,7 @@ export default function (view, params) {
 
     // init code here
     view.addEventListener('viewshow', (e) => {
-        import("/web/configurationpage?name=shared.js").then((shared) => {
+        import(window.ApiClient.getUrl("web/configurationpage?name=shared.js")).then((shared) => {
             shared.setPage("Application");
 
             setOptions(shared.getJsonSchema());

--- a/Jellyfin.Plugin.Streamyfin/Pages/Notifications/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Notifications/index.js
@@ -39,7 +39,7 @@ export default function (view, params) {
 
     // init code here
     view.addEventListener('viewshow', (e) => {
-        import("/web/configurationpage?name=shared.js").then((shared) => {
+        import(window.ApiClient.getUrl("web/configurationpage?name=shared.js")).then((shared) => {
             shared.setPage("Notifications");
             
             document.getElementById("notification-endpoint").innerText = shared.NOTIFICATION_URL

--- a/Jellyfin.Plugin.Streamyfin/Pages/Other/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Other/index.js
@@ -11,7 +11,7 @@ export default function (view, params) {
 
     // init code here
     view.addEventListener('viewshow', (e) => {
-        import("/web/configurationpage?name=shared.js").then((shared) => {
+        import(window.ApiClient.getUrl("web/configurationpage?name=shared.js")).then((shared) => {
             shared.setPage("Other");
 
             homePage().options.length = 0;

--- a/Jellyfin.Plugin.Streamyfin/Pages/YamlEditor/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/YamlEditor/index.js
@@ -6,14 +6,14 @@ export default function (view, params) {
 
     // init code here
     view.addEventListener('viewshow', (e) => {
-        import("/web/configurationpage?name=shared.js").then((shared) => {
+        import(window.ApiClient.getUrl("web/configurationpage?name=shared.js")).then((shared) => {
             shared.setPage("Yaml");
             return shared;
         }).then(async (shared) => {
             // Import monaco after shared resources and wait until its done before continuing
             if (!window.monaco) {
                 Dashboard.showLoadingMsg();
-                await import("/web/configurationpage?name=monaco-editor.bundle.js")
+                await import(window.ApiClient.getUrl('web/configurationpage?name=monaco-editor.bundle.js'))
             }
 
             const Page = {

--- a/Jellyfin.Plugin.Streamyfin/Pages/shared.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/shared.js
@@ -162,7 +162,7 @@ export const StreamyfinTabs = () => [
 // region on Shared init
 if (!window.Streamyfin?.shared) {
     // import json-yaml library
-    import("/web/configurationpage?name=js-yaml.js").then((jsYaml) => {
+    import(window.ApiClient.getUrl("web/configurationpage?name=js-yaml.js")).then((jsYaml) => {
         tools.jsYaml = jsYaml;
         
         //fetch default configuration


### PR DESCRIPTION
Use window.ApiClient.getUrl() to construct path for import instead of hardcoded absolute path

Fixes #45
