### PR TITLE
fix(notifications): stop the item added handler throwing on a default config

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/ItemAddedLibraryFilterTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ItemAddedLibraryFilterTests.cs
@@ -1,0 +1,67 @@
+using Jellyfin.Plugin.Streamyfin.PushNotifications.Events;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Library filtering rules for the item added notification, covering issue #74.
+/// </summary>
+public class ItemAddedLibraryFilterTests
+{
+    /// <summary>
+    /// A configuration that never mentions enabledLibraries leaves the property null.
+    /// Reading Length on it threw a NullReferenceException inside the event handler,
+    /// which is what issue #74 reports.
+    /// </summary>
+    [Fact]
+    public void AbsentLibraryListEnablesEveryLibrary()
+    {
+        Assert.True(ItemAddedService.IsLibraryEnabled(null, "3a1f0c2e"));
+    }
+
+    /// <summary>
+    /// An explicitly empty list means the same thing as an absent one.
+    /// </summary>
+    [Fact]
+    public void EmptyLibraryListEnablesEveryLibrary()
+    {
+        Assert.True(ItemAddedService.IsLibraryEnabled([], "3a1f0c2e"));
+    }
+
+    /// <summary>
+    /// A library named in the list produces notifications.
+    /// </summary>
+    [Fact]
+    public void ListedLibraryIsEnabled()
+    {
+        Assert.True(ItemAddedService.IsLibraryEnabled(["3a1f0c2e", "9b7d4e11"], "9b7d4e11"));
+    }
+
+    /// <summary>
+    /// A library absent from a non empty list does not.
+    /// </summary>
+    [Fact]
+    public void UnlistedLibraryIsDisabled()
+    {
+        Assert.False(ItemAddedService.IsLibraryEnabled(["3a1f0c2e"], "9b7d4e11"));
+    }
+
+    /// <summary>
+    /// Comparison is ordinal, so ids differing only by case are different libraries.
+    /// </summary>
+    [Fact]
+    public void LibraryIdComparisonIsOrdinal()
+    {
+        Assert.False(ItemAddedService.IsLibraryEnabled(["3A1F0C2E"], "3a1f0c2e"));
+    }
+
+    /// <summary>
+    /// An item whose library could not be identified is not notified about once the
+    /// admin has restricted the list, since we cannot tell whether it is allowed.
+    /// </summary>
+    [Fact]
+    public void UnknownLibraryIsDisabledWhenTheListIsRestricted()
+    {
+        Assert.False(ItemAddedService.IsLibraryEnabled(["3a1f0c2e"], null));
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Notifications/Notifications.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Notifications/Notifications.cs
@@ -21,9 +21,9 @@ public class NotificationConfiguration
 
 public class ItemAddedNotificationConfiguration: NotificationConfiguration
 {
-    [Display(Name = "Enabled libraries", Description = "Enter all library Ids you want to receive notifications from")]
+    [Display(Name = "Enabled libraries", Description = "Enter all library Ids you want to receive notifications from. Leave it out to notify for every library.")]
     [JsonPropertyName(name: "enabledLibraries")]
-    public string[] EnabledLibraries { get; set; }
+    public string[]? EnabledLibraries { get; set; }
 }
 
 public class UserNotificationConfig : NotificationConfiguration

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/Events/ItemAdded/ItemAddedService.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/Events/ItemAdded/ItemAddedService.cs
@@ -33,6 +33,23 @@ public class ItemAddedService : BaseEvent, IHostedService
         _seasonItems = new ConcurrentDictionary<Guid, EpisodeTimer>();
     }
 
+    /// <summary>
+    /// Whether notifications are enabled for the library an item was added to.
+    /// </summary>
+    /// <param name="enabledLibraries">
+    /// The configured library ids. Absent or empty means every library is enabled, so a
+    /// configuration that never mentions <c>enabledLibraries</c> notifies for everything.
+    /// </param>
+    /// <param name="libraryItemId">The id of the library the item was found in.</param>
+    /// <returns><c>true</c> when the library should produce notifications.</returns>
+    public static bool IsLibraryEnabled(string[]? enabledLibraries, string? libraryItemId)
+    {
+        if (enabledLibraries is not { Length: > 0 }) return true;
+
+        return libraryItemId is not null
+               && enabledLibraries.Contains(libraryItemId, StringComparer.Ordinal);
+    }
+
     private void ItemAddedHandler(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
         if (
@@ -46,11 +63,7 @@ public class ItemAddedService : BaseEvent, IHostedService
         var virtualFolder = _libraryManager.GetVirtualFolders()
             .Find(folder => folder.Locations.Any(location => item?.Path?.Contains(location) == true));
 
-        if (
-            virtualFolder != null &&
-            enabledLibraries.Length > 0 &&
-            !enabledLibraries.Contains(virtualFolder.ItemId)
-        )
+        if (virtualFolder != null && !IsLibraryEnabled(enabledLibraries, virtualFolder.ItemId))
         {
             _logger.LogInformation(
                 "Failed to notify about item {0} - {1}. Library {2} currently not enabled for notifications.",


### PR DESCRIPTION
Fixes #74. Found while triaging the open issues for the rewrite, see `docs/rewrite/issue-triage.md`.

Eleven months open, 26 comments, and it is a missing null.

## What happens

`ItemAddedNotificationConfiguration.EnabledLibraries` is declared `string[]` with no initializer. A configuration that never mentions `enabledLibraries`, which includes every default install, leaves it null. `ItemAddedService` then read `.Length` on it:

```csharp
var enabledLibraries = Config.notifications.ItemAdded.EnabledLibraries;
var virtualFolder = _libraryManager.GetVirtualFolders().Find(...);

if (virtualFolder != null && enabledLibraries.Length > 0 && !enabledLibraries.Contains(virtualFolder.ItemId))
```

`virtualFolder != null` short circuits first, which is why it only fired for some people and only on some items: you need an item whose path actually matched a library location. That is also why the thread never converged on a reproduction.

Jellyfin caught it as `Error in ItemAdded event handler` and no notification went out.

## What changes

The property is nullable, which is what it always was in practice. The rule moved into a named function so the "absent or empty means every library" semantics are stated once rather than implied by an `&&` chain:

```csharp
public static bool IsLibraryEnabled(string[]? enabledLibraries, string? libraryItemId)
{
    if (enabledLibraries is not { Length: > 0 }) return true;

    return libraryItemId is not null
           && enabledLibraries.Contains(libraryItemId, StringComparer.Ordinal);
}
```

Behaviour is unchanged for every configuration that did not throw. The one new decision is the last case: an item whose library could not be identified is not notified about once the admin has restricted the list, because we cannot tell whether it is allowed. Before, it was notified about, which leaked items from libraries the admin had excluded.

Six tests cover the matrix, including the null case that reproduces the issue.

## Worth knowing

This is the argument for P0.12 in one property. `<Nullable>enable</Nullable>` is on, so the compiler has been emitting `CS8618` on that exact declaration the whole time, into a build where `TreatWarningsAsErrors` is false and 88 warnings are ignored.

`UserNotificationConfig.UserIds` and `Usernames` carry the same declaration, but nothing reads them, and nothing constructs a `UserNotificationConfig` at all. Left alone here, they belong to P4.4 where the event configuration gets rebuilt.

## Testing

`dotnet test` on both targets, Windows, fr-FR locale: **20 passed, 0 failed** on `jf11` and on `jf12`.
