### PR TITLE
feat: add Jellyseerr webhook notification integration

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/LocalizationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/LocalizationHelper.cs
@@ -43,7 +43,7 @@ public class LocalizationHelper
         _resourceManager.GetString(key, cultureInfo ?? GetServerCultureInfo()) ?? key;
 
     private CultureInfo? GetServerCultureInfo() {
-        _logger?.LogInformation("Current Server UI Culture: {0}", _serverConfig.Configuration.UICulture);
+        _logger?.LogDebug("Current Server UI Culture: {0}", _serverConfig.Configuration.UICulture);
         return _serverConfig?.Configuration.UICulture != null
             ? CultureInfo.CreateSpecificCulture(_serverConfig.Configuration.UICulture.Replace("\"", ""))
             : null;

--- a/Jellyfin.Plugin.Streamyfin/Pages/Notifications/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Notifications/index.html
@@ -111,6 +111,52 @@
             </div>
         </fieldset>
 
+        <hr style="margin: 2em 0; border: 1px solid #444;">
+
+        <div class="verticalSection">
+            <div class="sectionTitleContainer">
+                <h2 class="sectionTitle">Jellyseerr Integration</h2>
+            </div>
+        </div>
+
+        <p>
+            <strong>Jellyseerr Webhook Endpoint:</strong><br>
+            <code style="font-size: 1.25em" id="jellyseerr-endpoint"></code>
+            <br><br>
+
+            <span style="color: #2196F3; font-weight: bold;">📋 Jellyseerr Webhook Configuration:</span>
+            <ul style="margin-top: 8px;">
+                <li><strong>Webhook URL:</strong> Use the endpoint shown above</li>
+                <li><strong>Notification Types:</strong> Enable all types <strong>EXCEPT</strong> issue-related events</li>
+                <li><strong>JSON Payload:</strong> Use the <strong>DEFAULT</strong> template (do not customize)</li>
+            </ul>
+            <br>
+
+            <span style="color: #4CAF50; font-weight: bold;">✅ Supported Notification Types:</span>
+            <ul style="margin-top: 8px;">
+                <li><strong>MEDIA_PENDING</strong> - New media request (sent to admins)</li>
+                <li><strong>MEDIA_AUTO_APPROVED</strong> - Request auto-approved (sent to admins)</li>
+                <li><strong>MEDIA_FAILED</strong> - Request processing failed (sent to admins)</li>
+                <li><strong>MEDIA_APPROVED</strong> - Request approved (sent to requesting user)</li>
+                <li><strong>MEDIA_DECLINED</strong> - Request declined (sent to requesting user)</li>
+                <li><strong>MEDIA_AVAILABLE</strong> - Media now available (sent to requesting user)</li>
+            </ul>
+            <br>
+
+            <span style="color: orange; font-weight: bold;">⚠️ Important Notes:</span>
+            <ul style="margin-top: 8px;">
+                <li><strong>Jellyseerr Only</strong> - This endpoint is specifically designed for Jellyseerr webhooks</li>
+                <li><strong>Issue Events Not Supported</strong> - All issue-related notification types will be automatically ignored</li>
+                <li><strong>Notification Routing is Fixed</strong> - Routing logic is hardcoded and cannot be configured:
+                    <ul style="margin-top: 8px; margin-left: 20px;">
+                        <li>Admin notifications: MEDIA_PENDING, MEDIA_AUTO_APPROVED, MEDIA_FAILED</li>
+                        <li>User notifications: MEDIA_APPROVED, MEDIA_DECLINED, MEDIA_AVAILABLE</li>
+                    </ul>
+                </li>
+                <li><strong>Localization Support</strong> - Notification content is automatically localized based on server UI culture (supports English, Chinese, French, Spanish, Dutch)</li>
+            </ul>
+        </p>
+
         <div id="config-layout">
             <button id="save-notification-btn" is="emby-button" type="submit" class="raised button-submit block">
                 <span>Save</span>

--- a/Jellyfin.Plugin.Streamyfin/Pages/Notifications/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Notifications/index.js
@@ -46,6 +46,10 @@ export default function (view, params) {
             
             document.getElementById("notification-endpoint").innerText = shared.NOTIFICATION_URL
 
+            // Set Jellyseerr endpoint URL
+            const jellyseerrEndpoint = shared.NOTIFICATION_URL.replace('/notification', '/notification/seerr');
+            document.getElementById("jellyseerr-endpoint").innerText = jellyseerrEndpoint
+
             shared.setDomValues(document, shared.getConfig()?.notifications)
             shared.setOnConfigUpdatedListener('notifications', (config) => {
                 console.log("updating dom for notifications")

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/JellyseerrNotificationMapper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/JellyseerrNotificationMapper.cs
@@ -1,0 +1,147 @@
+using Jellyfin.Plugin.Streamyfin.PushNotifications.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Streamyfin.PushNotifications;
+
+/// <summary>
+/// Maps Jellyseerr webhook notifications to Streamyfin notifications
+/// </summary>
+public class JellyseerrNotificationMapper
+{
+    private readonly LocalizationHelper _localizationHelper;
+    private readonly ILogger<JellyseerrNotificationMapper> _logger;
+
+    public JellyseerrNotificationMapper(
+        LocalizationHelper localizationHelper,
+        ILogger<JellyseerrNotificationMapper> logger)
+    {
+        _localizationHelper = localizationHelper;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Convert Jellyseerr payload to Streamyfin notification
+    /// </summary>
+    /// <param name="payload">Jellyseerr webhook payload</param>
+    /// <returns>Streamyfin notification or null if event should be ignored</returns>
+    public Notification? MapToNotification(JellyseerrNotificationPayload payload)
+    {
+        if (payload == null || string.IsNullOrWhiteSpace(payload.NotificationType))
+        {
+            _logger.LogWarning("Invalid Jellyseerr payload: missing notification type");
+            return null;
+        }
+
+        // Ignore issue-related events
+        if (IsIssueEvent(payload.NotificationType))
+        {
+            _logger.LogDebug("Ignoring issue-related event: {0}", payload.NotificationType);
+            return null;
+        }
+
+        var notificationType = payload.NotificationType.ToUpperInvariant();
+        var mediaName = payload.Subject ?? "Unknown Media";
+        var requestedBy = payload.Request?.RequestedByUsername ?? "Unknown User";
+
+        _logger.LogDebug(
+            "Processing Jellyseerr notification - Original type: '{0}', Normalized type: '{1}', Media: '{2}', Requested by: '{3}'",
+            payload.NotificationType,
+            notificationType,
+            mediaName,
+            requestedBy
+        );
+
+        var notification = new Notification
+        {
+            IsAdmin = false  // Explicitly set default value
+        };
+
+        switch (notificationType)
+        {
+            case "TEST":
+            case "TEST_NOTIFICATION":
+            case "MEDIA_PENDING":
+                notification.IsAdmin = true;
+                notification.Title = _localizationHelper.GetString("JellyseerrRequestPendingTitle");
+                notification.Body = _localizationHelper.GetFormatted(
+                    "JellyseerrRequestPendingBody",
+                    args: new object[] { requestedBy, mediaName }
+                );
+                break;
+
+            case "MEDIA_AUTO_APPROVED":
+                notification.IsAdmin = true;
+                notification.Title = _localizationHelper.GetString("JellyseerrRequestAutoApprovedTitle");
+                notification.Body = _localizationHelper.GetFormatted(
+                    "JellyseerrRequestAutoApprovedBody",
+                    args: new object[] { requestedBy, mediaName }
+                );
+                break;
+
+            case "MEDIA_FAILED":
+                notification.IsAdmin = true;
+                notification.Title = _localizationHelper.GetString("JellyseerrRequestFailedTitle");
+                notification.Body = _localizationHelper.GetFormatted(
+                    "JellyseerrRequestFailedBody",
+                    args: new object[] { requestedBy, mediaName }
+                );
+                break;
+
+            case "MEDIA_APPROVED":
+                notification.Username = requestedBy;
+                notification.Title = _localizationHelper.GetString("JellyseerrRequestApprovedTitle");
+                notification.Body = _localizationHelper.GetFormatted(
+                    "JellyseerrRequestApprovedBody",
+                    args: new object[] { requestedBy, mediaName }
+                );
+                break;
+
+            case "MEDIA_DECLINED":
+                notification.Username = requestedBy;
+                notification.Title = _localizationHelper.GetString("JellyseerrRequestDeclinedTitle");
+                notification.Body = _localizationHelper.GetFormatted(
+                    "JellyseerrRequestDeclinedBody",
+                    args: new object[] { requestedBy, mediaName }
+                );
+                break;
+
+            case "MEDIA_AVAILABLE":
+                notification.Username = requestedBy;
+                notification.Title = _localizationHelper.GetString("JellyseerrRequestAvailableTitle");
+                notification.Body = _localizationHelper.GetFormatted(
+                    "JellyseerrRequestAvailableBody",
+                    args: new object[] { requestedBy, mediaName }
+                );
+                break;
+
+            default:
+                _logger.LogWarning("Unknown Jellyseerr notification type: '{0}', sending to requesting user with original content", notificationType);
+                // Fallback to original subject and message, send to requesting user (safer than sending to all admins)
+                notification.Title = payload.Subject;
+                notification.Body = payload.Message;
+                notification.Username = requestedBy;
+                // Note: IsAdmin is already false from initialization
+                break;
+        }
+
+        _logger.LogDebug(
+            "Mapped Jellyseerr event '{0}' to notification - Title: '{1}', Body: '{2}', IsAdmin: {3}, Username: '{4}'",
+            notificationType,
+            notification.Title ?? "N/A",
+            notification.Body ?? "N/A",
+            notification.IsAdmin,
+            notification.Username ?? "N/A"
+        );
+
+        return notification;
+    }
+
+    /// <summary>
+    /// Check if the notification type is issue-related
+    /// </summary>
+    private bool IsIssueEvent(string notificationType)
+    {
+        var type = notificationType.ToUpperInvariant();
+        return type.Contains("ISSUE");
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/JellyseerrNotification.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/JellyseerrNotification.cs
@@ -1,0 +1,138 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Streamyfin.PushNotifications.Models;
+
+/// <summary>
+/// Jellyseerr webhook notification payload
+/// </summary>
+public class JellyseerrNotificationPayload
+{
+    [JsonPropertyName("notification_type")]
+    public string? NotificationType { get; set; }
+
+    [JsonPropertyName("event")]
+    public string? Event { get; set; }
+
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("image")]
+    public string? Image { get; set; }
+
+    [JsonPropertyName("media")]
+    public JellyseerrMedia? Media { get; set; }
+
+    [JsonPropertyName("request")]
+    public JellyseerrRequest? Request { get; set; }
+
+    [JsonPropertyName("issue")]
+    public JellyseerrIssue? Issue { get; set; }
+
+    [JsonPropertyName("comment")]
+    public JellyseerrComment? Comment { get; set; }
+
+    [JsonPropertyName("extra")]
+    public object[]? Extra { get; set; }
+}
+
+/// <summary>
+/// Media information from Jellyseerr
+/// </summary>
+public class JellyseerrMedia
+{
+    [JsonPropertyName("media_type")]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("tmdbId")]
+    public string? TmdbId { get; set; }
+
+    [JsonPropertyName("tvdbId")]
+    public string? TvdbId { get; set; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("status4k")]
+    public string? Status4k { get; set; }
+}
+
+/// <summary>
+/// Request information from Jellyseerr
+/// </summary>
+public class JellyseerrRequest
+{
+    [JsonPropertyName("request_id")]
+    public string? RequestId { get; set; }
+
+    [JsonPropertyName("requestedBy_email")]
+    public string? RequestedByEmail { get; set; }
+
+    [JsonPropertyName("requestedBy_username")]
+    public string? RequestedByUsername { get; set; }
+
+    [JsonPropertyName("requestedBy_avatar")]
+    public string? RequestedByAvatar { get; set; }
+
+    [JsonPropertyName("requestedBy_settings_discordId")]
+    public string? RequestedBySettingsDiscordId { get; set; }
+
+    [JsonPropertyName("requestedBy_settings_telegramChatId")]
+    public string? RequestedBySettingsTelegramChatId { get; set; }
+}
+
+/// <summary>
+/// Issue information from Jellyseerr
+/// </summary>
+public class JellyseerrIssue
+{
+    [JsonPropertyName("issue_id")]
+    public string? IssueId { get; set; }
+
+    [JsonPropertyName("issue_type")]
+    public string? IssueType { get; set; }
+
+    [JsonPropertyName("issue_status")]
+    public string? IssueStatus { get; set; }
+
+    [JsonPropertyName("reportedBy_email")]
+    public string? ReportedByEmail { get; set; }
+
+    [JsonPropertyName("reportedBy_username")]
+    public string? ReportedByUsername { get; set; }
+
+    [JsonPropertyName("reportedBy_avatar")]
+    public string? ReportedByAvatar { get; set; }
+
+    [JsonPropertyName("reportedBy_settings_discordId")]
+    public string? ReportedBySettingsDiscordId { get; set; }
+
+    [JsonPropertyName("reportedBy_settings_telegramChatId")]
+    public string? ReportedBySettingsTelegramChatId { get; set; }
+}
+
+/// <summary>
+/// Comment information from Jellyseerr
+/// </summary>
+public class JellyseerrComment
+{
+    [JsonPropertyName("comment_message")]
+    public string? CommentMessage { get; set; }
+
+    [JsonPropertyName("commentedBy_email")]
+    public string? CommentedByEmail { get; set; }
+
+    [JsonPropertyName("commentedBy_username")]
+    public string? CommentedByUsername { get; set; }
+
+    [JsonPropertyName("commentedBy_avatar")]
+    public string? CommentedByAvatar { get; set; }
+
+    [JsonPropertyName("commentedBy_settings_discordId")]
+    public string? CommentedBySettingsDiscordId { get; set; }
+
+    [JsonPropertyName("commentedBy_settings_telegramChatId")]
+    public string? CommentedBySettingsTelegramChatId { get; set; }
+}

--- a/Jellyfin.Plugin.Streamyfin/Resources/Strings.es-MX.resx
+++ b/Jellyfin.Plugin.Streamyfin/Resources/Strings.es-MX.resx
@@ -93,7 +93,57 @@
     <!-- endregion ItemAddedEvent -->
 
     <data name="NameAndYear" xml:space="preserve">
-        <!-- 0 = Name, 1 = Year -->U
+        <!-- 0 = Name, 1 = Year -->
         <value>{0} ({1})</value>
     </data>
+
+    <!-- region Jellyseerr Events -->
+    <data name="JellyseerrRequestPendingTitle" xml:space="preserve">
+        <value>Nueva Solicitud de Medios</value>
+    </data>
+    <data name="JellyseerrRequestPendingBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{0} solicitó {1}</value>
+    </data>
+
+    <data name="JellyseerrRequestAutoApprovedTitle" xml:space="preserve">
+        <value>Solicitud Auto-Aprobada</value>
+    </data>
+    <data name="JellyseerrRequestAutoApprovedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>La solicitud de {0} para {1} fue aprobada automáticamente</value>
+    </data>
+
+    <data name="JellyseerrRequestApprovedTitle" xml:space="preserve">
+        <value>Solicitud Aprobada</value>
+    </data>
+    <data name="JellyseerrRequestApprovedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Tu solicitud para {1} ha sido aprobada</value>
+    </data>
+
+    <data name="JellyseerrRequestDeclinedTitle" xml:space="preserve">
+        <value>Solicitud Rechazada</value>
+    </data>
+    <data name="JellyseerrRequestDeclinedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Tu solicitud para {1} ha sido rechazada</value>
+    </data>
+
+    <data name="JellyseerrRequestAvailableTitle" xml:space="preserve">
+        <value>Medios Disponibles</value>
+    </data>
+    <data name="JellyseerrRequestAvailableBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{1} ahora está disponible para ver</value>
+    </data>
+
+    <data name="JellyseerrRequestFailedTitle" xml:space="preserve">
+        <value>Error al Procesar Solicitud</value>
+    </data>
+    <data name="JellyseerrRequestFailedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Error al procesar la solicitud de {1} por {0}</value>
+    </data>
+    <!-- endregion Jellyseerr Events -->
 </root>

--- a/Jellyfin.Plugin.Streamyfin/Resources/Strings.nl.resx
+++ b/Jellyfin.Plugin.Streamyfin/Resources/Strings.nl.resx
@@ -93,7 +93,57 @@
     <!-- endregion ItemAddedEvent -->
 
     <data name="NameAndYear" xml:space="preserve">
-        <!-- 0 = Name, 1 = Year -->U
+        <!-- 0 = Name, 1 = Year -->
         <value>{0} ({1})</value>
     </data>
+
+    <!-- region Jellyseerr Events -->
+    <data name="JellyseerrRequestPendingTitle" xml:space="preserve">
+        <value>Nieuwe Mediaverzoek</value>
+    </data>
+    <data name="JellyseerrRequestPendingBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{0} heeft {1} aangevraagd</value>
+    </data>
+
+    <data name="JellyseerrRequestAutoApprovedTitle" xml:space="preserve">
+        <value>Verzoek Automatisch Goedgekeurd</value>
+    </data>
+    <data name="JellyseerrRequestAutoApprovedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Het verzoek van {0} voor {1} is automatisch goedgekeurd</value>
+    </data>
+
+    <data name="JellyseerrRequestApprovedTitle" xml:space="preserve">
+        <value>Verzoek Goedgekeurd</value>
+    </data>
+    <data name="JellyseerrRequestApprovedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Uw verzoek voor {1} is goedgekeurd</value>
+    </data>
+
+    <data name="JellyseerrRequestDeclinedTitle" xml:space="preserve">
+        <value>Verzoek Afgewezen</value>
+    </data>
+    <data name="JellyseerrRequestDeclinedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Uw verzoek voor {1} is afgewezen</value>
+    </data>
+
+    <data name="JellyseerrRequestAvailableTitle" xml:space="preserve">
+        <value>Media Beschikbaar</value>
+    </data>
+    <data name="JellyseerrRequestAvailableBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{1} is nu beschikbaar om te kijken</value>
+    </data>
+
+    <data name="JellyseerrRequestFailedTitle" xml:space="preserve">
+        <value>Verwerking Verzoek Mislukt</value>
+    </data>
+    <data name="JellyseerrRequestFailedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Kan verzoek voor {1} door {0} niet verwerken</value>
+    </data>
+    <!-- endregion Jellyseerr Events -->
 </root>

--- a/Jellyfin.Plugin.Streamyfin/Resources/Strings.resx
+++ b/Jellyfin.Plugin.Streamyfin/Resources/Strings.resx
@@ -96,4 +96,54 @@
         <!-- 0 = Name, 1 = Year -->
         <value>{0} ({1})</value>
     </data>
+
+    <!-- region Jellyseerr Events -->
+    <data name="JellyseerrRequestPendingTitle" xml:space="preserve">
+        <value>New Media Request</value>
+    </data>
+    <data name="JellyseerrRequestPendingBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{0} requested {1}</value>
+    </data>
+
+    <data name="JellyseerrRequestAutoApprovedTitle" xml:space="preserve">
+        <value>Request Auto-Approved</value>
+    </data>
+    <data name="JellyseerrRequestAutoApprovedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{0}'s request for {1} was automatically approved</value>
+    </data>
+
+    <data name="JellyseerrRequestApprovedTitle" xml:space="preserve">
+        <value>Request Approved</value>
+    </data>
+    <data name="JellyseerrRequestApprovedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Your request for {1} has been approved</value>
+    </data>
+
+    <data name="JellyseerrRequestDeclinedTitle" xml:space="preserve">
+        <value>Request Declined</value>
+    </data>
+    <data name="JellyseerrRequestDeclinedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Your request for {1} has been declined</value>
+    </data>
+
+    <data name="JellyseerrRequestAvailableTitle" xml:space="preserve">
+        <value>Media Available</value>
+    </data>
+    <data name="JellyseerrRequestAvailableBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>{1} is now available to watch</value>
+    </data>
+
+    <data name="JellyseerrRequestFailedTitle" xml:space="preserve">
+        <value>Request Processing Failed</value>
+    </data>
+    <data name="JellyseerrRequestFailedBody" xml:space="preserve">
+        <!-- 0 = Username, 1 = Media name -->
+        <value>Failed to process request for {1} by {0}</value>
+    </data>
+    <!-- endregion Jellyseerr Events -->
 </root>

--- a/Jellyfin.Plugin.Streamyfin/Resources/Strings.zh-CN.resx
+++ b/Jellyfin.Plugin.Streamyfin/Resources/Strings.zh-CN.resx
@@ -16,11 +16,11 @@
 
     <!-- region PlaybackStartEvent -->
     <data name="PlaybackStartTitle" xml:space="preserve">
-        <value>Lecture Lancé</value>
+        <value>开始播放</value>
     </data>
     <data name="UserWatching" xml:space="preserve">
         <!-- 0 = Username -->
-        <value>{0} En visionnage</value>
+        <value>{0} 正在观看</value>
     </data>
     <data name="SeriesSeasonAndEpisode" xml:space="preserve">
         <!-- 0 = Name, 1 = Season index number, 2 = Episode index number -->
@@ -28,67 +28,67 @@
     </data>
     <data name="SeriesSeason" xml:space="preserve">
         <!-- 0 = Name, 1 = Season index number -->
-        <value>{0}, Saison {1}</value>
+        <value>{0}, 第 {1} 季</value>
     </data>
     <data name="Series Episode" xml:space="preserve">
         <!-- 0 = Name, 1 = Episode index number -->
-        <value>{0}, Episode {1}</value>
+        <value>{0}, 第 {1} 集</value>
     </data>
     <!-- endregion PlaybackStartEvent -->
-    
+
     <!-- region SessionStartEvent -->
     <data name="SessionStartTitle" xml:space="preserve">
-        <value>Session lancée</value>
+        <value>会话已开始</value>
     </data>
     <data name="UserNowOnline" xml:space="preserve">
         <!-- 0 = Username -->
-        <value>{0} Est en ligne</value>
+        <value>{0} 现已上线</value>
     </data>
     <!-- endregion SessionStartEvent -->
 
     <!-- region UserLockedOutEvent -->
     <data name="UserLockedOutTitle" xml:space="preserve">
-        <value>Utilisateur bloqué</value>
+        <value>用户已锁定</value>
     </data>
     <data name="UserHasBeenLockedOut" xml:space="preserve">
         <!-- 0 = Username -->
-        <value> L’utilisateur {0} a été bloquer </value>
+        <value>{0} 已被锁定</value>
     </data>
     <!-- endregion SessionStartEvent -->
 
     <!-- region ItemAddedEvent -->
     <data name="ItemAddedTitle" xml:space="preserve">
         <!-- 0 = Media type -->
-        <value>{0} Ajouté</value>
+        <value>{0} 已添加</value>
     </data>
     <data name="EpisodeAddedTitle" xml:space="preserve">
         <!-- 0 = Media type -->
-        <value>Episode ajouté</value>
+        <value>剧集已添加</value>
     </data>
     <data name="EpisodesAddedTitle" xml:space="preserve">
         <!-- 0 = Media type -->
-        <value>Episode ajouté</value>
+        <value>多个剧集已添加</value>
     </data>
 
     <data name="EpisodeNumberAddedForSeason" xml:space="preserve">
         <!-- 0 = Series Name, 1 = Episode index, 2 = Season index -->
-        <value>{0} - Episode {1} ajouté pour la saison {2}</value>
+        <value>{0} - 第 {2} 季第 {1} 集已添加</value>
     </data>
     <data name="EpisodeAdded" xml:space="preserve">
         <!-- 0 = Series Name, 1 = Episode index -->
-        <value>{0} - Episode {1} ajouté</value>
+        <value>{0} - 第 {1} 集已添加</value>
     </data>
     <data name="EpisodeAddedForSeason" xml:space="preserve">
         <!-- 0 = Series Name, 1 = Season index -->
-        <value>{0} - Aflevering toegevoegd voor Seizoen {1}</value>
+        <value>{0} - 第 {1} 季的剧集已添加</value>
     </data>
     <data name="TotalEpisodesAddedForSeason" xml:space="preserve">
         <!-- 0 = Series Name, 1 = Episode count, 2 = Season index -->
-        <value>{0} - {1} Episode(s) ajouté pour la saison {1}</value>
+        <value>{0} - 第 {2} 季添加了 {1} 集</value>
     </data>
     <data name="EpisodesAddedToSeries" xml:space="preserve">
         <!-- 0 = Series Name, 1 = Episode count -->
-        <value>{0} - {1} épisode(s) ajouté</value>
+        <value>{0} - 已添加 {1} 集</value>
     </data>
     <!-- endregion ItemAddedEvent -->
 
@@ -99,51 +99,51 @@
 
     <!-- region Jellyseerr Events -->
     <data name="JellyseerrRequestPendingTitle" xml:space="preserve">
-        <value>Nouvelle Demande de Média</value>
+        <value>新媒体请求</value>
     </data>
     <data name="JellyseerrRequestPendingBody" xml:space="preserve">
         <!-- 0 = Username, 1 = Media name -->
-        <value>{0} a demandé {1}</value>
+        <value>{0} 请求了 {1}</value>
     </data>
 
     <data name="JellyseerrRequestAutoApprovedTitle" xml:space="preserve">
-        <value>Demande Auto-Approuvée</value>
+        <value>请求已自动批准</value>
     </data>
     <data name="JellyseerrRequestAutoApprovedBody" xml:space="preserve">
         <!-- 0 = Username, 1 = Media name -->
-        <value>La demande de {0} pour {1} a été approuvée automatiquement</value>
+        <value>{0} 对 {1} 的请求已自动批准</value>
     </data>
 
     <data name="JellyseerrRequestApprovedTitle" xml:space="preserve">
-        <value>Demande Approuvée</value>
+        <value>请求已批准</value>
     </data>
     <data name="JellyseerrRequestApprovedBody" xml:space="preserve">
         <!-- 0 = Username, 1 = Media name -->
-        <value>Votre demande pour {1} a été approuvée</value>
+        <value>你对 {1} 的请求已被批准</value>
     </data>
 
     <data name="JellyseerrRequestDeclinedTitle" xml:space="preserve">
-        <value>Demande Refusée</value>
+        <value>请求已拒绝</value>
     </data>
     <data name="JellyseerrRequestDeclinedBody" xml:space="preserve">
         <!-- 0 = Username, 1 = Media name -->
-        <value>Votre demande pour {1} a été refusée</value>
+        <value>你对 {1} 的请求已被拒绝</value>
     </data>
 
     <data name="JellyseerrRequestAvailableTitle" xml:space="preserve">
-        <value>Média Disponible</value>
+        <value>媒体已可用</value>
     </data>
     <data name="JellyseerrRequestAvailableBody" xml:space="preserve">
         <!-- 0 = Username, 1 = Media name -->
-        <value>{1} est maintenant disponible pour regarder</value>
+        <value>{1} 现在可以观看了</value>
     </data>
 
     <data name="JellyseerrRequestFailedTitle" xml:space="preserve">
-        <value>Échec du Traitement de la Demande</value>
+        <value>请求处理失败</value>
     </data>
     <data name="JellyseerrRequestFailedBody" xml:space="preserve">
         <!-- 0 = Username, 1 = Media name -->
-        <value>Échec du traitement de la demande pour {1} par {0}</value>
+        <value>处理 {0} 对 {1} 的请求时失败</value>
     </data>
     <!-- endregion Jellyseerr Events -->
 </root>


### PR DESCRIPTION
## Summary

This PR adds Jellyseerr webhook notification integration to Streamyfin, allowing users to receive push notifications for media requests and status updates directly from Jellyseerr.

### Key Features

- **Jellyseerr Webhook Endpoint**: New `POST /notification/seerr` endpoint to receive Jellyseerr webhooks
- **Intelligent Notification Routing**: 
  - Admin notifications: `MEDIA_PENDING`, `MEDIA_AUTO_APPROVED`, `MEDIA_FAILED`
  - User notifications: `MEDIA_APPROVED`, `MEDIA_DECLINED`, `MEDIA_AVAILABLE`
- **Multi-language Support**: Added comprehensive localization (EN, ZH-CN, ES-MX, FR, NL)
- **UI Documentation**: Added Jellyseerr integration guide in plugin settings
- **Improved Logging**: Reduced log verbosity by changing routine operations from Info to Debug level

### Technical Details

- Added `JellyseerrNotificationMapper.cs` to convert Jellyseerr webhook payloads to Streamyfin notifications
- Added `JellyseerrNotification.cs` model with complete Jellyseerr webhook payload structure
- Automatically filters out issue-related events (ISSUE_CREATED, ISSUE_COMMENT, etc.)
- Integrates seamlessly with existing notification infrastructure

### Files Changed

- New: `PushNotifications/JellyseerrNotificationMapper.cs`
- New: `PushNotifications/Models/JellyseerrNotification.cs`
- New: `Resources/Strings.zh-CN.resx`
- Modified: API controller, localization helper, UI pages, and resource files

## ⚠️ Code Generation Disclosure

This PR was generated with assistance from **Claude Code**, and has been:
- ✅ **Manually reviewed** by human developer
- ✅ **Integration tested** with actual Jellyseerr webhooks
- ✅ **Verified** for notification routing logic correctness
- ✅ **Validated** for localization accuracy across all languages

## Configuration Example

Users can configure this in their Jellyseerr instance:
```
Webhook URL: http://your-jellyfin-server/streamyfin/notification/seerr
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)