### PR TITLE
docs(examples): document the segment skip settings

### DIFF
--- a/examples/full.yml
+++ b/examples/full.yml
@@ -26,6 +26,28 @@ settings:
     locked: false
     value: 3  # Maximum episodes to autoplay (1-10)
 
+  # ==================== Media Segment Skip ====================
+  # Every type takes: none (never skip), ask (show a skip button), auto (skip on its own)
+  skipIntro:
+    locked: false
+    value: ask  # Intro segments
+
+  skipOutro:
+    locked: false
+    value: ask  # Outro / credits segments
+
+  skipRecap:
+    locked: false
+    value: ask  # Recap segments
+
+  skipCommercial:
+    locked: false
+    value: ask  # Commercial segments
+
+  skipPreview:
+    locked: false
+    value: ask  # Preview segments
+
   # ==================== Audio Settings ====================
   rememberAudioSelections:
     locked: false


### PR DESCRIPTION
## Summary

#87 added the five media segment skip settings to `Settings.cs` but never documented them in `examples/full.yml`, which claims to show every supported setting. They have been shippable since 0.67.0.0 and an admin reading the example had no way to know they exist.

Adds a `Media Segment Skip` section with `skipIntro`, `skipOutro`, `skipRecap`, `skipCommercial` and `skipPreview`, all defaulting to `ask` like the app does, and a one-line reminder of the three accepted values.

### Notes

- Documentation only, no C# touched.
- `examples/full.yml` still parses, and the five keys read back as `{ locked: false, value: ask }`.
- Checked the rest of the file against `Settings.cs` while I was there: no other supported setting is missing. `defaultAudioLanguage` and `defaultSubtitleLanguage` are still commented out on the C# side (the `CultureDto` converter TODO), so they stay out of the example.
- The app half is streamyfin/streamyfin#1367, which reads these keys and honours `locked` on both the mobile and TV settings screens. Setting them today has no effect until that lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable media segment skipping for intros, outros, recaps, commercials, and previews.
  * Supports three modes: never skip, ask before skipping, or skip automatically.
  * Settings default to asking and can be customized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->