### PR TITLE
Fix: use IUserManager.GetUsers() for Jellyfin 10.11.9+ (fixes notification 500)

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -227,7 +227,7 @@ public class StreamyfinController : ControllerBase
           } 
           else if (notification.Username != null)
           {
-            userId = _userManager.Users.ToList().Find(u => u.Username == notification.Username)?.Id;
+            userId = _userManager.GetUsers().ToList().Find(u => u.Username == notification.Username)?.Id;
           }
           if (userId != null)
           {

--- a/Jellyfin.Plugin.Streamyfin/Extensions/UserManagerExtensions.cs
+++ b/Jellyfin.Plugin.Streamyfin/Extensions/UserManagerExtensions.cs
@@ -10,7 +10,7 @@ namespace Jellyfin.Plugin.Streamyfin.Extensions;
 public static class UserManagerExtensions
 {
     public static List<DeviceToken> GetAdminDeviceTokens(this IUserManager? manager) => (
-        manager?.Users
+        manager?.GetUsers()
             .Where(u => u.Permissions.Any(p => p.Kind == PermissionKind.IsAdministrator && p.Value))
             .SelectMany(u =>
                 StreamyfinPlugin.Instance?.Database.GetUserDeviceTokens(u.Id) ?? Enumerable.Empty<DeviceToken>()) 


### PR DESCRIPTION
---
Jellyfin 10.11.9 removed the IUserManager.Users property and replaced it with the GetUsers() method. The plugin still referenced .Users, so POST /streamyfin/notification threw MissingMethodException: IUserManager.get_Users() and returned HTTP 500 for every notification on 10.11.9+

  This swaps the two .Users call sites over to .GetUsers():
  - Api/StreamyfinController.cs — resolving a target user by username
  - Extensions/UserManagerExtensions.cs — collecting admin device tokens

  GetUsers() returns IEnumerable<User>, so the existing .ToList() / .Where(...) chains are unchanged.

  Fixes #100.

  ---