### PR TITLE
feat(settings): sync lockable settings with the Streamyfin app

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/PluginConfiguration.cs
@@ -67,7 +67,6 @@ public class PluginConfiguration : BasePluginConfiguration
     subtitleMode = new() { value = SubtitlePlaybackMode.Default },
     rememberSubtitleSelections = new() { value = false },
     subtitleSize = new() { value = 80 },
-    autoRotate = new() { value = true },
     defaultVideoOrientation = new() { value = OrientationLock.Default },
     safeAreaInControlsEnabled = new() { value = true },
     showCustomMenuLinks = new() { value = false },

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -176,6 +176,22 @@ public class Settings
     [NotNull]
     [Display(Name = "Remember audio selection", Description = "Allows you to set the audio language from the previous played item")]
     public Lockable<bool>? rememberAudioSelections { get; set; } // = true;
+
+    [NotNull]
+    [Display(Name = "Prefer local audio", Description = "Prefer downloaded audio over streaming when it is available")]
+    public Lockable<bool>? preferLocalAudio { get; set; } // = true;
+
+    [NotNull]
+    [Display(Name = "Audio look-ahead caching", Description = "Pre-cache upcoming tracks for gapless music playback")]
+    public Lockable<bool>? audioLookaheadEnabled { get; set; } // = true;
+
+    [NotNull]
+    [Display(Name = "Audio look-ahead count", Description = "How many upcoming tracks to pre-cache")]
+    public Lockable<int>? audioLookaheadCount { get; set; } // = 1;
+
+    [NotNull]
+    [Display(Name = "Audio max cache size (MB)", Description = "Maximum disk space used for audio look-ahead caching")]
+    public Lockable<int>? audioMaxCacheSizeMB { get; set; } // = 500;
     // TODO create type converter for CultureDto
     //  Currently fails since it doesnt have a parameterless constructor
     // public Lockable<CultureDto?>? defaultAudioLanguage { get; set; }
@@ -195,10 +211,6 @@ public class Settings
     public Lockable<int>? subtitleSize { get; set; } // = 80;
 
     // Other
-    [NotNull]
-    [Display(Name = "Auto rotate", Description = "Grant ability to auto rotate during video playback")]
-    public Lockable<bool>? autoRotate { get; set; } // true
-    
     [NotNull]
     [Display(Name = "Default video orientation", Description = "Lock orientation during video playback")]
     public Lockable<OrientationLock>? defaultVideoOrientation { get; set; }
@@ -225,7 +237,15 @@ public class Settings
 
     [NotNull]
     [Display(Name = "Max auto play episode count")]
-    public Lockable<int>? maxAutoPlayEpisodeCount { get; set; } // = 3 
+    public Lockable<int>? maxAutoPlayEpisodeCount { get; set; } // = 3
+
+    [NotNull]
+    [Display(Name = "Auto play next episode", Description = "Automatically start the next episode when one finishes")]
+    public Lockable<bool>? autoPlayNextEpisode { get; set; } // = true
+
+    [NotNull]
+    [Display(Name = "Default playback speed", Description = "The default video playback speed multiplier")]
+    public Lockable<double>? defaultPlaybackSpeed { get; set; } // = 1.0
 
     // Swipe controls
 
@@ -240,6 +260,14 @@ public class Settings
     [NotNull]
     [Display(Name = "Right side volume control")]
     public Lockable<bool>? enableRightSideVolumeSwipe { get; set; } // = true
+
+    [NotNull]
+    [Display(Name = "Hide volume slider", Description = "Hide the volume slider in the video controls")]
+    public Lockable<bool>? hideVolumeSlider { get; set; } // = false
+
+    [NotNull]
+    [Display(Name = "Hide brightness slider", Description = "Hide the brightness slider in the video controls")]
+    public Lockable<bool>? hideBrightnessSlider { get; set; } // = false
 
     // region Plugins
     // Seerr
@@ -272,6 +300,15 @@ public class Settings
     [NotNull]
     [Display(Name = "Streamystats Promoted Watchlists", Description = "Allow Streamystats to promote watchlists using your watch history")]
     public Lockable<bool>? streamyStatsPromotedWatchlists { get; set; }
+
+    [NotNull]
+    [Display(Name = "Hide watchlists tab", Description = "Hide the Streamystats watchlists tab in the app")]
+    public Lockable<bool>? hideWatchlistsTab { get; set; }
+
+    // KefinTweaks
+    [NotNull]
+    [Display(Name = "KefinTweaks watchlist integration", Description = "Enable the KefinTweaks watchlist integration")]
+    public Lockable<bool>? useKefinTweaks { get; set; }
     // endregion Plugins
     
     // Misc.

--- a/examples/full.yml
+++ b/examples/full.yml
@@ -45,10 +45,6 @@ settings:
     value: 80  # Subtitle size percentage (0-120)
 
   # ==================== Video Orientation ====================
-  autoRotate:
-    locked: false
-    value: true  # Allow auto-rotation during playback
-  
   defaultVideoOrientation:
     locked: false
     value: Default  # Options: Default, PortraitUp, LandscapeLeft, LandscapeRight
@@ -78,6 +74,14 @@ settings:
   enableRightSideVolumeSwipe:
     locked: false
     value: true  # Enable right side swipe for volume control
+
+  hideVolumeSlider:
+    locked: false
+    value: false  # Hide the volume slider in the video controls
+
+  hideBrightnessSlider:
+    locked: false
+    value: false  # Hide the brightness slider in the video controls
 
   # ==================== Library Management ====================
   hiddenLibraries:
@@ -126,6 +130,40 @@ settings:
   streamyStatsPromotedWatchlists:
     locked: false
     value: false  # Enable promoted watchlists
+
+  hideWatchlistsTab:
+    locked: false
+    value: false  # Hide the Streamystats watchlists tab in the app
+
+  # KefinTweaks
+  useKefinTweaks:
+    locked: false
+    value: false  # Enable the KefinTweaks watchlist integration
+
+  # ==================== Playback & Audio ====================
+  autoPlayNextEpisode:
+    locked: false
+    value: true  # Automatically start the next episode when one finishes
+
+  defaultPlaybackSpeed:
+    locked: false
+    value: 1.0  # Default video playback speed multiplier
+
+  preferLocalAudio:
+    locked: false
+    value: true  # Prefer downloaded audio over streaming when available
+
+  audioLookaheadEnabled:
+    locked: false
+    value: true  # Pre-cache upcoming tracks for gapless music playback
+
+  audioLookaheadCount:
+    locked: false
+    value: 1  # How many upcoming tracks to pre-cache
+
+  audioMaxCacheSizeMB:
+    locked: false
+    value: 500  # Maximum disk space (MB) for audio look-ahead caching
 
   # ==================== Custom Home Screen ====================
   home:


### PR DESCRIPTION
## Summary

Sync the plugin's lockable settings schema with what the Streamyfin app actually reads from `pluginSettings`. The app exposes per-setting admin locks for several settings the schema didn't define, so admins couldn't centrally lock or push them — they silently did nothing on the client.

### Added (app reads `pluginSettings.<key>`, schema was missing it)

| Setting | Type | Used by (app) |
|---|---|---|
| `useKefinTweaks` | bool | KefinTweaks plugin toggle |
| `hideWatchlistsTab` | bool | Streamystats watchlists tab |
| `defaultPlaybackSpeed` | double | Playback controls |
| `autoPlayNextEpisode` | bool | Playback controls |
| `hideVolumeSlider` | bool | Gesture controls |
| `hideBrightnessSlider` | bool | Gesture controls |
| `preferLocalAudio` | bool | Music playback |
| `audioLookaheadEnabled` | bool | Music look-ahead cache |
| `audioLookaheadCount` | int | Music look-ahead cache |
| `audioMaxCacheSizeMB` | int | Music look-ahead cache |

### Removed

- `autoRotate` — the app no longer has this setting (dropped in favour of `defaultVideoOrientation`).

### Notes

- Defaults match the app's `defaultValues`. The new settings are nullable `Lockable<T>?` (opt-in), like the existing Streamystats settings — they are not added to `DefaultSettings()`.
- `examples/full.yml` updated to match (autoRotate removed, the 10 new settings documented).
- `seerrServerUrl` left as-is — the app-side `jellyseerr → seerr` rename is handled separately.

Verified against the app's `pluginSettings?.<key>` reads (`utils/atoms/settings.ts` + the settings components). Builds clean for the touched files (the 2 pre-existing `IUserManager.Users` errors on this branch are unrelated to this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio settings including local audio preference and lookahead caching controls
  * Added playback customization with auto-play next episode and default speed options
  * Added UI options to hide volume and brightness sliders
  * Extended integration support with watchlist tab toggle and KefinTweaks options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->