### PR TITLE
ci(coderabbit): review pull requests targeting develop

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    # The default branch is always included. The rewrite lands on develop, and
+    # stacked pull requests target the branch below them, so both need to be
+    # listed or CodeRabbit skips every pull request in the stack.
+    base_branches:
+      - "develop"
+      - "refonte/.*"


### PR DESCRIPTION
Part of #114.

Every pull request in the rewrite stack currently reports:

> CodeRabbit — Review skipped: reviews are disabled for this base branch

That is not a clean review, it is no review. CodeRabbit auto reviews pull requests whose base is the default branch only, unless `reviews.auto_review.base_branches` says otherwise. We retargeted the rewrite onto `develop` and lost the bot without noticing, because a skipped check shows up green.

`develop` and `refonte/.*` are both listed. The second one matters for the stack: #117 has `refonte/p0-1-multitarget` as its base, not `develop`.

The configuration is read from the head branch, so this pull request is its own test. If CodeRabbit reviews it, the fix works. The existing pull requests pick it up once they merge or rebase onto `develop`.

Nothing else is configured. Everything not listed keeps CodeRabbit's defaults.

## Testing

Watch the CodeRabbit check on this pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review coverage for the `develop` branch and matching `refonte/*` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->