### PR TITLE
fix(settings): add the missing landscape orientation option

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/OrientationLockTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/OrientationLockTests.cs
@@ -1,0 +1,52 @@
+using Jellyfin.Plugin.Streamyfin.Configuration;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// The orientation lock is served to the app as a number, not as a name, because
+/// <c>SerializationHelper</c> registers a <c>JsonNumberEnumConverter</c> for it. The app
+/// hands that number straight to Expo's <c>ScreenOrientation.lockAsync</c>, so these values
+/// are a contract with <c>expo-screen-orientation</c> rather than an internal detail.
+/// Renumbering a member silently changes what every device does.
+/// </summary>
+public class OrientationLockTests
+{
+    /// <summary>
+    /// Every member matches its counterpart in Expo's <c>OrientationLock</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(OrientationLock.Default, 0)]
+    [InlineData(OrientationLock.PortraitUp, 3)]
+    [InlineData(OrientationLock.Landscape, 5)]
+    [InlineData(OrientationLock.LandscapeLeft, 6)]
+    [InlineData(OrientationLock.LandscapeRight, 7)]
+    public void MemberMatchesExpoScreenOrientation(OrientationLock member, int expected)
+    {
+        Assert.Equal(expected, (int)member);
+    }
+
+    /// <summary>
+    /// The value serves as a number over the wire. A name would reach the app as a string
+    /// and Expo would not recognise it.
+    /// </summary>
+    [Fact]
+    public void OrientationIsServedAsANumber()
+    {
+        var helper = new SerializationHelper();
+
+        var json = helper.SerializeToJson(
+            new Settings
+            {
+                defaultVideoOrientation = new Lockable<OrientationLock>
+                {
+                    locked = true,
+                    value = OrientationLock.Landscape
+                }
+            });
+
+        Assert.Contains("\"value\":5", json.Replace(" ", string.Empty, System.StringComparison.Ordinal), System.StringComparison.Ordinal);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Enums.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Enums.cs
@@ -34,6 +34,10 @@ public enum OrientationLock {
      */
     PortraitUp = 3,
     /**
+     * Both landscape directions, letting the device rotate between them.
+     */
+    Landscape = 5,
+    /**
      * Left landscape only.
      */
     LandscapeLeft = 6,

--- a/examples/full.yml
+++ b/examples/full.yml
@@ -69,7 +69,7 @@ settings:
   # ==================== Video Orientation ====================
   defaultVideoOrientation:
     locked: false
-    value: Default  # Options: Default, PortraitUp, LandscapeLeft, LandscapeRight
+    value: Default  # Options: Default, PortraitUp, Landscape, LandscapeLeft, LandscapeRight
 
   # ==================== UI & Controls ====================
   safeAreaInControlsEnabled:


### PR DESCRIPTION
Fixes #110. Found while triaging the open issues for the rewrite, see `docs/rewrite/issue-triage.md`.

## What was missing

`OrientationLock` in `Configuration/Settings/Enums.cs` is a hand copied subset of Expo's `ScreenOrientation.OrientationLock`, and the copy dropped members. It carried `Default = 0`, `PortraitUp = 3`, `LandscapeLeft = 6` and `LandscapeRight = 7`. Expo's `LANDSCAPE = 5`, the both directions lock, was never carried over, so an admin could push a fixed left or right landscape but never the automatic one.

## Why the numbers matter

They are not arbitrary and they are not internal. `SerializationHelper` registers a `JsonNumberEnumConverter<OrientationLock>`, so `GET /streamyfin/config` serves this setting as a **number**, and the app hands that number straight to `ScreenOrientation.lockAsync`. The values are a contract with `expo-screen-orientation`, and renumbering a member silently changes what every device does.

That is why the change is one line plus a test that pins every member against its Expo counterpart, rather than one line alone. A second test asserts the setting still leaves the plugin as `"value":5` and not as a name, since a name would reach Expo as a string it does not recognise.

The YAML side keeps names, so `examples/full.yml` gains `Landscape` in its list of options.

## Still to do on the app side

The app's own settings screen offers four choices in `components/settings/OtherSettings.tsx`:

```ts
const orientations = [
  ScreenOrientation.OrientationLock.DEFAULT,
  ScreenOrientation.OrientationLock.PORTRAIT_UP,
  ScreenOrientation.OrientationLock.LANDSCAPE_LEFT,
  ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT,
];
```

A value pushed by the plugin is applied whether or not it appears in that list, so this pull request is enough to close the issue as filed. But a user cannot pick Landscape Auto for themselves until `LANDSCAPE` joins that array, and the translation key `home.settings.other.orientations.LANDSCAPE` already exists. That is a separate pull request on streamyfin/streamyfin.

## Testing

`dotnet test` on both targets, Windows, fr-FR locale: **20 passed, 0 failed** on `jf11` and on `jf12`.
