### PR TITLE
feat: use conventional commits to determine semver bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: build and release application
         run: |
-          git config --global user.name 'lostb1t'
-          git config --global user.email 'coding-mosses0z@icloud.com'
+          git config --global user.name 'streamyfin'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 export VERSION := $(shell node scripts/next-version.js)
+ifeq ($(VERSION),)
+$(error Failed to compute VERSION via scripts/next-version.js)
+endif
 export GITHUB_REPO := streamyfin/jellyfin-plugin-streamyfin
 export FILE := streamyfin-${VERSION}.zip
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION := $(shell git describe --tags --abbrev=0 | awk -F. -v OFS=. '{ $$2 = $$2 + 1; $$3 = 0; $$4 = 0; print }')
+export VERSION := $(shell node scripts/next-version.js)
 export GITHUB_REPO := streamyfin/jellyfin-plugin-streamyfin
 export FILE := streamyfin-${VERSION}.zip
 

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -1,0 +1,54 @@
+const { execSync } = require('child_process');
+
+function getLastTag() {
+    try {
+        return execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
+    } catch {
+        return null;
+    }
+}
+
+function getCommitsSince(tag) {
+    try {
+        const range = tag ? `${tag}..HEAD` : 'HEAD';
+        const raw = execSync(`git log ${range} --format=%B%x00`, { encoding: 'utf8' });
+        return raw.split('\x00').map(s => s.trim()).filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+function determineBump(commits) {
+    let bump = 'patch';
+    for (const msg of commits) {
+        const subject = msg.split('\n')[0];
+        const body = msg.split('\n').slice(1).join('\n');
+
+        if (/^(\w+)(\([^)]*\))?!:/.test(subject) || /BREAKING CHANGE/.test(body)) {
+            return 'major';
+        }
+        if (/^feat(\([^)]*\))?:/.test(subject) && bump !== 'major') {
+            bump = 'minor';
+        }
+    }
+    return bump;
+}
+
+function parseVersion(tag) {
+    const parts = tag.replace(/^v/, '').split('.').map(Number);
+    while (parts.length < 4) parts.push(0);
+    return parts.slice(0, 4);
+}
+
+function applyBump([major, minor, patch], bump) {
+    if (bump === 'major') return [major + 1, 0, 0, 0];
+    if (bump === 'minor') return [major, minor + 1, 0, 0];
+    return [major, minor, patch + 1, 0];
+}
+
+const lastTag = getLastTag();
+const commits = getCommitsSince(lastTag);
+const bump = commits.length > 0 ? determineBump(commits) : 'patch';
+const current = lastTag ? parseVersion(lastTag) : [0, 0, 0, 0];
+
+process.stdout.write(applyBump(current, bump).join('.') + '\n');

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -1,8 +1,8 @@
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 function getLastTag() {
     try {
-        return execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
+        return execFileSync('git', ['describe', '--tags', '--abbrev=0'], { encoding: 'utf8' }).trim();
     } catch {
         return null;
     }
@@ -11,7 +11,7 @@ function getLastTag() {
 function getCommitsSince(tag) {
     try {
         const range = tag ? `${tag}..HEAD` : 'HEAD';
-        const raw = execSync(`git log ${range} --format=%B%x00`, { encoding: 'utf8' });
+        const raw = execFileSync('git', ['log', range, '--format=%B%x00'], { encoding: 'utf8' });
         return raw.split('\x00').map(s => s.trim()).filter(Boolean);
     } catch {
         return [];
@@ -24,7 +24,7 @@ function determineBump(commits) {
         const subject = msg.split('\n')[0];
         const body = msg.split('\n').slice(1).join('\n');
 
-        if (/^(\w+)(\([^)]*\))?!:/.test(subject) || /BREAKING CHANGE/.test(body)) {
+        if (/^(\w+)(\([^)]*\))?!:/.test(subject) || /BREAKING(?: |-)CHANGE:/.test(body)) {
             return 'major';
         }
         if (/^feat(\([^)]*\))?:/.test(subject) && bump !== 'major') {
@@ -36,6 +36,9 @@ function determineBump(commits) {
 
 function parseVersion(tag) {
     const parts = tag.replace(/^v/, '').split('.').map(Number);
+    if (parts.some(n => !Number.isFinite(n) || n < 0)) {
+        throw new Error(`Invalid version tag: ${tag}`);
+    }
     while (parts.length < 4) parts.push(0);
     return parts.slice(0, 4);
 }

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -3,6 +3,9 @@ const { execFileSync } = require('child_process');
 // Only consider real version tags (e.g. 1.2.3 or 1.2.3.4); ignore backup/* and
 // other non-version tags so they can never pollute the computed version.
 const VERSION_TAG_GLOB = '[0-9]*.[0-9]*';
+// Strict shape check: optional `v`, then 2 to 4 numeric segments. Rejects
+// malformed tags like `1..2` or `1.2.` that `Number()` would coerce to 0.
+const VERSION_TAG_RE = /^v?\d+(?:\.\d+){1,3}$/;
 
 const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
 
@@ -35,10 +38,10 @@ function determineBump(commits) {
 }
 
 function parseVersion(tag) {
-  const parts = tag.replace(/^v/, '').split('.').map(Number);
-  if (!parts.length || parts.some((n) => !Number.isInteger(n) || n < 0)) {
+  if (!VERSION_TAG_RE.test(tag)) {
     throw new Error(`Invalid version tag: ${tag}`);
   }
+  const parts = tag.replace(/^v/, '').split('.').map(Number);
   while (parts.length < 4) parts.push(0);
   return parts.slice(0, 4);
 }

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -1,57 +1,59 @@
 const { execFileSync } = require('child_process');
 
-function getLastTag() {
-    try {
-        return execFileSync('git', ['describe', '--tags', '--abbrev=0'], { encoding: 'utf8' }).trim();
-    } catch {
-        return null;
-    }
+// Only consider real version tags (e.g. 1.2.3 or 1.2.3.4); ignore backup/* and
+// other non-version tags so they can never pollute the computed version.
+const VERSION_TAG_GLOB = '[0-9]*.[0-9]*';
+
+const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
+
+function lastVersionTag() {
+  try {
+    return git(['describe', '--tags', '--abbrev=0', '--match', VERSION_TAG_GLOB]).trim() || null;
+  } catch {
+    return null;
+  }
 }
 
-function getCommitsSince(tag) {
-    try {
-        const range = tag ? `${tag}..HEAD` : 'HEAD';
-        const raw = execFileSync('git', ['log', range, '--format=%B%x00'], { encoding: 'utf8' });
-        return raw.split('\x00').map(s => s.trim()).filter(Boolean);
-    } catch {
-        return [];
-    }
+function commitsSince(tag) {
+  try {
+    const range = tag ? `${tag}..HEAD` : 'HEAD';
+    return git(['log', range, '--format=%B%x00'])
+      .split('\0').map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
 }
 
 function determineBump(commits) {
-    let bump = 'patch';
-    for (const msg of commits) {
-        const subject = msg.split('\n')[0];
-        const body = msg.split('\n').slice(1).join('\n');
-
-        if (/^(\w+)(\([^)]*\))?!:/.test(subject) || /BREAKING(?: |-)CHANGE:/.test(body)) {
-            return 'major';
-        }
-        if (/^feat(\([^)]*\))?:/.test(subject) && bump !== 'major') {
-            bump = 'minor';
-        }
-    }
-    return bump;
+  let bump = 'patch';
+  for (const msg of commits) {
+    const subject = msg.split('\n', 1)[0];
+    if (/^\w+(\([^)]*\))?!:/.test(subject) || /BREAKING[ -]CHANGE:/.test(msg)) return 'major';
+    if (/^feat(\([^)]*\))?:/.test(subject)) bump = 'minor';
+  }
+  return bump;
 }
 
 function parseVersion(tag) {
-    const parts = tag.replace(/^v/, '').split('.').map(Number);
-    if (parts.some(n => !Number.isFinite(n) || n < 0)) {
-        throw new Error(`Invalid version tag: ${tag}`);
-    }
-    while (parts.length < 4) parts.push(0);
-    return parts.slice(0, 4);
+  const parts = tag.replace(/^v/, '').split('.').map(Number);
+  if (!parts.length || parts.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new Error(`Invalid version tag: ${tag}`);
+  }
+  while (parts.length < 4) parts.push(0);
+  return parts.slice(0, 4);
 }
 
 function applyBump([major, minor, patch], bump) {
-    if (bump === 'major') return [major + 1, 0, 0, 0];
-    if (bump === 'minor') return [major, minor + 1, 0, 0];
-    return [major, minor, patch + 1, 0];
+  if (bump === 'major') return [major + 1, 0, 0, 0];
+  if (bump === 'minor') return [major, minor + 1, 0, 0];
+  return [major, minor, patch + 1, 0];
 }
 
-const lastTag = getLastTag();
-const commits = getCommitsSince(lastTag);
-const bump = commits.length > 0 ? determineBump(commits) : 'patch';
-const current = lastTag ? parseVersion(lastTag) : [0, 0, 0, 0];
+const tag = lastVersionTag();
+const current = tag ? parseVersion(tag) : [0, 0, 0, 0];
+const next = applyBump(current, tag ? determineBump(commitsSince(tag)) : 'minor');
 
-process.stdout.write(applyBump(current, bump).join('.') + '\n');
+if (next.some((n) => !Number.isInteger(n) || n < 0)) {
+  throw new Error(`Computed invalid version: ${next.join('.')}`);
+}
+process.stdout.write(next.join('.') + '\n');


### PR DESCRIPTION
## Summary

- Replace the hardcoded minor-bump `awk` one-liner in `Makefile` with a new `scripts/next-version.js` script
- The script reads commits since the last tag and determines the correct bump level according to [Conventional Commits](https://www.conventionalcommits.org/) and [semver](https://semver.org/lang/fr/)
- PR titles are already enforced by `lint_pr.yml`, so this change makes the version bump consistent with what's already required

## Bump rules

| Commits since last tag | Bump | Example |
|---|---|---|
| `fix:`, `chore:`, `refactor:`, etc. | PATCH | `0.67.0.0` → `0.67.1.0` |
| `feat:` | MINOR | `0.67.0.0` → `0.68.0.0` |
| `feat!:` or `BREAKING CHANGE` in body | MAJOR | `0.67.0.0` → `1.0.0.0` |

## Test plan

- [ ] Run `node scripts/next-version.js` locally — should output the correct next version based on commits since last tag
- [ ] Run `make print` — should match the output above
- [ ] Verify PATCH bump: only `fix:` commits since last tag → version ends in `.1.0`
- [ ] Verify MINOR bump: at least one `feat:` commit → second segment increments
- [ ] Verify MAJOR bump: commit with `feat!:` or `BREAKING CHANGE` in body → first segment increments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automatic version numbering by generating the next semantic version from Git history.
  * Bump logic now detects breaking changes and conventional feature commits to choose major/minor/patch.
  * Version parsing and validation were hardened, and the build now fails early if the computed version is invalid.
* **CI**
  * Updated the Git commit author identity used during the release workflow’s build-and-release step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->