### PR TITLE
fix(tests): make the suite pass outside an English Linux box

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/DatabaseTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/DatabaseTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Jellyfin.Plugin.Streamyfin.Storage;
+using Microsoft.Data.Sqlite;
 using Jellyfin.Plugin.Streamyfin.Storage.Models;
 using Xunit;
 using Xunit.Abstractions;
@@ -103,6 +104,20 @@ public class DatabaseTests(ITestOutputHelper output): IDisposable
     public void Dispose()
     {
         output.WriteLine($"Deleting database {db.DbFilePath}");
-        File.Delete(db.DbFilePath);
+
+        // Microsoft.Data.Sqlite pools connections, so closing one is not enough:
+        // the pooled handle keeps the file open. Linux happily unlinks an open
+        // file, Windows throws IOException, which is why these tests only ever
+        // passed on CI. Drain the pool before deleting.
+        db.Dispose();
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in new[] { db.DbFilePath, db.DbFilePath + "-wal", db.DbFilePath + "-shm" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
     }
 }

--- a/Jellyfin.Plugin.Streamyfin.Tests/LocalizationTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/LocalizationTests.cs
@@ -41,6 +41,10 @@ public class LocalizationTests
     [Fact]
     public void TestStringFormatLocalization()
     {
+        // No culture given: the helper resolves to the invariant culture, which
+        // serves the neutral English resource. Before, it deferred to
+        // CultureInfo.CurrentUICulture and this assertion failed on any machine
+        // whose locale had a translated resx, French for instance.
         Assert.Equal(
             expected: "Test watching",
             actual: _helper.GetFormatted("UserWatching", args: "Test")

--- a/Jellyfin.Plugin.Streamyfin/LocalizationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/LocalizationHelper.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA1869
 
+using System;
 using System.Globalization;
 using System.Resources;
 using MediaBrowser.Controller.Configuration;
@@ -42,11 +43,17 @@ public class LocalizationHelper
     public string GetString(string key, CultureInfo? cultureInfo = null) => 
         _resourceManager.GetString(key, cultureInfo ?? GetServerCultureInfo()) ?? key;
 
-    private CultureInfo? GetServerCultureInfo() {
-        _logger?.LogInformation("Current Server UI Culture: {0}", _serverConfig.Configuration.UICulture);
+    /// <summary>
+    /// Falls back to the invariant culture rather than to the ambient one.
+    /// Returning null hands the choice to CultureInfo.CurrentUICulture, so the
+    /// strings a server produced depended on the locale of the machine it ran
+    /// on instead of on its configured UICulture.
+    /// </summary>
+    private CultureInfo GetServerCultureInfo() {
+        _logger?.LogInformation("Current Server UI Culture: {0}", _serverConfig?.Configuration.UICulture);
         return _serverConfig?.Configuration.UICulture != null
-            ? CultureInfo.CreateSpecificCulture(_serverConfig.Configuration.UICulture.Replace("\"", ""))
-            : null;
+            ? CultureInfo.CreateSpecificCulture(_serverConfig.Configuration.UICulture.Replace("\"", "", StringComparison.Ordinal))
+            : CultureInfo.InvariantCulture;
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #114 (P0.11).

The suite only passed on an English Linux box. Since CI is about to start running it on every pull request, that is worth fixing first, otherwise the safety net has holes nobody sees.

## Culture

`LocalizationHelper.GetServerCultureInfo()` returned `null` when the server configuration was unavailable, and `ResourceManager.GetString(key, null)` then falls back to `CultureInfo.CurrentUICulture`. The strings the plugin produced depended on the locale of the machine the process ran on rather than on the configured `UICulture`.

It now falls back to `CultureInfo.InvariantCulture`, which serves the neutral English resource. On a real server nothing changes, `_serverConfig` is never null there and `UICulture` still decides. What changes is that the fallback is now a decision rather than an accident of the host OS.

`TestStringFormatLocalization` asserted the English string without pinning a culture, so it failed on any French machine: `Strings.fr.resx` returns `{0} regarde actuellement`.

## Database file handles

`DatabaseTests.Dispose()` deleted the SQLite file without disposing the database. `Microsoft.Data.Sqlite` pools connections, so closing one is not enough, the pooled handle keeps the file open. Linux unlinks an open file without complaint, Windows throws `IOException`. Both database tests failed on every Windows checkout.

Now it disposes, clears the pool, then deletes the file with its `-wal` and `-shm` siblings, the same order intro-skipper uses.

This layer moves to EF Core in P0.4 and these tests will be rewritten then. The fix is deliberately minimal, just enough that the suite is trustworthy in the meantime.

## Testing

`dotnet test` on Windows with a fr-FR locale: 13 passed, 0 failed. Before: 10 passed, 3 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localization handling when no server language is configured.
  - Ensured culture-neutral formatting consistently uses neutral English resources.
  - Improved reliability when server configuration is unavailable.
  - Fixed database test cleanup to remove associated SQLite temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->