### PR TITLE
build: select the Jellyfin target with an MSBuild switch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,17 +4,17 @@
     Build target selector. The same source produces two artifacts, one per
     Jellyfin runtime, never a single DLL for both:
 
-      JellyfinTarget=jf10  -> Jellyfin 10.11, .NET 9
+      JellyfinTarget=jf11  -> Jellyfin 10.11, .NET 9
       JellyfinTarget=jf12  -> Jellyfin 12,    .NET 10
 
     Build the other target with: dotnet build -p:JellyfinTarget=jf12
 
-    The default stays jf10 while 12 is a release candidate. Flip it the day 12
-    goes stable, and drop the jf10 block entirely the day 10.11 support ends.
+    The default stays jf11 while 12 is a release candidate. Flip it the day 12
+    goes stable, and drop the jf11 block entirely the day 10.11 support ends.
     See Jellyfin.Plugin.Streamyfin/Compat/README.md for the removal procedure.
   -->
   <PropertyGroup>
-    <JellyfinTarget Condition="'$(JellyfinTarget)' == ''">jf10</JellyfinTarget>
+    <JellyfinTarget Condition="'$(JellyfinTarget)' == ''">jf11</JellyfinTarget>
   </PropertyGroup>
 
   <!--
@@ -29,13 +29,13 @@
     through 10.11.8 as well. Those servers should update. This is still wider
     than the current manifest, which demands 10.11.11.
   -->
-  <PropertyGroup Condition="'$(JellyfinTarget)' == 'jf10'">
+  <PropertyGroup Condition="'$(JellyfinTarget)' == 'jf11'">
     <TargetFramework>net9.0</TargetFramework>
     <JellyfinVersion>10.11.9</JellyfinVersion>
     <JellyfinAbi>10.11.9.0</JellyfinAbi>
     <RuntimeJsonVersion>9.0.0</RuntimeJsonVersion>
     <RuntimeSqliteVersion>9.0.1</RuntimeSqliteVersion>
-    <DefineConstants>$(DefineConstants);JF10</DefineConstants>
+    <DefineConstants>$(DefineConstants);JF11</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(JellyfinTarget)' == 'jf12'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,50 @@
+<Project>
+
+  <!--
+    Build target selector. The same source produces two artifacts, one per
+    Jellyfin runtime, never a single DLL for both:
+
+      JellyfinTarget=jf10  -> Jellyfin 10.11, .NET 9
+      JellyfinTarget=jf12  -> Jellyfin 12,    .NET 10
+
+    Build the other target with: dotnet build -p:JellyfinTarget=jf12
+
+    The default stays jf10 while 12 is a release candidate. Flip it the day 12
+    goes stable, and drop the jf10 block entirely the day 10.11 support ends.
+    See Jellyfin.Plugin.Streamyfin/Compat/README.md for the removal procedure.
+  -->
+  <PropertyGroup>
+    <JellyfinTarget Condition="'$(JellyfinTarget)' == ''">jf10</JellyfinTarget>
+  </PropertyGroup>
+
+  <!--
+    Jellyfin.Controller is pinned rather than left floating on 10.11.*-*, so the
+    minimum supported server is a decision instead of whatever happened to be
+    latest on build day. A newer host satisfies a lower reference; the reverse
+    is not true.
+
+    10.11.9 is the floor of what this plugin actually uses, not the floor of the
+    line. IUserManager.Users was replaced by IUserManager.GetUsers() in 10.11.9,
+    a breaking change inside the patch line, so no single build covers 10.11.0
+    through 10.11.8 as well. Those servers should update. This is still wider
+    than the current manifest, which demands 10.11.11.
+  -->
+  <PropertyGroup Condition="'$(JellyfinTarget)' == 'jf10'">
+    <TargetFramework>net9.0</TargetFramework>
+    <JellyfinVersion>10.11.9</JellyfinVersion>
+    <JellyfinAbi>10.11.9.0</JellyfinAbi>
+    <RuntimeJsonVersion>9.0.0</RuntimeJsonVersion>
+    <RuntimeSqliteVersion>9.0.1</RuntimeSqliteVersion>
+    <DefineConstants>$(DefineConstants);JF10</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(JellyfinTarget)' == 'jf12'">
+    <TargetFramework>net10.0</TargetFramework>
+    <JellyfinVersion>12.0.0-rc5</JellyfinVersion>
+    <JellyfinAbi>12.0.0.0</JellyfinAbi>
+    <RuntimeJsonVersion>10.0.11</RuntimeJsonVersion>
+    <RuntimeSqliteVersion>10.0.11</RuntimeSqliteVersion>
+    <DefineConstants>$(DefineConstants);JF12</DefineConstants>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,8 +6,8 @@
     Fail here instead, with the accepted values.
   -->
   <Target Name="ValidateJellyfinTarget" BeforeTargets="PrepareForBuild;Restore">
-    <Error Condition="'$(JellyfinTarget)' != 'jf10' AND '$(JellyfinTarget)' != 'jf12'"
-           Text="Unknown JellyfinTarget '$(JellyfinTarget)'. Use jf10 (Jellyfin 10.11, .NET 9) or jf12 (Jellyfin 12, .NET 10)." />
+    <Error Condition="'$(JellyfinTarget)' != 'jf11' AND '$(JellyfinTarget)' != 'jf12'"
+           Text="Unknown JellyfinTarget '$(JellyfinTarget)'. Use jf11 (Jellyfin 10.11, .NET 9) or jf12 (Jellyfin 12, .NET 10)." />
   </Target>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    A typo in -p:JellyfinTarget leaves TargetFramework empty, and MSBuild then
+    fails deep in restore with an error that says nothing about the real cause.
+    Fail here instead, with the accepted values.
+  -->
+  <Target Name="ValidateJellyfinTarget" BeforeTargets="PrepareForBuild;Restore">
+    <Error Condition="'$(JellyfinTarget)' != 'jf10' AND '$(JellyfinTarget)' != 'jf12'"
+           Text="Unknown JellyfinTarget '$(JellyfinTarget)'. Use jf10 (Jellyfin 10.11, .NET 9) or jf12 (Jellyfin 12, .NET 10)." />
+  </Target>
+
+</Project>

--- a/Jellyfin.Plugin.Streamyfin.Tests/CompatBoundaryTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/CompatBoundaryTests.cs
@@ -15,29 +15,33 @@ namespace Jellyfin.Plugin.Streamyfin.Tests;
 /// </summary>
 public class CompatBoundaryTests
 {
+    // Matches NET<n>_0 rather than the two current monikers, and spells out
+    // _OR_GREATER: a word boundary after NET10_0 does not stop at
+    // NET10_0_OR_GREATER, since the underscore is a word character, so that
+    // spelling slipped straight through.
     private static readonly Regex VersionDirective = new(
-        @"^[^\S\r\n]*#[^\S\r\n]*(?:if|elif)\b[^\r\n]*\b(?:JF10|JF12|NET9_0|NET10_0)\b",
+        @"^[^\S\r\n]*#[^\S\r\n]*(?:if|elif)\b[^\r\n]*\b(?:JF11|JF12|NET\d+_0(?:_OR_GREATER)?)\b",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
     [Fact]
     public void VersionSpecificCodeStaysInTheCompatFolder()
     {
-        var projectRoot = PluginProjectRoot();
+        var repositoryRoot = RepositoryRoot();
         Assert.True(
-            Directory.Exists(projectRoot),
-            $"Plugin sources not found at '{projectRoot}'. This test reads the checkout it was compiled from.");
+            Directory.Exists(repositoryRoot),
+            $"Sources not found at '{repositoryRoot}'. This test reads the checkout it was compiled from.");
 
-        var compatRoot = Path.Combine(projectRoot, "Compat") + Path.DirectorySeparatorChar;
+        var compatRoot = Path.Combine(repositoryRoot, "Jellyfin.Plugin.Streamyfin", "Compat") + Path.DirectorySeparatorChar;
 
         var offenders = new List<string>();
-        foreach (var file in Directory.EnumerateFiles(projectRoot, "*.cs", SearchOption.AllDirectories))
+        foreach (var file in Directory.EnumerateFiles(repositoryRoot, "*.cs", SearchOption.AllDirectories))
         {
-            if (file.StartsWith(compatRoot, StringComparison.OrdinalIgnoreCase) || IsBuildOutput(file, projectRoot))
+            if (file.StartsWith(compatRoot, StringComparison.OrdinalIgnoreCase) || IsBuildOutput(file, repositoryRoot))
             {
                 continue;
             }
 
-            var relative = Path.GetRelativePath(projectRoot, file);
+            var relative = Path.GetRelativePath(repositoryRoot, file);
             offenders.AddRange(
                 VersionDirective.Matches(File.ReadAllText(file))
                     .Select(match => $"{relative}: {match.Value.Trim()}"));
@@ -51,18 +55,18 @@ public class CompatBoundaryTests
             + string.Join(Environment.NewLine, offenders));
     }
 
-    private static bool IsBuildOutput(string file, string projectRoot)
+    private static bool IsBuildOutput(string file, string repositoryRoot)
     {
-        var relative = Path.GetRelativePath(projectRoot, file);
-        var first = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)[0];
-        return first.Equals("bin", StringComparison.OrdinalIgnoreCase)
-            || first.Equals("obj", StringComparison.OrdinalIgnoreCase);
+        var relative = Path.GetRelativePath(repositoryRoot, file);
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return segments.Any(segment =>
+            segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+            || segment.Equals("obj", StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string PluginProjectRoot([CallerFilePath] string testFilePath = "")
+    private static string RepositoryRoot([CallerFilePath] string testFilePath = "")
     {
         var testsDirectory = Path.GetDirectoryName(testFilePath)!;
-        var repositoryRoot = Path.GetDirectoryName(testsDirectory)!;
-        return Path.Combine(repositoryRoot, "Jellyfin.Plugin.Streamyfin");
+        return Path.GetDirectoryName(testsDirectory)!;
     }
 }

--- a/Jellyfin.Plugin.Streamyfin.Tests/CompatBoundaryTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/CompatBoundaryTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Guards the rule stated in Compat/README.md: version specific code lives in
+/// the Compat folder and nowhere else, so that retiring a Jellyfin version is a
+/// deletion rather than a hunt through the whole codebase.
+/// </summary>
+public class CompatBoundaryTests
+{
+    private static readonly Regex VersionDirective = new(
+        @"^[^\S\r\n]*#[^\S\r\n]*(?:if|elif)\b[^\r\n]*\b(?:JF10|JF12|NET9_0|NET10_0)\b",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    [Fact]
+    public void VersionSpecificCodeStaysInTheCompatFolder()
+    {
+        var projectRoot = PluginProjectRoot();
+        Assert.True(
+            Directory.Exists(projectRoot),
+            $"Plugin sources not found at '{projectRoot}'. This test reads the checkout it was compiled from.");
+
+        var compatRoot = Path.Combine(projectRoot, "Compat") + Path.DirectorySeparatorChar;
+
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(projectRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.StartsWith(compatRoot, StringComparison.OrdinalIgnoreCase) || IsBuildOutput(file, projectRoot))
+            {
+                continue;
+            }
+
+            var relative = Path.GetRelativePath(projectRoot, file);
+            offenders.AddRange(
+                VersionDirective.Matches(File.ReadAllText(file))
+                    .Select(match => $"{relative}: {match.Value.Trim()}"));
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Version specific preprocessor directives found outside Compat/. Move the branch into Compat "
+            + "and expose it as a normal API. See Compat/README.md."
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders));
+    }
+
+    private static bool IsBuildOutput(string file, string projectRoot)
+    {
+        var relative = Path.GetRelativePath(projectRoot, file);
+        var first = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)[0];
+        return first.Equals("bin", StringComparison.OrdinalIgnoreCase)
+            || first.Equals("obj", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string PluginProjectRoot([CallerFilePath] string testFilePath = "")
+    {
+        var testsDirectory = Path.GetDirectoryName(testFilePath)!;
+        var repositoryRoot = Path.GetDirectoryName(testsDirectory)!;
+        return Path.Combine(repositoryRoot, "Jellyfin.Plugin.Streamyfin");
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/Jellyfin.Plugin.Streamyfin.Tests.csproj
+++ b/Jellyfin.Plugin.Streamyfin.Tests/Jellyfin.Plugin.Streamyfin.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/Jellyfin.Plugin.Streamyfin/Compat/README.md
+++ b/Jellyfin.Plugin.Streamyfin/Compat/README.md
@@ -1,0 +1,20 @@
+# Compat
+
+Everything that differs between Jellyfin 10.11 and Jellyfin 12 lives here, and
+nowhere else. No file outside this folder may branch on `JF10`, `JF12`,
+`NET9_0` or `NET10_0`. `CompatBoundaryTests` fails the build if one does.
+
+The rule exists so that dropping a Jellyfin version stays a deletion rather
+than an archaeology exercise. Version specific code scattered through the
+domain is exactly what makes old runtimes impossible to retire.
+
+## Dropping Jellyfin 10.11, when the time comes
+
+1. Delete the `jf10` `PropertyGroup` from `Directory.Build.props` and make
+   `jf12` the default.
+2. Delete the `jf10` entry from the build and release workflow matrices.
+3. Delete every `#if JF10` branch in this folder, keeping the `JF12` side.
+4. Drop the 10.11 manifest and stop publishing its artifact.
+
+Nothing else in the codebase should need to change. If it does, something
+leaked out of this folder and the guard test was bypassed.

--- a/Jellyfin.Plugin.Streamyfin/Compat/README.md
+++ b/Jellyfin.Plugin.Streamyfin/Compat/README.md
@@ -1,7 +1,7 @@
 # Compat
 
 Everything that differs between Jellyfin 10.11 and Jellyfin 12 lives here, and
-nowhere else. No file outside this folder may branch on `JF10`, `JF12`,
+nowhere else. No file outside this folder may branch on `JF11`, `JF12`,
 `NET9_0` or `NET10_0`. `CompatBoundaryTests` fails the build if one does.
 
 The rule exists so that dropping a Jellyfin version stays a deletion rather
@@ -10,10 +10,10 @@ domain is exactly what makes old runtimes impossible to retire.
 
 ## Dropping Jellyfin 10.11, when the time comes
 
-1. Delete the `jf10` `PropertyGroup` from `Directory.Build.props` and make
+1. Delete the `jf11` `PropertyGroup` from `Directory.Build.props` and make
    `jf12` the default.
-2. Delete the `jf10` entry from the build and release workflow matrices.
-3. Delete every `#if JF10` branch in this folder, keeping the `JF12` side.
+2. Delete the `jf11` entry from the build and release workflow matrices.
+3. Delete every `#if JF11` branch in this folder, keeping the `JF12` side.
 4. Drop the 10.11 manifest and stop publishing its artifact.
 
 Nothing else in the codebase should need to change. If it does, something

--- a/Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
+++ b/Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Streamyfin</RootNamespace>
     <AssemblyVersion>0.68.1.0</AssemblyVersion>
     <FileVersion>0.68.1.0</FileVersion>
@@ -12,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
+    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
     <PackageReference Include="Namotion.Reflection" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.16" />
     <PackageReference Include="NJsonSchema" Version="11.0.2" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="$(RuntimeJsonVersion)" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="$(RuntimeSqliteVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of #114 (P0.1).

## What this does

Introduces a `JellyfinTarget` MSBuild switch so the same source produces two artifacts, one per Jellyfin runtime, never a single DLL for both:

- `jf10` (default): Jellyfin 10.11, .NET 9
- `jf12`: Jellyfin 12, .NET 10

Build the other target with `dotnet build -p:JellyfinTarget=jf12`. The switch lives in `Directory.Build.props` so the plugin and the test project can never drift apart, and `Directory.Build.targets` fails early with the accepted values if the property is misspelled, instead of failing deep in restore with an empty `TargetFramework`.

This is the approach the JavaScript Injector plugin uses. It keeps one branch and one codebase, so nothing has to be forward ported between version branches.

## The pinning change, and what it revealed

`Jellyfin.Controller` and `Jellyfin.Model` were floating on `10.11.*-*`. That silently pinned every build to whatever shipped that day, which makes the minimum supported server an accident rather than a decision.

They are now pinned to `10.11.9`. Not `10.11.0`, and that is the interesting part: `IUserManager.Users` was replaced by `IUserManager.GetUsers()` in 10.11.9, a breaking change inside the patch line. Building against 10.11.0 fails on `UserManagerExtensions.cs` and `StreamyfinController.cs`. So no single artifact can cover 10.11.0 through 10.11.8 as well, and those servers should update.

This still widens support: the published manifest currently advertises `targetAbi 10.11.11`.

## The Compat rule

`Jellyfin.Plugin.Streamyfin/Compat/` is the only place allowed to branch on `JF10`, `JF12`, `NET9_0` or `NET10_0`. `CompatBoundaryTests` scans the sources and fails if a directive appears anywhere else.

The point is that dropping a Jellyfin version stays a deletion rather than an archaeology exercise. `Compat/README.md` spells out the removal procedure: delete one `PropertyGroup`, one matrix entry, and the `#if JF10` branches inside the folder. Nothing else should need to change, and if it does, the guard was bypassed.

## Testing

`dotnet build` on jf10 is clean, 0 errors, the same 88 pre-existing analyzer warnings as before.

`dotnet build -p:JellyfinTarget=jf12` is also clean, 0 errors, 107 warnings. The extra 19 over jf10 are analyzer rules that .NET 10 adds, not anything specific to Jellyfin 12. Worth stating plainly: the plugin compiles against Jellyfin 12 without a single source change, so `Compat/` starts empty and stays that way until something actually diverges.

`dotnet test` gives the same result on both targets, 11 passed and 3 failed, all three failing before this change too and for reasons unrelated to it:

- `DatabaseTests` deletes the SQLite file in `Dispose()` without closing the connection. Fine on Linux, `IOException` on Windows. These two fail on any Windows checkout.
- `LocalizationTests.TestStringFormatLocalization` asserts the English string without pinning the culture. On a French machine the resource manager serves `Strings.fr.resx` and returns `{0} regarde actuellement`.

So the suite only passes on an English Linux box today. Fixed separately in #116, which should land first.
