### PR TITLE
feat: Adding custom endpoint option for sections

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -142,7 +142,7 @@ public class CustomEndpoint
   [Display(Name = "Endpoint")]
   public string endpoint { get; set; }
   
-  [Display(Name = "Query headers")]
+  [Display(Name = "Request headers")]
   public SerializableDictionary<string, string>? headers { get; set; }
   
   [Display(Name = "Query parameters")]


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
Similar to the next up and latest sections having their own logic, this PR adds support for the user to configure a section based on an endpoint that returns a `QueryResult<BaseItemDto>`. It allows for plugin endpoints that provide items to be used as sections in streamyfin as well as more flexibility of already exposed JF endpoints for more advanced users.

This change is only to add the support for the custom object into the section configuration for admin usage in the plugin configuration page.

## 🏷️ Ticket / Issue
Relates to https://github.com/streamyfin/streamyfin/issues/1108

## 🛠️ What’s Changed
- Type: feat
- Scope (optional): home screen
- Short summary: `custom` block added to section definition which allows for endpoints to be used on the home screen of streamyfin.

## 📋 Details
**Required Change**: https://github.com/streamyfin/streamyfin/pull/1118

**Usage in yaml config inside the `sections` array**
```
- title: Section title
  orientation: horizontal
  custom:
    endpoint: /Custom/Plugin/Endpoint
    query:
      some_query: argument
```

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
  - _Unsure what is needed here_
- [x] Verified locally that changes behave as expected