### PR TITLE
Fix: allow negative for autoPlayCount

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Pages/Application/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Application/index.html
@@ -250,7 +250,7 @@
                             id="max-auto-play-episode-count-value"
                             data-key-name="maxAutoPlayEpisodeCount" 
                             data-prop-name="value"
-                            min="1"
+                            min="-1"
                             max="10"
                             step="1"
                             type="number" 


### PR DESCRIPTION
To allow maxAutoPlayCount to be disabled from the plugin with -1