### PR TITLE
fix(examples): revert leftover seerr naming to jellyseerr

### DIFF
--- a/examples/episodeimages.yml
+++ b/examples/episodeimages.yml
@@ -96,10 +96,10 @@ settings:
 
   # ==================== Third-Party Integrations ====================
   
-  # Seerr (Media Request Management)
-  seerrServerUrl:
+  # Jellyseerr (Media Request Management)
+  jellyseerrServerUrl:
     locked: false
-    value: "Enter Seerr server URL"  # e.g., https://seerr.example.com
+    value: "Enter jellyseerr server url"  # e.g., https://jellyseerr.example.com
   
   # Marlin (Enhanced Search)
   searchEngine:

--- a/examples/watchlist
+++ b/examples/watchlist
@@ -96,10 +96,10 @@ settings:
 
   # ==================== Third-Party Integrations ====================
   
-  # Seerr (Media Request Management)
-  seerrServerUrl:
+  # Jellyseerr (Media Request Management)
+  jellyseerrServerUrl:
     locked: false
-    value: "Enter Seerr server URL"  # e.g., https://seerr.example.com
+    value: "Enter jellyseerr server url"  # e.g., https://jellyseerr.example.com
   
   # Marlin (Enhanced Search)
   searchEngine:


### PR DESCRIPTION
Follow-up to #105.

Two example files — `examples/episodeimages.yml` and `examples/watchlist` — were added in #92 (*more examples*) carrying the migrated `seerrServerUrl` key. They were created after the #105 revert branch was cut, so the revert missed them, leaving them inconsistent with the now-restored `jellyseerrServerUrl` config key.

This aligns both example blocks with the reverted naming (comment, key, example value), matching `examples/full.yml`.

Docs/examples only — no code or build impact.
🤖 Generated with [Claude Code](https://claude.com/claude-code)