### PR TITLE
chore: drop failed 0.67.0.0 release bookkeeping

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
+++ b/Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
@@ -2,8 +2,8 @@
 <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Streamyfin</RootNamespace>
-    <AssemblyVersion>0.67.0.0</AssemblyVersion>
-    <FileVersion>0.67.0.0</FileVersion>
+    <AssemblyVersion>0.66.0.0</AssemblyVersion>
+    <FileVersion>0.66.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/manifest.json
+++ b/manifest.json
@@ -9,14 +9,6 @@
         "imageUrl": "https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/logo.png",
         "versions": [
             {
-                "version": "0.67.0.0",
-                "changelog": "- See the full changelog at [GitHub](https://github.com/streamyfin/jellyfin-plugin-streamyfin/releases/tag/0.67.0.0)\n",
-                "targetAbi": "10.11.11",
-                "sourceUrl": "https://github.com/streamyfin/jellyfin-plugin-streamyfin/releases/download/0.67.0.0/streamyfin-0.67.0.0.zip",
-                "checksum": "d926306b271007b00e365e3616ab4744",
-                "timestamp": "2026-06-20T13:12:28Z"
-            },
-            {
                 "version": "0.66.0.0",
                 "changelog": "- See the full changelog at [GitHub](https://github.com/streamyfin/jellyfin-plugin-streamyfin/releases/tag/0.66.0.0)\n",
                 "targetAbi": "10.11.0",


### PR DESCRIPTION
Prep for republishing **0.67.0.0** (the prior 0.67.0.0 shipped the breaking jellyseerr→seerr rename, now reverted on main via #105/#106).

Reverts the `dd29704` release bookkeeping:
- Removes the stale `0.67.0.0` entry from `manifest.json`
- Resets `csproj` version back to `0.66.0.0`

This lets the release workflow recompute the version cleanly (latest tag becomes `0.66.0.0` → bumps to `0.67.0.0`) and append a fresh manifest entry with the corrected checksum, instead of producing `0.68.0.0` or a duplicate entry.

**After merge:** the `0.67.0.0` git tag + GitHub release must be deleted, then dispatch *Create release* on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)