### PR TITLE
fix: add missing showLargeHomeCarousel setting to YAML config support

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/PluginConfiguration.cs
@@ -70,6 +70,7 @@ public class PluginConfiguration : BasePluginConfiguration
     defaultVideoOrientation = new() { value = OrientationLock.Default },
     safeAreaInControlsEnabled = new() { value = true },
     showCustomMenuLinks = new() { value = false },
+    showLargeHomeCarousel = new() { value = false },
     hiddenLibraries = new() { value = new[] { "Enter library id(s)" } },
     disableHapticFeedback = new() { value = false },
     defaultBitrate = new() { value = null },

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -210,6 +210,10 @@ public class Settings
     [NotNull]
     [Display(Name = "Show custom menu links", Description = "Show custom menu links in Jellyfin's web configuration")]
     public Lockable<bool>? showCustomMenuLinks { get; set; } // = false;
+
+    [NotNull]
+    [Display(Name = "Show large home carousel (beta)", Description = "Enable the large carousel layout on the home screen")]
+    public Lockable<bool>? showLargeHomeCarousel { get; set; }
     
     [NotNull]
     [Display(Name = "Hidden libraries", Description = "Enter all library Ids you want hidden from users")]


### PR DESCRIPTION
Very small changes to add support for the showLargeHomeCarousel setting to the YAML config editor. Since the app introduces this setting (albeit in beta), I wanted to be able to impose this setting on my users.

Running `make test` succeeds on 13/13 tests, and 96 warnings that don't seem relevant to the changes I have made. Testing on my Jellyfin server, I am able to change the value of this setting for my users, and lock the value, however the setting is not greyed out when locked like other settings, which I assume is a Streamyfin app UI change, not a jellyfin-plugin-streamyfin change.