### PR TITLE
feat: distributable Seerr API key for passwordless sign-in

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -296,6 +296,10 @@ public class Settings
     [Display(Name = "Jellyseerr Server URL", Description = "Enter the url for your jellyseerr server. **Jellyfin authentication is required**")]
     public Lockable<string>? jellyseerrServerUrl { get; set; }
 
+    [NotNull]
+    [Display(Name = "Jellyseerr API Key", Description = "Seerr admin API key (Seerr Settings > General). Lets Streamyfin sign each user in to Seerr without a password. **Warning: every authenticated Jellyfin user on this server can read this key and it grants full admin access to the Seerr API — only set it if you trust all of your users.** Requires a Seerr version with the /user/jellyfin/{id} route.")]
+    public Lockable<string>? jellyseerrApiKey { get; set; }
+
     // Marlin Search
     [NotNull]
     [Display(Name = "Default search engine", Description = "Enter the search engine you want to use in streamyfin")]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Enable automatic authentication for your users:
 2. Ensure Jellyseerr is configured for **Jellyfin authentication**
 3. Users will be automatically logged in when opening Jellyseerr from the app
 
+Optionally set the **Jellyseerr API Key** (Seerr Settings > General) to let Streamyfin sign users in without a password — this also covers Quick Connect and OIDC logins, which have no password. **Warning:** every authenticated Jellyfin user can read this key and it grants full admin access to the Seerr API, so only set it on servers where you trust all users. Requires a Seerr version with the `/user/jellyfin/{id}` route and a Streamyfin version with API-key sign-in.
+
 ### Streamystats Integration
 Get personalized recommendations:
 1. Set your Streamystats server URL

--- a/examples/full.yml
+++ b/examples/full.yml
@@ -104,6 +104,13 @@ settings:
   jellyseerrServerUrl:
     locked: false
     value: "Enter jellyseerr server url"  # e.g., https://jellyseerr.example.com
+  # Optional: Seerr admin API key (Seerr Settings > General). Lets Streamyfin
+  # sign each user in to Seerr without a password (works with Quick Connect).
+  # WARNING: every authenticated Jellyfin user can read this key and it grants
+  # full admin access to the Seerr API. Only set it if you trust all users.
+  # jellyseerrApiKey:
+  #   locked: true
+  #   value: "your-seerr-api-key"
   
   # Marlin (Enhanced Search)
   searchEngine:


### PR DESCRIPTION
## Description

Add an optional `jellyseerrApiKey` setting next to `jellyseerrServerUrl`. When an admin sets it, Streamyfin resolves each user's Seerr account through Seerr's `/user/jellyfin/{id}` route (seerr-team/seerr#2074) and signs them in without a password. This also covers Quick Connect and OIDC logins, which have no password to replay.

App side: streamyfin/streamyfin#1973 (already reads `jellyseerrApiKey` from the plugin config, including the locked state).

## Security note

This is the Seerr **admin** API key, and `GET /Streamyfin/config` is readable by every authenticated Jellyfin user. Setting it means anyone with an account on the server can extract the key and act as Seerr admin via the raw API. The setting description, README, and example YAML all carry this warning, and the example ships commented out. Intended for servers where all users are trusted (the typical family/friends instance).

## Testing

`dotnet build` passes with no new warnings. I could not run `dotnet test` locally (missing .NET 9 runtime on this machine), CI should cover it. The JSON schema for the YAML editor is generated from the Settings class, so the new key validates automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Jellyseerr API-key authentication.
  * Supports passwordless Seerr sign-in for Quick Connect and OIDC users.
  * API-key settings include admin-privilege and security warnings.

* **Documentation**
  * Updated the Jellyseerr integration guide with authentication requirements, supported versions, and security considerations.
  * Added a sample configuration entry with guidance for safely sharing administrator API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->