### PR TITLE
docs(rewrite): add the rewrite dossier

### DIFF
--- a/docs/rewrite/README.md
+++ b/docs/rewrite/README.md
@@ -1,0 +1,21 @@
+# Plugin rewrite
+
+Working documents for the rewrite tracked in issue #114.
+
+| Document | What it holds |
+|---|---|
+| [state-of-the-plugin.md](state-of-the-plugin.md) | What exists today, and what is wrong with it. Written from reading the code, not from memory. |
+| [issue-triage.md](issue-triage.md) | Every open issue, diagnosed and mapped onto the plan. |
+| [plan.md](plan.md) | The seven parts, their sub parts, and the order they land in. |
+
+## How the work is organised
+
+`develop` is the integration branch. Every sub part gets its own branch named
+`refonte/pX-N-slug` and its own pull request onto `develop`. Related branches
+are chained with `gh stack` so each pull request shows only its own layer.
+`main` keeps serving the published plugin until the rewrite is coherent end to
+end, then `develop` merges into it in one go.
+
+If a hotfix ever lands on `main` during the rewrite, merge `main` into
+`develop` the same day. A long lived branch is only cheap while it stays close
+to the trunk.

--- a/docs/rewrite/issue-triage.md
+++ b/docs/rewrite/issue-triage.md
@@ -1,0 +1,200 @@
+# Issue triage
+
+Every issue open on the plugin repository, diagnosed against the code rather
+than against its title, and mapped onto the plan in [plan.md](plan.md).
+
+Issue #114 is the tracking issue for the rewrite itself and is not triaged here.
+
+## Summary
+
+| Issue | Title | Verdict | Lands in |
+|---|---|---|---|
+| [#100](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/100) | Notification endpoint broken since 10.11.9 | Fixed and released | Close |
+| [#90](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/90) | Hide Watchlist not settable from the plugin | Setting exists now | Close after confirming |
+| [#74](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/74) | NullReferenceException in ItemAddedHandler | Live, one missing guard | Fix now, P0 |
+| [#110](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/110) | Missing "Landscape Auto" orientation | Live, enum copied incompletely | Fix now, P0 |
+| [#95](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/95) | `seerrServerUrl` does not work | Accurate, keys still say jellyseerr | P6.1 |
+| [#82](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/82) | Auto link Seerr accounts to Jellyfin users | Design already settled upstream | P6 |
+| [#108](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/108) | Seerr integration missing on tvOS | App side | streamyfin repo, P6.3 helps |
+| [#69](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/69) | Hidden libraries leak section headers | Live, needs server side resolution | P1.4 with P5.4 |
+| [#29](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/29) | Native Jellyfin notification events | Design validates P1 | P4.4 and P4.5 |
+| [#34](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/34) | Customizable notification messages | Contested, scope it down | P4.4 |
+| [#30](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/30) | Images in notifications | Blocked by Expo, Android only | P4.4 |
+| [#93](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/93) | Explicit ordering for home sections | Straightforward | P5.3 |
+| [#78](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/78) | "My Media" home section | Missing section kind | P5.1 |
+| [#21](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/21) | "Recommended" / "For you" section | Jellyfin already has the endpoint | P5.1 |
+| [#88](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/88) | Collections in `includeItemTypes` | Not a bug, a discoverability failure | P3.1 |
+| [#17](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/17) | Support for `CultureDto` | Needs the typed schema first | P1.1 then P3.1 |
+
+## Close now
+
+### #100, notification endpoint returning 500 since 10.11.9
+
+Fixed by [#101](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/101),
+merged 2026-06-16 and shipped in 0.67.0.0, so it is present in 0.68.1.0. Both
+reporters were waiting on a release rather than on a fix. Close with the version
+that carries it.
+
+### #90, hide watchlist not settable from the plugin
+
+`hideWatchlistsTab` exists today at `Configuration/Settings/Settings.cs:331` and
+is documented at `examples/full.yml:163`. The issue predates it. Ask the reporter
+to confirm on a current version, then close.
+
+## Fix now, they do not need the rewrite
+
+### #74, NullReferenceException in ItemAddedHandler
+
+Open for eleven months with 26 comments, and it is four lines of code.
+`Configuration/Notifications/Notifications.cs:26` declares
+`public string[] EnabledLibraries { get; set; }` with no initializer. Leave the
+key out of the YAML and it is null. `ItemAddedService.cs:51` reads
+`enabledLibraries.Length` behind a `virtualFolder != null` guard, which is why it
+only fires for some people and only on some items.
+
+The thread converged on a workaround, tick your libraries, and the last comments
+read as resolved. It is not: the default configuration still throws. A null
+coalescing guard closes it, and the nullability annotation pass in P0.12 is what
+stops the next one.
+
+This is also the clearest argument for that pass. The compiler has been emitting
+`CS8618` on that exact property the whole time, into a build where
+`TreatWarningsAsErrors` is false.
+
+### #110, missing "Landscape Auto" orientation
+
+`OrientationLock` in `Configuration/Settings/Enums.cs` is a hand copied subset of
+Expo's `ScreenOrientation.OrientationLock`, and the copy dropped values. It has
+`Default = 0`, `PortraitUp = 3`, `LandscapeLeft = 6` and `LandscapeRight = 7`.
+Expo's `Landscape = 5`, the one the app exposes as Landscape Auto, was never
+copied. Numeric values are preserved, so adding the missing member is safe.
+
+The enum is copied at all because of the 10.10 to 10.11 move noted in
+`Enums.cs:77`. Worth checking the other copied enums for the same kind of gap
+while we are in there.
+
+## Blocked on the settings model
+
+### #69, hidden libraries still expose their section headers
+
+A "Recently Added in X" section built on a library `ParentId` renders its header
+for users who cannot see that library, revealing the name of a restricted
+library. The reporter filed it as a privacy concern and they are right.
+
+It cannot be fixed on the app side without leaking the same information a
+different way, because today the app receives the raw global config and decides
+locally. The server has to resolve the section list for the calling user and
+serve only what that user may see. That is exactly P1.4, with P5.4 for the
+targeting. Until then the only honest mitigation is documentation.
+
+### #29, native Jellyfin notification events
+
+Two years old and still the best statement of what the notification subsystem
+should be: configurable events, per event enable, target users, forward to
+admins. The discussion in the thread went further than the title. lostb1t
+proposed, and herrrta agreed, a general per user override shape:
+
+```yaml
+settings:
+  notification_new_movie:
+    lock: true
+    value: true
+    overrides:
+      - users: [john, simon]
+        lock: false
+        value: true
+```
+
+That is the three level model of P1, proposed by the maintainers before this
+rewrite was scoped. Worth quoting in the P1 spec, since it means the design is
+not being imposed on the project from outside.
+
+Lands in P4.4 for the declared events and P4.5 for the per user preferences, both
+on top of P1.
+
+### #17, support for CultureDto
+
+Language properties need a real type in the schema instead of free text. Waiting
+on P1.1, then it is a form control in P3.1. Small once the schema is typed,
+awkward before.
+
+## Notifications
+
+### #34, customizable notification messages
+
+The requester wants the Handlebars templating the Jellyfin webhook plugin offers.
+herrrta pushed back with a real constraint: the webhook plugin waits for metadata
+to be loaded before firing, while this plugin consolidates events, for instance a
+whole season at once, and therefore has much less metadata to interpolate.
+
+Do not promise templating. What P4.4 can honestly deliver is per event, per
+locale message overrides on the fields that are actually populated. Say so on the
+issue rather than leaving it open as if full templating were coming.
+
+### #30, images in notifications
+
+Expo's push service does not carry images on iOS. The linked Expo discussion has
+a working Android path. Ship it Android only under P4.4, with the limitation
+written into the setting description, or say no. Leaving it open with no decision
+is the worst of the three.
+
+## Home sections
+
+All three are the same structural gap: the section model has four hardcoded
+shapes (`items`, `nextUp`, `latest`, `custom`) and no way to add a fifth without
+another nullable sibling. P5.1 replaces that with a discriminated type, and then
+each of these becomes one new kind.
+
+- **#78, My Media.** A section listing the user's library folders, like the
+  default Jellyfin home. New kind.
+- **#21, Recommended.** lostb1t already pointed at the Jellyfin endpoint that
+  serves this. New kind, thin wrapper.
+- **#93, section ordering.** Sections currently render in YAML order. An explicit
+  `order` field is trivial in the model. The real reason it is worth doing is
+  P5.3: a reorderable editor needs a persisted order to write to, so this is a
+  prerequisite rather than a nicety.
+
+## Not bugs
+
+### #88, Collections in `includeItemTypes`
+
+`includeItemTypes` is `BaseItemKind[]` (`Settings.cs:95`), so it already accepts
+collections. Jellyfin calls them `BoxSet`, not `Collections`, and nothing in
+`examples/full.yml` says which values are legal. The reporter tried the obvious
+word, got no error and no results, and filed a feature request for something that
+already works.
+
+That is the whole case for P3.1 in one issue. A generated form renders a
+`BaseItemKind` field as a list of the values that exist, and the question cannot
+be asked again. Until then, one line in `examples/full.yml` pointing at the enum
+is worth writing.
+
+## Third party integrations
+
+### #95, `seerrServerUrl` does not work but `jellyseerrServerUrl` does
+
+Accurate. The plugin schema still says `jellyseerrServerUrl` and
+`jellyseerrApiKey` (`Settings.cs:297` and `301`) while the app and its
+documentation have moved to Seerr. Renaming is a breaking change for every
+existing YAML, so it needs the alias mechanism rather than a find and replace.
+P6.1 groups integrations into typed blocks, which is the moment to rename with an
+alias kept for the old key.
+
+### #82, automatically link Seerr accounts to Jellyfin users
+
+The interesting part is in the comments, not the body. The requester asked for
+the Jellyfin Enhanced approach, an admin API key that the plugin uses on behalf
+of everyone. herrrta rejected that and changed Seerr instead so a client can
+authenticate with a user's own Jellyfin access token
+([seerr#2244](https://github.com/seerr-team/seerr/pull/2244)).
+
+That decision is already made and it is the right one, since it is the same
+admin key that #1 of [state-of-the-plugin.md](state-of-the-plugin.md) says every
+authenticated user can currently read. P6 should implement the token path and
+plan for the API key setting to become optional, then go away.
+
+### #108, Seerr integration missing on tvOS
+
+App side, belongs on the streamyfin repository. Worth keeping in view here
+because P6.3, exposing integration health, is what would have turned "is this
+something I'm doing wrong" into an answer on screen.

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -1,0 +1,218 @@
+# Plan
+
+Seven parts. Each one ships on its own and leaves the plugin working. Tracked as
+checkboxes in
+[issue #114](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/114),
+which stays the source of truth for progress. This document holds the reasoning
+that does not fit in a checkbox.
+
+App side counterpart: [streamyfin/streamyfin](https://github.com/streamyfin/streamyfin).
+
+## Decisions already taken
+
+**Breaking change with a migration.** New config model, one time migration that
+reads the old XML at startup. Old routes stay as compatibility shims until the
+app fleet has moved. The pattern is copied from intro-skipper's
+[#871](https://github.com/intro-skipper/intro-skipper/pull/871): read only import
+of the old store, an `ImportHistory` marker, an atomic commit, a retry on the next
+start if it fails, and the old file left untouched as the rollback path.
+
+**Three targeting levels.** Server default, then plugin defined groups, then per
+user. The server resolves the three and serves the effective set, with secrets
+filtered out for non admins. Jellyfin has a `Group` entity in `JellyfinDbContext`
+with permissions and preferences, but nothing uses it, no manager, no controller,
+no route, so the groups are defined by the plugin rather than borrowed from a
+dormant entity the server may reshape.
+
+**Plugin and app move together.** Two repositories, one project.
+
+**Dual Jellyfin support via an MSBuild switch**, the same approach as the
+JavaScript Injector plugin: one branch, a `JellyfinTarget` property flipping
+`TargetFramework` and package versions, CI building twice. The alternative,
+intro-skipper's branch per Jellyfin major, means porting every fix by hand
+forever. Dropping 10.11 later means deleting one `PropertyGroup`, one matrix
+entry and the compat folder.
+
+**Everything version specific lives in one folder**, behind `#if`, enforced by a
+test that fails the build if a version conditional appears anywhere else. The
+constraint is deletability, and a rule that is not executable decays in six
+months.
+
+**Generated admin forms.** `@json-editor/json-editor` 2.15.2 is already vendored
+in `Pages/Libraries/` and imported by nothing. Simple settings render from the
+JSON schema the plugin already publishes. The home editor and the group targeting
+screen stay hand written. That hybrid is what KefinTweaks landed on in
+`scripts/configuration.js`: descriptor driven for the repetitive fields, hand
+written where the shape is genuinely irregular.
+
+## How it lands
+
+`develop` is the integration branch, `main` keeps serving the published plugin.
+One branch per sub part named `refonte/pX-N-slug`, one pull request onto
+`develop`, chained with `gh stack` so each pull request shows only its own layer.
+
+Order: **P0**, then **P1**, then **P2** and **P3** in parallel, then **P4**,
+**P5**, **P6** in whatever order suits.
+
+Two ordering constraints inside P0 that are not obvious:
+
+- **P0.11 before P0.2.** Do not switch CI on over a suite that fails on Windows
+  and on any non English machine. Red that everybody ignores is worse than no CI.
+- **P0.12 after P0.5.** The warning policy pass must not annotate nullability in
+  `Storage/`, since P0.5 deletes that folder.
+
+## P0. Foundation
+
+Two artifacts from one source, and the storage layer moved to EF Core before
+anything is built on top of it. Nothing changes for the user.
+
+- **P0.1** `JellyfinTarget` switch (`jf11` = net9.0 + Jellyfin 10.11, `jf12` =
+  net10.0 + Jellyfin 12), single compat folder, test that fails on a stray `#if`
+  outside it
+- **P0.11** Make the test suite pass outside an English Linux box
+- **P0.2** `build.yml`: build and test both targets on every pull request and
+  push, upload DLL artifacts
+- **P0.3** EF Core `DbContext`, baseline migration, `IDesignTimeDbContextFactory`,
+  database file under `IApplicationPaths`
+- **P0.4** Move device tokens off `Storage/` onto EF, one time read only import of
+  the old database, old file left untouched
+- **P0.5** Drop the direct `Microsoft.Data.Sqlite` usage and the hand written SQL
+- **P0.6** Reworked `release.yml`: matrix produces one zip per target, a single
+  GitHub release carries both
+- **P0.7** Two manifests with their own `targetAbi` and checksum, keeping the
+  current URL for 10.11 so no configured server breaks
+- **P0.8** Script cleanup: manifest deduplication, zip path derived from the TFM
+  instead of the hardcoded `net9.0`, `Jellyfin.Controller` pinned to each line's
+  floor rather than `10.11.*-*`
+- **P0.9** Set `owner` in `manifest.json` to the organisation instead of a
+  personal account
+- **P0.10** Optional: SignPath artifact signing, free for open source
+- **P0.12** Warning policy, once P0.5 has removed `Storage/`
+- **P0.13** The three `CS4014` fire and forget calls in the notification handlers
+
+Two findings from P0 that changed the shape of the rest:
+
+The plugin **compiles against Jellyfin 12 with zero source changes**. The compat
+folder starts empty. `net9.0` to `net10.0` is the only structural break, and
+everything the plugin consumes, `IUserManager`, `ILibraryManager`,
+`IServerConfigurationManager`, `IApplicationPaths`, `IPluginServiceRegistrator`
+and the `BaseItemKind`, `ItemSortBy`, `ItemFilter`, `SubtitlePlaybackMode` enums,
+exists unchanged in both.
+
+`IUserManager.Users` became `IUserManager.GetUsers()` in **10.11.9**, a breaking
+change inside a patch line, so the floor for the 10.11 artifact is 10.11.9 and
+not 10.11.0. Still wider than the published manifest, which demands 10.11.11 by
+accident.
+
+Also settled here: both versions register
+`AddPooledDbContextFactory<JellyfinDbContext>`, so a plugin can inject
+`IDbContextFactory<JellyfinDbContext>`, but that is the server's own context and
+its migrations belong to the server. The plugin owns its own SQLite database
+either way. There is no cleaner story on 12 worth waiting for.
+
+## P1. Settings model
+
+The core. Everything after this depends on it.
+
+- **P1.1** Typed settings schema carrying, per key: value, lock, and a secret
+  marker
+- **P1.2** Plugin defined groups: table, user assignment, API
+- **P1.3** Resolution engine global to group to user, with precedence tests
+- **P1.4** Output filtering: secrets go to admins only, everything else resolved
+  for the caller
+- **P1.5** One time migration of the old XML config
+- **P1.6** New routes, old ones kept as shims
+
+P1.4 is the fix for the finding at the top of
+[state-of-the-plugin.md](state-of-the-plugin.md): today `GET config` hands the
+whole configuration, Seerr admin key included, to every authenticated account.
+It is also what closes #69, since only the server can decide which sections a
+given user is allowed to know exist.
+
+The shape of P1 was proposed by the maintainers themselves in
+[#29](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/29), well
+before this rewrite was scoped. See [issue-triage.md](issue-triage.md).
+
+## P2. App on the new contract
+
+- **P2.1** Consume the server resolved effective set instead of the raw map
+- **P2.2** Keep the three existing semantics: locked, pushed once as a default,
+  free
+- **P2.3** Tolerate a server still on the old format during rollout
+- **P2.4** Remove the hardcoded rule that forces `searchEngine` to Streamystats
+  when `streamyStatsServerUrl` is set
+
+P2.2 is the one that is easy to lose. The app has two distinct behaviours today,
+not one. A `locked` setting is enforced on read, through `effectiveSettingsAtom`,
+and on write, through `updateSettings`. An unlocked plugin value is applied
+exactly once, through `pendingPluginDefaults` and the `PLUGIN_APPLIED_DEFAULTS`
+registry, so the admin proposes a starting value and the user stays free to change
+it afterwards. Collapsing those two into one flag would take away an admin's
+ability to suggest without imposing. The schema in P1.1 must carry all three
+states: locked, pushed once, unmanaged.
+
+## P3. Generated admin UI
+
+- **P3.1** Render simple settings from the JSON schema using the already vendored
+  json-editor
+- **P3.2** Hand written editor for home sections
+- **P3.3** Hand written screen for group and user targeting
+- **P3.4** JSON export and import
+- **P3.5** Decide between embedded pages and `jellyfin-plugin-pages`
+
+P3.5 is a real fork. Today the pages are HTML and JS embedded as resources in the
+DLL, 16 MB of it. `jellyfin-plugin-pages` and `jellyfin-plugin-custom-tabs` are
+both built on File Transformation, which lets a plugin change what jellyfin-web
+serves without touching its files. The call has to go through reflection, since
+every plugin lives in its own `AssemblyLoadContext`, which is a real cost to
+weigh against dropping the embedded page machinery.
+
+## P4. Push notifications
+
+- **P4.1** Inject `IHttpClientFactory` with a named client and a timeout
+- **P4.2** Read Expo receipts and prune `DeviceNotRegistered` tokens
+- **P4.3** Batching, honour 429 and `Retry-After`, retry with backoff
+- **P4.4** Declared events instead of the four hardcoded ones
+- **P4.5** Per user notification preferences, on top of P1
+
+P4.2 is the one with user visible consequences. Expo only reports a dead token
+through `/push/getReceipts`, which the plugin never calls, so tokens accumulate
+forever and sends go nowhere.
+
+P4.4 absorbs #29, #34 and #30, and each needs an explicit decision rather than an
+open ended promise. See [issue-triage.md](issue-triage.md).
+
+## P5. Custom home
+
+- **P5.1** Replace the four nullable siblings (`items`, `nextUp`, `latest`,
+  `custom`) with a discriminated type
+- **P5.2** Server side section validation with errors the UI can show
+- **P5.3** Dedicated reorderable section editor with a preview
+- **P5.4** Per group section targeting, once P1 is in
+- **P5.5** Migrate existing configurations
+
+P5.1 is what unblocks #78, #21 and every future section kind. Today adding a kind
+means adding a fifth nullable sibling that nothing says is exclusive with the
+other four. P5.3 needs the explicit `order` field from #93 to have somewhere to
+write to.
+
+## P6. Third party integrations
+
+- **P6.1** Group integrations into typed blocks instead of flat keys
+- **P6.2** Server side connection probe with a test button in the admin UI
+- **P6.3** Expose health so the app knows an integration is down
+- **P6.4** Replace the hidden Streamystats rule with a declared one
+
+P6.2 belongs on the server, which can reach an internal URL a phone never will.
+The app's `utils/serverUrl/probes/reachability.ts` is the pattern to follow.
+
+P6.1 is also the moment to rename the `jellyseerr*` keys to `seerr*` with the old
+names kept as aliases, which closes #95 without breaking every existing YAML.
+
+## Progress
+
+| Sub part | Pull request |
+|---|---|
+| P0.1 | [#115](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/115) |
+| P0.2 | [#117](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/117) |
+| P0.11 | [#116](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/116) |

--- a/docs/rewrite/state-of-the-plugin.md
+++ b/docs/rewrite/state-of-the-plugin.md
@@ -1,0 +1,181 @@
+# State of the plugin
+
+Read from the code at `da60702`, the last commit on `main` before the rewrite
+branches. Every claim points at a file so it can be checked instead of believed.
+
+## Shape
+
+| | |
+|---|---|
+| C# | 3862 lines across 35 files |
+| Settings schema | `Configuration/Settings/Settings.cs`, 409 lines |
+| Storage | `Storage/Database.cs` 282 lines and `Storage/Extensions.cs` 387 lines, hand written `Microsoft.Data.Sqlite` |
+| Admin pages | 4 pages, 717 lines of hand written JS including `Pages/shared.js` at 230 |
+| Vendored JS | 16 MB under `Pages/Libraries/`, all embedded in the DLL |
+| Tests | 4 files |
+| Target | `net9.0`, `Jellyfin.Controller 10.11.*-*` |
+| CI | `lint_pr.yml` and `release.yml`, nothing that builds or tests |
+| Published zip | 3.1 MB for 0.68.1.0 |
+
+## The public contract
+
+`StreamyfinController` is routed at `streamyfin` and carries no class level
+`[Authorize]`. Endpoint by endpoint:
+
+| Route | Guard |
+|---|---|
+| `POST config/yaml` | `RequiresElevation` |
+| `GET config` | `[Authorize]` |
+| `GET config/schema` | none, anonymous |
+| `GET config/yaml` | `[Authorize]` |
+| `GET config/default` | `[Authorize]` |
+| `POST device`, `DELETE device/{id}`, `POST notification` | `[Authorize]` |
+
+The app consumes `GET /streamyfin/config` and caches the result in MMKV under
+`STREAMYFIN_PLUGIN_SETTINGS`.
+
+## What is wrong
+
+### 1. Any authenticated user can read the whole configuration
+
+`GET config` (`Api/StreamyfinController.cs:107`) and `GET config/yaml`
+(`Api/StreamyfinController.cs:124`) are guarded by `[Authorize]` alone, so every
+account on the server receives the entire config, secrets included. This is not
+a suspicion, `examples/full.yml:131` already warns in capitals that the Seerr
+admin API key is readable by anyone with an account. Only the write path
+requires elevation. A settings model that cannot filter its own output is the
+root cause, not the endpoint.
+
+### 2. One global blob, no targeting
+
+There is a single `Config` (`Configuration/Config.cs`) for the whole server.
+Nothing expresses "this value for these users". Issue #29 already argued for per
+user overrides two years ago, and #90 and #69 are the same gap seen from two
+other angles.
+
+### 3. Storage is hand written SQLite
+
+`Storage/` is 669 lines of `Microsoft.Data.Sqlite` with SQL as strings, its own
+schema handling and its own `Dispose` pattern. intro-skipper is the cautionary
+tale here: it moved to EF Core late and still carries several hundred lines of
+`EnsureLegacySchemaCompatibility()` doing raw `ALTER TABLE` and manual
+`__EFMigrationsHistory` inserts. Starting on EF Core means never writing that.
+
+### 4. The admin UI is a YAML text editor
+
+Adding a setting means editing `Settings.cs`, then `examples/full.yml`, and an
+admin only discovers the setting by reading the example. `examples/full.yml` is
+304 lines. The editor is Monaco, an 11 MB bundle embedded in the DLL, wrapped in
+228 lines of `Pages/YamlEditor/index.js`.
+
+`Pages/Libraries/json-editor.min.js` is `@json-editor/json-editor` at 523 KB,
+embedded in the DLL and imported by nothing. Grep the whole tree and it never
+appears outside its own file. Today that is dead weight. For P3 it is the answer
+already paid for: a form generator driven by the JSON schema the plugin already
+publishes at `GET config/schema`.
+
+### 5. Push notifications never learn that a token is dead
+
+`PushNotifications/NotificationHelper.cs:132` does `using HttpClient client =
+new()` on every send. Jellyfin injects `IHttpClientFactory`, so this is socket
+exhaustion and frozen DNS for nothing.
+
+Worse on the substance: Expo answers with tickets, `ExpoNotificationResponse`
+deserialises them, and `/push/getReceipts` is never called. That endpoint is the
+only place Expo reports `DeviceNotRegistered`. No dead token is ever pruned, the
+table only grows, and sends go nowhere. There is no batching, no handling of 429
+or `Retry-After`, and no retry.
+
+Three sends are fire and forget, flagged as `CS4014` and ignored:
+`ItemAddedService.cs:76`, `PlaybackStartEvent.cs:73`, `SessionStartEvent.cs:51`.
+The handler returns before the send completes and any failure lands in an
+unobserved task.
+
+### 6. Home sections have four mutually exclusive fields and nothing says so
+
+`Section` (`Configuration/Settings/Settings.cs:40`) carries `items`, `nextUp`,
+`latest` and `custom`, all nullable siblings. Exactly one should be set. Neither
+the type nor any validation enforces it. That is what makes the YAML awkward to
+write and a generated form impossible: a generator cannot guess it should show
+only one of the four. A discriminated type fixes the schema, the form and the
+server side validation in one move.
+
+### 7. Nothing builds the plugin on a pull request
+
+`.github/workflows/` holds `lint_pr.yml`, which checks PR titles, and
+`release.yml`. Code that does not compile can be merged. The four test files are
+only ever run by hand.
+
+### 8. The shipped dependencies are not the ones we compile against
+
+Third party assemblies are not produced by the build. They are committed as
+binaries in `packages/` and zipped by the `Makefile`. The only two commits that
+ever touched that folder are both named `wip`.
+
+| Assembly | Committed | Referenced in csproj |
+|---|---|---|
+| `Newtonsoft.Json.Schema.dll` | 4.0.1 | 3.0.16 |
+| `NJsonSchema.dll` | 11.0.2 | 11.0.2 |
+| `NJsonSchema.Annotations.dll` | 11.0.2 | 11.0.2 |
+| `Namotion.Reflection.dll` | 3.1.1 | 3.1.1 |
+| `YamlDotNet.dll` | 16.0.0 | 16.0.0 |
+| `Newtonsoft.Json` | not shipped | 13.0.3 |
+
+Two problems. We compile against `Newtonsoft.Json.Schema` 3.0.16 and ship 4.0.1,
+a major version apart. And `Newtonsoft.Json` is referenced but not shipped, so we
+silently rely on Jellyfin carrying it.
+
+There is a third, smaller one: no source file references the
+`Newtonsoft.Json.Schema` namespace at all. The package is a paid product, it is
+referenced, it is shipped, and it is unused.
+
+The zip path in the `Makefile` is hardcoded on `net9.0`, twice. It breaks on the
+first multi target release. `targetAbi` is hardcoded to `10.11.11` in
+`scripts/validate-and-update-manifest.js:9`, and that script does
+`versions.unshift(newVersion)` with no lookup, so republishing a version creates
+a duplicate entry.
+
+### 9. The project opted into every analyser rule, then ignored all of them
+
+The csproj sets `AnalysisMode=AllEnabledByDefault` with
+`TreatWarningsAsErrors=false`. Result: 88 warnings on the 10.11 target, 107 on 12
+where .NET 10 adds rules. Roughly 30 are noise on serialization DTOs (`CA1002`,
+`CA1819`, `CA2227`), and `PluginConfiguration.cs` already carries a file level
+`#pragma warning disable CA2227`, which says someone hit it and worked around it
+locally. Roughly 30 more are nullability debt: `<Nullable>` is enabled and the
+code was never annotated.
+
+That debt is not cosmetic. `Notifications.cs:26` declares
+`public string[] EnabledLibraries { get; set; }` with no initializer. Omit the
+key from the YAML and it is null. `ItemAddedService.cs:51` then reads
+`enabledLibraries.Length`. That is issue #74, open for eleven months, 26
+comments, and it is one ignored `CS8618` away from never having existed.
+
+### 10. The test suite only passes on an English Linux box
+
+`DatabaseTests` deletes the SQLite file without closing the connection, which
+throws `IOException` on Windows. `LocalizationTests.TestStringFormatLocalization`
+asserts the English string without pinning the culture, so it fails on any French
+machine because `Strings.fr.resx` wins. Three failures on this workstation, none
+of them caused by our changes. Turning CI on before fixing this would only teach
+everyone to ignore red.
+
+## What the in flight pull requests already change
+
+| PR | Sub part | Effect |
+|---|---|---|
+| [#116](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/116) | P0.11 | Suite passes off an English Linux box, 13/13 |
+| [#115](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/115) | P0.1 | `JellyfinTarget` switch, `Compat/` folder and the test that keeps the boundary |
+| [#117](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/117) | P0.2 | `build.yml` building and testing `jf11` and `jf12` on every pull request |
+
+The most useful result so far: the plugin compiles against Jellyfin 12 with zero
+source changes, 0 errors on both targets. `Compat/` starts empty and stays empty
+until something actually diverges, and #117 is what tells us the day a 12 release
+candidate breaks that.
+
+The one real surprise from building: `IUserManager.Users` became
+`IUserManager.GetUsers()` in **10.11.9**, a breaking change inside a patch line.
+Pinning `Jellyfin.Controller` at `10.11.0` does not compile. The floor for the
+10.11 artifact is 10.11.9, which is still wider than what the published manifest
+demands today, since `targetAbi` sits at 10.11.11 by accident rather than by
+choice.


### PR DESCRIPTION
Part of #114.

The tracking issue holds the checkboxes. This adds the working documents behind them, so the reasoning lives in the repository and survives the issue getting long.

## `state-of-the-plugin.md`

What exists today and what is wrong with it, read from the code at `da60702` rather than from memory. Every claim points at a file so it can be checked.

Ten findings. The ones worth naming here:

- `GET config` and `GET config/yaml` are guarded by `[Authorize]` alone, so every account on the server reads the whole configuration, Seerr admin key included. `examples/full.yml` already warns about it in capitals.
- The third party assemblies in `packages/` are committed binaries, not build output. We compile against `Newtonsoft.Json.Schema` 3.0.16 and ship 4.0.1. `Newtonsoft.Json` is referenced but not shipped at all. And no source file references the `Newtonsoft.Json.Schema` namespace, so that paid package is referenced, shipped, and unused.
- `Pages/Libraries/` is 16 MB of vendored JavaScript embedded in the DLL. 523 KB of it is `json-editor`, imported by nothing, which is the form generator P3 needs.

## `issue-triage.md`

The sixteen open issues, diagnosed against the code and mapped onto the plan.

- **#100 and #90 can be closed.** #100 was fixed by #101 and shipped in 0.67.0.0, both reporters were waiting on a release. #90 asks for a setting that exists today at `Settings.cs:331`.
- **#74 and #110 are small fixes that need none of the rewrite.** #74 is eleven months old with 26 comments and is one missing null guard: `EnabledLibraries` is declared non nullable with no initializer, so leaving the key out of the YAML makes it null and `ItemAddedService.cs:51` reads `.Length` on it. The compiler has been emitting `CS8618` on that property the whole time. #110 is a value dropped when `OrientationLock` was hand copied from Expo.
- **#88 is not a bug.** `includeItemTypes` already accepts collections, Jellyfin just calls them `BoxSet` and nothing documents the legal values. That single issue is the case for P3.1.
- **#34 and #30 need a decision rather than an open ticket.** Templating cannot be delivered the way the requester expects, and notification images are Android only. Both are better answered than left open.

## `plan.md`

The seven parts, their sub parts, and the reasoning that does not fit in a checkbox: why the compat folder starts empty, why the 10.11 floor is 10.11.9 and not 10.11.0, why groups are defined by the plugin rather than borrowed from Jellyfin's dormant `Group` entity, and the two ordering constraints inside P0 that are not obvious from the numbering.

One thing worth surfacing from it: the three level settings model was proposed by the maintainers themselves in #29, two years ago, in almost exactly the shape P1 specifies.

## Testing

Documentation only, no code touched. Links checked, file and line references checked against `da60702`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive rewrite planning and workflow documentation.
  - Documented issue triage, including diagnoses, resolutions, and planned work.
  - Added an overview of the plugin’s current state, identified limitations, and compatibility findings.
  - Included rewrite phases, progress tracking, migration considerations, integration plans, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->