### PR TITLE
fix: show the Jellyseerr API key field on the settings page

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Pages/Application/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Application/index.html
@@ -326,6 +326,18 @@
                             <span>Locked</span>
                         </label>
                     </div>
+
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="jellyseerr-api-key-value">Jellyseerr API Key</label>
+                        <input id="jellyseerr-api-key-value" data-key-name="jellyseerrApiKey" data-prop-name="value" type="password" autocomplete="off" is="emby-input"/>
+                        <div class="fieldDescription">Seerr admin API key (Seerr Settings &gt; General). Lets Streamyfin sign each user in to Seerr without a password.<br><b>Warning: every authenticated Jellyfin user can read this key and it grants full admin access to the Seerr API &mdash; only set it if you trust all of your users.</b><br>Requires a Seerr version with the /user/jellyfin/{id} route.</div>
+                    </div>
+                    <div class="checkboxContainer">
+                        <label class="emby-checkbox-label">
+                            <input id="jellyseerr-api-key-locked" data-key-name="jellyseerrApiKey" data-prop-name="locked" type="checkbox" is="emby-checkbox"/>
+                            <span>Locked</span>
+                        </label>
+                    </div>
                     <hr class="input-divider"/>
 
                     <div class="inputContainer">


### PR DESCRIPTION
## Description

Follow-up to #111: the `jellyseerrApiKey` setting existed in the model (and the YAML editor, which is schema-generated) but the visual settings page is hand-written HTML, so the field never appeared there. This adds the input and its Locked checkbox right under the Jellyseerr Server URL, with the same admin-key warning as the setting description. The input is `type="password"` so the key is masked in the dashboard.

No JS changes needed — the page binds inputs generically via `data-key-name`/`data-prop-name`.

## Testing

`dotnet build` passes. Verified the binding code only special-cases checkboxes, so a password input round-trips like a text input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Jellyseerr API key setting to the plugin configuration page.
  * API keys are masked for security and include a warning about administrative access and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->