### PR TITLE
feat: tv sidebar options

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/PluginConfiguration.cs
@@ -81,7 +81,8 @@ public class PluginConfiguration : BasePluginConfiguration
     jellyseerrServerUrl = new() { value = "Enter jellyseerr server url" },
     searchEngine = new() { value = SearchEngine.Jellyfin },
     marlinServerUrl = new() { value = "Enter marlin server url" },
-    libraryOptions = new() { value = new LibraryOptions() },
+  libraryOptions = new() { value = new LibraryOptions() },
+  tvSidebarLinks = new() { value = new SidebarLink[] { } },
     home = new()
     {
       value = new Home

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Enums.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Enums.cs
@@ -78,6 +78,13 @@ public enum DownloadQuality
     High
 }
 
+[JsonConverter(typeof(StringEnumConverter))]
+public enum SidebarLinkType
+{
+    library,
+    collection
+}
+
 // Limit Int range. Don't use Converter for this since we want them to enter int value
 public enum RemuxConcurrentLimit
 {

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -144,6 +144,24 @@ public class SuggestionsArgs
   public BaseItemKind[]? type { get; set; }
 }
 
+public class SidebarLink
+{
+  [NotNull]
+  [Display(Name = "Name", Description = "Display name for the link in the TV sidebar")]
+  public string name { get; set; } = default!;
+
+  [NotNull]
+  [Display(Name = "Type", Description = "The type of link this is (library or collection)")]
+  public SidebarLinkType type { get; set; }
+
+  [NotNull]
+  [Display(Name = "Id", Description = "The target id for the link (Library or Collection id)")]
+  public string id { get; set; } = default!;
+
+  [Display(Name = "Icon", Description = "Optional icon URL to display for the link")]
+  public string? icon { get; set; }
+}
+
 /// <summary>
 /// Streamyfin application settings
 /// </summary>
@@ -269,6 +287,10 @@ public class Settings
     [NotNull]
     [Display(Name = "Library options", Description = "Customize how you want streamfins library tab to look")]
     public Lockable<LibraryOptions>? libraryOptions { get; set; }
+
+  [NotNull]
+  [Display(Name = "TV sidebar links", Description = "Custom links to show in the TV app sidebar")]
+  public Lockable<SidebarLink[]?>? tvSidebarLinks { get; set; }
     
     // TODO: These are used outside of settings. Review usages/delete any unused later.
     // public Lockable<bool?>? forceLandscapeInVideoPlayer { get; set; }

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -160,6 +160,9 @@ public class SidebarLink
 
   [Display(Name = "Icon", Description = "Optional icon URL to display for the link")]
   public string? icon { get; set; }
+
+  [Display(Name = "Sections", Description = "Optional content sections to display when this sidebar link is opened (same schema as home.sections)")]
+  public Section[]? sections { get; set; }
 }
 
 /// <summary>

--- a/examples/full.yml
+++ b/examples/full.yml
@@ -62,10 +62,31 @@ settings:
         type: library
         id: <library id>
         icon: https://example.com/movies.png
+        sections:
+          - title: Recently Added
+            orientation: vertical
+            items:
+              sortBy:
+              - DateCreated
+              sortOrder:
+              - Descending
+              includeItemTypes:
+              - Movie
+              limit: 25
       - name: Netflix
         type: collection
         id: <collection id>
         icon: https://example.com/netflix.png
+        sections:
+          - title: Continue Watching
+            orientation: horizontal
+            items:
+              filters:
+              - IsResumable
+              includeItemTypes:
+              - Episode
+              - Movie
+              limit: 20
 
   # Home
   home:

--- a/examples/full.yml
+++ b/examples/full.yml
@@ -54,6 +54,19 @@ settings:
       showTitles: boolean
       showStats: boolean
 
+  # TV app sidebar
+  tvSidebarLinks:
+    locked: false
+    value:
+      - name: Movies
+        type: library
+        id: <library id>
+        icon: https://example.com/movies.png
+      - name: Netflix
+        type: collection
+        id: <collection id>
+        icon: https://example.com/netflix.png
+
   # Home
   home:
     locked: true


### PR DESCRIPTION
# Summary 
- Introduces a new settings entry `settings.tvSidebarLinks` to configure custom TV app sidebar links (`name`,`type: library|collection`, `id`, `icon`).
- Extends SidebarLink to support optional sections (reusing the existing Section model) so each sidebar link can render curated content like “Recently Added” or “Continue Watching”. 

## Why

Enables richer navigation in the TV app by letting admins present curated, link-specific content pages, improving usability and discoverability.

## Notes

Backward compatible: tvSidebarLinks and sections are optional.
UI/editor and consumption logic can be extended to render per-link sections similarly to home.sections.
