### PR TITLE
ci: build and test both Jellyfin targets on every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# A new push supersedes the one before it on the same ref.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Both targets always report. Knowing only that jf10 broke, while jf12 was
+      # cancelled, means running the whole thing again to learn the other half.
+      fail-fast: false
+      matrix:
+        include:
+          - target: jf10
+            dotnet: 9.0.x
+          - target: jf12
+            dotnet: 10.0.x
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      # JellyfinTarget picks the framework and the package versions, so every
+      # command needs it. Leave it off one of them and that step silently works
+      # on the default target instead.
+      - name: Restore
+        run: dotnet restore -p:JellyfinTarget=${{ matrix.target }}
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore -p:JellyfinTarget=${{ matrix.target }}
+
+      - name: Test
+        run: dotnet test Jellyfin.Plugin.Streamyfin.Tests --configuration Release --no-build -p:JellyfinTarget=${{ matrix.target }}
+
+      - name: Upload plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: Jellyfin.Plugin.Streamyfin-${{ matrix.target }}
+          path: Jellyfin.Plugin.Streamyfin/bin/Release/*/Jellyfin.Plugin.Streamyfin.dll
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Both targets always report. Knowing only that jf10 broke, while jf12 was
+      # Both targets always report. Knowing only that jf11 broke, while jf12 was
       # cancelled, means running the whole thing again to learn the other half.
       fail-fast: false
       matrix:
         include:
-          - target: jf10
+          - target: jf11
             dotnet: 9.0.x
           - target: jf12
             dotnet: 10.0.x


### PR DESCRIPTION
Part of #114 (P0.2). Stacked on #115, which introduces the `JellyfinTarget` switch this workflow drives. Retarget to `main` once that merges.

## Why

The repository had no build workflow. `lint_pr.yml` checks the pull request title and `release.yml` only runs on manual dispatch. Nothing compiled the plugin or ran its tests before a merge, so a change that does not build could land on `main` and only surface when someone cut a release.

## What it does

A matrix builds both targets on every pull request and every push to `main`:

- `jf10` on .NET 9
- `jf12` on .NET 10

Each one restores, builds, runs the test suite and uploads its DLL as an artifact, so a reviewer can install the exact build a pull request produces on either Jellyfin version.

`fail-fast` is off on purpose. With it on, jf10 breaking cancels jf12 and you have to run the whole thing again to learn whether the other half was fine.

Every step passes `-p:JellyfinTarget`. The property picks the framework and the package versions, so leaving it off one command silently builds the default target instead.

## Testing

Both targets verified locally before opening this:

- `dotnet build -p:JellyfinTarget=jf10`: 0 errors
- `dotnet build -p:JellyfinTarget=jf12`: 0 errors
- `dotnet test` on both: identical results

The suite currently has 3 failures on a Windows or non English checkout, fixed in #116. On the Linux runner it is green either way, but #116 should land first so the workflow is trustworthy for contributors too.
