### PR TITLE
docs(rewrite): track the open pull requests, the app side work and a log

### DIFF
--- a/docs/rewrite/README.md
+++ b/docs/rewrite/README.md
@@ -2,11 +2,18 @@
 
 Working documents for the rewrite tracked in issue #114.
 
+Everything about the chantier lives here. If a decision, a finding or a piece of
+work exists only in a pull request thread or a chat, it is not findable, so it
+goes in one of these files instead.
+
 | Document | What it holds |
 |---|---|
+| [log.md](log.md) | What happened and why, newest first. Read this first to catch up. |
 | [state-of-the-plugin.md](state-of-the-plugin.md) | What exists today, and what is wrong with it. Written from reading the code, not from memory. |
-| [issue-triage.md](issue-triage.md) | Every open issue, diagnosed and mapped onto the plan. |
 | [plan.md](plan.md) | The seven parts, their sub parts, and the order they land in. |
+| [issue-triage.md](issue-triage.md) | Every open issue, diagnosed and mapped onto the plan. |
+| [pull-request-triage.md](pull-request-triage.md) | The pull requests that were open when the rewrite started. |
+| [app-side-work.md](app-side-work.md) | What the app repository has to do, and what it is waiting on. |
 
 ## How the work is organised
 
@@ -16,6 +23,23 @@ are chained with `gh stack` so each pull request shows only its own layer.
 `main` keeps serving the published plugin until the rewrite is coherent end to
 end, then `develop` merges into it in one go.
 
+Pull request #121 is the draft from `develop` onto `main`. It stays open for the
+whole chantier and shows the cumulative diff in one place.
+
 If a hotfix ever lands on `main` during the rewrite, merge `main` into
 `develop` the same day. A long lived branch is only cheap while it stays close
 to the trunk.
+
+## Keeping this current
+
+When a pull request merges, in the same sitting:
+
+1. Tick its box in issue #114 and update the Progress table there.
+2. Add its row to the table in #121.
+3. Add an entry to [log.md](log.md) if it changed a decision or turned something
+   up, not for routine work.
+4. Move the item in [app-side-work.md](app-side-work.md) from Open to Done if it
+   was one.
+
+Fixes that close a user issue also get a comment on that issue saying what
+changed for them, in plain terms, before it is closed.

--- a/docs/rewrite/README.md
+++ b/docs/rewrite/README.md
@@ -36,8 +36,8 @@ When a pull request merges, in the same sitting:
 
 1. Tick its box in issue #114 and update the Progress table there.
 2. Add its row to the table in #121.
-3. Add an entry to [log.md](log.md) if it changed a decision or turned something
-   up, not for routine work.
+3. Add an entry to [log.md](log.md). Same rule as the file states: whenever
+   something lands or a decision is taken.
 4. Move the item in [app-side-work.md](app-side-work.md) from Open to Done if it
    was one.
 

--- a/docs/rewrite/app-side-work.md
+++ b/docs/rewrite/app-side-work.md
@@ -1,0 +1,140 @@
+# App side work
+
+The rewrite spans two repositories. This is the running list of what
+[streamyfin/streamyfin](https://github.com/streamyfin/streamyfin) has to do, kept
+here rather than there so the whole chantier can be read from one place.
+
+Every entry says where it came from and where it is going, so nothing depends on
+remembering a conversation. When an item ships, move it to Done with its pull
+request rather than deleting it.
+
+## Open
+
+| Item | Source | Lands with |
+|---|---|---|
+| Consume the server resolved effective set | plan P2.1 | after P1.6 |
+| Preserve locked, pushed once and free | plan P2.2 | with P2.1 |
+| Tolerate a server still on the old format | plan P2.3 | with P2.1 |
+| Remove the hidden Streamystats rule | plan P2.4 | any time |
+| Offer Landscape Auto in the settings screen | issue #110 | any time, small |
+| Grey out the mute subtitle switch when locked | PR #109 | any time, small |
+| Decide on an allow restart setting | PR #109 | before that plugin key |
+| Seerr integration on tvOS | issue #108 | with P6 |
+| Seerr authentication by user token | issue #82, seerr#2244 | with P6 |
+
+## Details
+
+### Offer Landscape Auto in the settings screen
+
+Issue [#110](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/110)
+asked for it on the plugin side, which is done. The app applies whatever number
+the plugin pushes, so an admin can set it, but a user cannot pick it for
+themselves.
+
+`components/settings/OtherSettings.tsx` offers four of Expo's ten values:
+
+```ts
+const orientations = [
+  ScreenOrientation.OrientationLock.DEFAULT,
+  ScreenOrientation.OrientationLock.PORTRAIT_UP,
+  ScreenOrientation.OrientationLock.LANDSCAPE_LEFT,
+  ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT,
+];
+```
+
+Add `ScreenOrientation.OrientationLock.LANDSCAPE` and its entry in the local
+`orientationTranslations` map. The translation key
+`home.settings.other.orientations.LANDSCAPE` already exists and is already mapped
+in `ScreenOrientationEnum` in `utils/atoms/settings.ts`, so nothing else is
+needed.
+
+### Grey out the mute subtitle switch when locked
+
+`components/settings/SubtitleToggles.tsx:442` renders the `subtitlesOnMute` switch
+with no `disabled` binding. A locked value is still enforced, on read through
+`effectiveSettingsAtom` and on write through `updateSettings`, so the setting
+cannot be changed. The switch just gives no sign of it, and the user is left
+wondering why it snaps back.
+
+`components/settings/OtherSettings.tsx` shows the pattern to copy: it reads
+`pluginSettings?.defaultVideoOrientation?.locked` and disables accordingly.
+
+The same audit is worth running across every settings screen. This one was found
+by accident while triaging a plugin pull request, which suggests there are others.
+
+### Decide on an allow restart setting
+
+Plugin pull request [#109](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/109)
+declares `autoSubtitlesOnMuteAllowRestart`, described as allowing subtitle formats
+that need the server to re-process the stream. Nothing in the app implements or
+reads it.
+
+Either the app grows the setting and the plugin declares it afterwards, or the
+plugin drops the key. Declaring a lockable key for behaviour that does not exist
+is how the plugin ends up with settings nobody can explain.
+
+Note also that the app's `subtitlesOnMute` is iOS only and not TV
+(`SubtitleToggles.tsx:439`) and lives in the native player
+(`providers/NativePlayerProvider.tsx:1039`). A plugin setting that silently does
+nothing on Android or on TV needs to say so in its description.
+
+### Consume the server resolved effective set
+
+Plan P2.1. Today the app calls `GET /Streamyfin/config`
+(`augmentations/api.ts:55`), caches the raw map in MMKV under
+`STREAMYFIN_PLUGIN_SETTINGS`, and resolves locally. After P1 the server sends the
+set already resolved for the caller, with secrets removed.
+
+This is also what fixes issue
+[#69](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/69): a
+section built on a library the user cannot see must not reach the device at all,
+and only the server can decide that.
+
+### Preserve locked, pushed once and free
+
+Plan P2.2, and the easiest thing to lose in the migration. The app has two
+distinct behaviours today, not one:
+
+- `locked` is enforced on read, through `effectiveSettingsAtom`, and on write,
+  through `updateSettings`.
+- An unlocked plugin value is applied **exactly once**, through
+  `pendingPluginDefaults` and the `PLUGIN_APPLIED_DEFAULTS` registry. The admin
+  proposes a starting value, the user stays free to change it afterwards.
+
+Collapsing those into a single flag takes away an admin's ability to suggest
+without imposing. The schema in P1.1 has to carry all three states: locked, pushed
+once, unmanaged.
+
+### Tolerate a server still on the old format
+
+Plan P2.3. Phones update on their own schedule and servers update on theirs, so
+for a while a new app will meet an old server and the reverse. Neither should
+degrade into no settings at all.
+
+### Remove the hidden Streamystats rule
+
+Plan P2.4. Setting `streamyStatsServerUrl` currently forces `searchEngine` to
+Streamystats, a rule written into the settings loading path rather than declared
+anywhere. It surprises admins who set a URL and find their search engine changed.
+Replace it with a rule the plugin states, per P6.4.
+
+### Seerr on tvOS, and Seerr authentication by user token
+
+Issue [#108](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/108)
+reports the Seerr integration working on iOS and not on tvOS. Filed on the plugin
+repository, but it is app work.
+
+Issue [#82](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/82)
+matters more than its title suggests. The request was for the plugin to hold a
+Seerr admin API key and act on everyone's behalf. herrrta rejected that and
+changed Seerr instead, so a client can authenticate with the user's own Jellyfin
+access token ([seerr#2244](https://github.com/seerr-team/seerr/pull/2244)).
+
+That is the same admin key that every authenticated user can currently read from
+`GET /streamyfin/config`, see finding 1 in
+[state-of-the-plugin.md](state-of-the-plugin.md). Once the app authenticates by
+user token, the key setting can become optional and then disappear.
+
+## Done
+
+Nothing yet.

--- a/docs/rewrite/app-side-work.md
+++ b/docs/rewrite/app-side-work.md
@@ -132,8 +132,12 @@ access token ([seerr#2244](https://github.com/seerr-team/seerr/pull/2244)).
 
 That is the same admin key that every authenticated user can currently read from
 `GET /streamyfin/config`, see finding 1 in
-[state-of-the-plugin.md](state-of-the-plugin.md). Once the app authenticates by
-user token, the key setting can become optional and then disappear.
+[state-of-the-plugin.md](state-of-the-plugin.md). Authenticating by user token
+does not close that on its own. The endpoint still hands the whole configuration
+to any account on the server, so the key stays readable until the server filters
+what it serves, which is P1.4. Treat P1.4 as the prerequisite for this item
+rather than a follow up: with it, the key setting can become optional and then
+disappear.
 
 ## Done
 

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -93,6 +93,56 @@ Diagnosed all sixteen open issues against the code, in
   just calls them `BoxSet` and nothing documents the legal values. That single
   issue is the argument for P3.1.
 
+### P0 finished, in four larger pull requests
+
+CodeRabbit gives two included reviews an hour, and one pull request per sub part
+was saturating it permanently, so the rest of P0 landed in four pieces instead of
+ten.
+
+**#125, P0.3 to P0.5.** `Storage/` deleted, EF Core in its place. The three could
+not land apart: the hand written store cannot go until its data has moved, and
+its data cannot move until there is somewhere to move it to. Device tokens are
+imported once from `streamyfin_plugin.db`, read only, in one transaction with a
+marker row, and the old file is never written to or deleted, so a downgrade still
+finds it. CodeRabbit caught a real regression on the first pass: the replacement
+of a device token used two `SaveChanges` calls, which is two transactions, and a
+failure between them left the device with no token. Fixed by updating in place.
+
+**#126, P0.6 to P0.9.** The release chain assumed a single artifact. The zip path
+was hardcoded on `net9.0` twice, `targetAbi` was hardcoded to 10.11.11, and
+nothing removed an existing entry before adding one. Now: one tag, one release,
+both zips, and a manifest per Jellyfin line with the `targetAbi` its own build
+was compiled against. The `Makefile` gave up tagging and pushing to `main`, which
+never belonged to it.
+
+The part that matters more than the fixes: **packaging now runs on every pull
+request**, in dry run. The release chain being exercised only by a release is how
+a zip path pinned to `net9.0` survived unnoticed in the first place.
+
+**#127, P0.12 and P0.13.** The warning policy. Five rules turned off in
+`.editorconfig` with the reason written next to each, everything else fixed, and
+`TreatWarningsAsErrors` turned on. Both targets now build at 0 warnings and 0
+errors. Turning it on immediately promoted a NuGet advisory on a transitive
+`SQLitePCLRaw` to an error, which is the policy working on its first day.
+
+P0.13 was the three `CS4014`. Jellyfin's event handlers are synchronous, so a
+notification send cannot be awaited from one, and the exception landed in a task
+nobody observed. A failing send looked exactly like a working one. They now go
+through `SendDetached`, which logs the failure.
+
+**P0.10, SignPath artifact signing, is not done.** It was optional, it needs an
+account and an application to the free open source programme, and it is the
+maintainer's call rather than a code change.
+
+### Not verified yet
+
+The plugin has not been loaded on a real server since the EF Core change. The
+evidence says `Microsoft.EntityFrameworkCore.Sqlite` is present on both Jellyfin
+lines, since intro-skipper ships nothing but its own dll against the same
+dependency, but that deserves a load test before a release goes out. The beta
+server is stopped and the workstation is off the network, so it is deferred
+rather than skipped. See `project_plugin_test_servers` for the access details.
+
 ### Pull request triage
 
 The three pull requests that were already open, diagnosed in

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -1,0 +1,104 @@
+# Log
+
+What actually happened, newest first. The plan says where we are going,
+[issue #114](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/114)
+says what is left, and this says what was done and why, so someone arriving in
+three months can catch up without reading a pull request thread.
+
+Append an entry whenever something lands or a decision is taken. A decision that
+lives only in a comment thread is a decision nobody will find.
+
+## 2026-08-24
+
+### The chantier opened
+
+Scoped the rewrite, wrote issue #114, and settled the decisions that everything
+else hangs off: breaking change with a migration, three targeting levels, plugin
+and app moving together, dual Jellyfin support through an MSBuild switch, admin
+forms generated from the JSON schema. Reasoning in [plan.md](plan.md).
+
+Studied four reference projects first rather than inventing: KefinTweaks for the
+hybrid form approach, intro-skipper for the EF Core model and for the migration
+pattern of its pull request #871, File Transformation and the JavaScript Injector
+for the page injection question and for the multi target build.
+
+### `develop` became the integration branch
+
+`main` keeps serving the published plugin. Every sub part gets its own branch and
+its own pull request onto `develop`, chained with `gh stack`. #121 is the draft
+pull request from `develop` onto `main` that shows the cumulative diff.
+
+Consequence nobody predicted: CodeRabbit only auto reviews pull requests based on
+the default branch, so the whole stack silently stopped being reviewed and the
+check went green as `Review skipped`. Fixed by #120, which adds `.coderabbit.yaml`
+listing `develop` and `refonte/.*`. Worth remembering as a shape of failure: a
+skipped check looks exactly like a passing one.
+
+### P0.1, P0.2 and P0.11 landed
+
+- **#116, P0.11.** The suite only passed on an English Linux box. `DatabaseTests`
+  deleted the SQLite file without draining the connection pool, which throws on
+  Windows, and a localization test asserted the English string without pinning the
+  culture, so it failed on any French machine. Fixed before turning CI on, not
+  after, because red that everyone ignores is worse than no CI.
+- **#115, P0.1.** `JellyfinTarget` switch, a single `Compat/` folder, and a test
+  that fails the build if a version conditional appears anywhere else.
+- **#117, P0.2.** `build.yml`, building and testing both targets on every pull
+  request.
+
+Two findings from doing it:
+
+**The plugin compiles against Jellyfin 12 with zero source changes**, 0 errors on
+both targets. `Compat/` starts empty. The only structural break between 10.11 and
+12 is `net9.0` to `net10.0`.
+
+**`IUserManager.Users` became `IUserManager.GetUsers()` in 10.11.9**, a breaking
+change inside a patch line. No single artifact can cover 10.11.0 through 10.11.11,
+so the floor is 10.11.9. That is still wider than the published manifest, which
+demands 10.11.11 by accident rather than by choice.
+
+### The dossier
+
+#119 added [state-of-the-plugin.md](state-of-the-plugin.md),
+[issue-triage.md](issue-triage.md) and [plan.md](plan.md). Reading the code to
+write the first one turned up three things that were not in anyone's head:
+
+- `Pages/Libraries/` is 16 MB of vendored JavaScript embedded in the DLL, and
+  523 KB of it is `json-editor`, imported by nothing. That is the form generator
+  P3 needs, already paid for.
+- The third party assemblies in `packages/` are committed binaries, not build
+  output. We compile against `Newtonsoft.Json.Schema` 3.0.16 and ship 4.0.1, and
+  no source file references that namespace at all. A paid package, referenced,
+  shipped, unused.
+- `GET config` and `GET config/yaml` are guarded by `[Authorize]` alone, so every
+  account on the server reads the whole configuration including the Seerr admin
+  key. `examples/full.yml` already warns about it in capitals.
+
+### Issue triage, and two fixes that needed none of the rewrite
+
+Diagnosed all sixteen open issues against the code, in
+[issue-triage.md](issue-triage.md). Results worth naming:
+
+- **#74**, open eleven months with 26 comments, is a missing null.
+  `EnabledLibraries` was declared non nullable with no initializer, so a default
+  configuration left it null and the handler read `.Length` on it. Fixed in #122.
+  The compiler had been emitting `CS8618` on that exact property the whole time,
+  into a build where warnings are ignored. That is P0.12 argued in one property.
+- **#110** is a value dropped when `OrientationLock` was hand copied from Expo.
+  Fixed in #123, with a test pinning every member to its Expo counterpart, since
+  the values are served as numbers and go straight to `lockAsync`.
+- **#100 and #90 can be closed.** One was fixed and shipped in 0.67.0.0 and both
+  reporters were waiting on a release, the other asks for a setting that exists.
+- **#88 is not a bug.** `includeItemTypes` already accepts collections, Jellyfin
+  just calls them `BoxSet` and nothing documents the legal values. That single
+  issue is the argument for P3.1.
+
+### Pull request triage
+
+The three pull requests that were already open, diagnosed in
+[pull-request-triage.md](pull-request-triage.md). #71 to close, #81 needs a
+decision after nine months of nobody answering, #109 declares keys the app does
+not read.
+
+The app side work that came out of it is tracked in
+[app-side-work.md](app-side-work.md).

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -59,7 +59,7 @@ demands 10.11.11 by accident rather than by choice.
 
 ### The dossier
 
-#119 added [state-of-the-plugin.md](state-of-the-plugin.md),
+Pull request #119 added [state-of-the-plugin.md](state-of-the-plugin.md),
 [issue-triage.md](issue-triage.md) and [plan.md](plan.md). Reading the code to
 write the first one turned up three things that were not in anyone's head:
 

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -211,8 +211,12 @@ names kept as aliases, which closes #95 without breaking every existing YAML.
 
 ## Progress
 
-| Sub part | Pull request |
-|---|---|
-| P0.1 | [#115](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/115) |
-| P0.2 | [#117](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/117) |
-| P0.11 | [#116](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/116) |
+| Sub part | Pull request | State |
+|---|---|---|
+| P0.1 | [#115](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/115) | merged |
+| P0.2 | [#117](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/117) | merged |
+| P0.11 | [#116](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/116) | merged |
+| P0.3, P0.4, P0.5 | [#125](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/125) | open |
+| P0.6 to P0.9 | [#126](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/126) | open |
+| P0.12, P0.13 | [#127](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/127) | open |
+| P0.10 | none | not started, optional, needs a SignPath application |

--- a/docs/rewrite/pull-request-triage.md
+++ b/docs/rewrite/pull-request-triage.md
@@ -1,0 +1,111 @@
+# Pull request triage
+
+The pull requests that were open when the rewrite started, diagnosed against the
+code on both sides rather than against their descriptions. Rewrite pull requests
+are tracked in [issue #114](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/114)
+and in [plan.md](plan.md), not here.
+
+## Summary
+
+| PR | Age | State | Verdict |
+|---|---|---|---|
+| [#109](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/109) | opened 2026-07-30 | clean | Right feature, wrong keys. Rename before merging. |
+| [#81](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/81) | opened 2025-11-18 | clean, never reviewed | Real feature, collides with P4.4. Decide, do not leave it rotting. |
+| [#71](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/71) | opened 2025-09-16 | conflicting | Close. |
+
+## #109, lockable auto subtitles on mute
+
+Two lockable booleans, `autoSubtitlesOnMute` and `autoSubtitlesOnMuteAllowRestart`,
+declared so the plugin can push and lock the app's mute behaviour. Eleven lines,
+CodeRabbit found nothing, and the reasoning in the description is right: a key the
+plugin does not declare resolves `locked` to `undefined`, so the lock can never
+take effect.
+
+**The keys do not match the app.** In `streamyfin/streamyfin` the setting is
+`subtitlesOnMute`, a single boolean:
+
+| Where | What |
+|---|---|
+| `utils/atoms/settings.ts:378` | `subtitlesOnMute: boolean` in the settings type |
+| `utils/atoms/settings.ts:552` | default `false` |
+| `components/settings/SubtitleToggles.tsx:442` | the switch, iOS only and not TV |
+| `providers/NativePlayerProvider.tsx:1039` | the behaviour, native player only |
+
+Neither `autoSubtitlesOnMute` nor anything resembling an allow restart setting
+exists anywhere in the app. Merged as it stands, this pull request ships two keys
+nothing reads, and the lock it is meant to enable still does nothing.
+
+Three things to settle before it merges:
+
+1. **Rename** `autoSubtitlesOnMute` to `subtitlesOnMute`, so the key the plugin
+   pushes is the key the app resolves.
+2. **The second key does not exist yet.** Either drop it, or add the setting to
+   the app first and land the plugin side after. Declaring it now is the same
+   mistake in the other direction.
+3. **The default disagrees.** The pull request defaults it to on, the app defaults
+   `subtitlesOnMute` to `false`. An unlocked plugin value is applied once as a
+   default, so merging as is turns the feature on for every user who has not
+   already chosen. That may well be the intent, but it should be a decision.
+
+One more thing the description assumes and the code does not do: the switch in
+`SubtitleToggles.tsx` has no `disabled` binding, unlike the orientation control in
+`OtherSettings.tsx` which reads `pluginSettings?.defaultVideoOrientation?.locked`.
+A locked value is still enforced centrally on read and on write, so locking works,
+but the switch will not grey out until that binding is added. Listed in
+[app-side-work.md](app-side-work.md).
+
+## #81, Seerr webhook notifications
+
+A `POST /streamyfin/notification/seerr` endpoint that receives Seerr webhooks and
+turns them into push notifications: `MEDIA_PENDING`, `MEDIA_AUTO_APPROVED` and
+`MEDIA_FAILED` to admins, `MEDIA_APPROVED`, `MEDIA_DECLINED` and `MEDIA_AVAILABLE`
+to the requesting user, issue events filtered out. 755 lines, a mapper, a payload
+model, and a new `Strings.zh-CN.resx`.
+
+It has sat for nine months with **zero comments and zero reviews**. Not one person
+said yes or no. That is the part worth fixing first, whatever the outcome.
+
+The feature is real and users want it. What has to be settled:
+
+- **Naming.** Everything in it says Jellyseerr. The project has moved to Seerr,
+  which is what issue #95 is about. New code should not arrive already carrying
+  the old name.
+- **It hardcodes the event routing**, which is exactly what P4.4 replaces with
+  declared events. Merging it adds surface that P4 then has to migrate. Holding it
+  makes a contributor wait on a part that is five steps away.
+- **A new locale.** `Strings.zh-CN.resx` is the first Chinese resource in the
+  plugin. The plugin has no translation platform, unlike the app which uses
+  Crowdin, so accepting it means accepting that someone maintains it by hand.
+- **The endpoint carries `[Authorize]`.** A webhook cannot log in as a Jellyfin
+  user, so this only works if the admin sets an authorization header in the Seerr
+  webhook agent. That works, but it is undocumented in the pull request and it is
+  the first thing anyone configuring it will hit.
+- **It logs the full payload at debug level**, which includes requester details.
+
+Recommendation: take the feature, on the current shape, with the renaming, and
+accept that P4.4 will reshape it. Nine months of silence is worse for the project
+than a migration cost we already signed up for. But say so on the pull request
+rather than leaving it open for another nine months.
+
+## #71, TV sidebar links
+
+`settings.tvSidebarLinks`, letting an admin declare custom TV sidebar entries
+pointing at libraries or collections, each able to carry curated sections.
+
+Close it. Three independent reasons:
+
+- **The maintainer already said so.** Comment of 2026-06-17: "I think this PR need
+  to be completely re-done since tv as change a lot."
+- **Nothing consumes it.** There is no `tvSidebarLinks`, no `sidebarLinks` and no
+  `SidebarLink` anywhere in the app. Merged, it is config an admin can write and
+  no device will read.
+- **It conflicts with `main`** and has since well before that comment.
+
+There is a fourth reason to close rather than rebase: it reuses the existing
+`Section` model, which is precisely the model P5.1 replaces with a discriminated
+type. Rebasing it now means rebasing it again in P5.
+
+Close with the reasoning, point at #114 and P5, and say the idea is wanted back
+once the section model is settled and the TV app side exists. The contributor put
+real work in; the close should read like a postponement, because that is what it
+is.

--- a/docs/rewrite/pull-request-triage.md
+++ b/docs/rewrite/pull-request-triage.md
@@ -9,7 +9,7 @@ and in [plan.md](plan.md), not here.
 
 | PR | Age | State | Verdict |
 |---|---|---|---|
-| [#109](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/109) | opened 2026-07-30 | clean | Right feature, wrong keys. Rename before merging. |
+| [#109](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/109) | opened 2026-07-30 | clean | Right feature, wrong keys. Settle the names, the allow restart setting and the default before merging. |
 | [#81](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/81) | opened 2025-11-18 | clean, never reviewed | Real feature, collides with P4.4. Decide, do not leave it rotting. |
 | [#71](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/71) | opened 2025-09-16 | conflicting | Close. |
 
@@ -80,12 +80,17 @@ The feature is real and users want it. What has to be settled:
   user, so this only works if the admin sets an authorization header in the Seerr
   webhook agent. That works, but it is undocumented in the pull request and it is
   the first thing anyone configuring it will hit.
-- **It logs the full payload at debug level**, which includes requester details.
+- **It logs the full payload at debug level**, which includes the requester's
+  username and email. `StreamyfinController.cs` serialises the whole webhook body
+  into a debug line, so turning debug logging on writes other people's contact
+  details into the server log.
 
-Recommendation: take the feature, on the current shape, with the renaming, and
-accept that P4.4 will reshape it. Nine months of silence is worse for the project
-than a migration cost we already signed up for. But say so on the pull request
-rather than leaving it open for another nine months.
+Recommendation: take the feature, with the renaming, and accept that P4.4 will
+reshape it. Nine months of silence is worse for the project than a migration cost
+we already signed up for. The payload logging is not part of that cost: log the
+notification type and the subject, not the body, before this merges. That is a
+one line change and it is not something to inherit deliberately. Say all of this
+on the pull request rather than leaving it open for another nine months.
 
 ## #71, TV sidebar links
 

--- a/examples/full.yml
+++ b/examples/full.yml
@@ -221,6 +221,14 @@ settings:
               - DateCreated
             sortOrder:
               - Descending
+            # Jellyfin's own item kind names, not the words used in the UI.
+            # A collection is a BoxSet, a folder is a Folder, a music album is a
+            # MusicAlbum. Common values: Movie, Series, Season, Episode, BoxSet,
+            # Playlist, MusicAlbum, MusicArtist, Audio, Book, Photo, PhotoAlbum,
+            # LiveTvChannel, LiveTvProgram, Folder, CollectionFolder.
+            # A name that is not one of these is ignored rather than reported,
+            # so the section simply comes back with the wrong contents.
+            # The full list is served at GET /streamyfin/config/schema.
             includeItemTypes:
               - Series
               - Movie


### PR DESCRIPTION
Part of #114.

The dossier covered the plugin and the issues. It did not cover the pull requests that were already open, the work that falls on the app repository, or what has actually happened so far. Three files, so the chantier can be followed by someone who was not in the room.

## `pull-request-triage.md`

The three pull requests open when the rewrite started, read against the code on both sides rather than against their descriptions.

**#109, auto subtitles on mute.** Right feature, wrong keys. It declares `autoSubtitlesOnMute` and `autoSubtitlesOnMuteAllowRestart`. The app reads `subtitlesOnMute`, a single boolean, at `utils/atoms/settings.ts:378`. Neither declared key exists anywhere in the app, so merged as it stands it ships two keys nothing reads and the lock it exists to enable still does nothing. Three things to settle first, including that the default disagrees with the app's: an unlocked plugin value is applied once as a default, so merging as is turns the feature on for everyone who has not already chosen.

**#81, Seerr webhook notifications.** Nine months open with **zero comments and zero reviews**. Nobody said yes or no, which is the part worth fixing whatever the outcome. The feature is real and wanted. It also hardcodes the event routing that P4.4 replaces, arrives named Jellyseerr after the project moved to Seerr, and adds the plugin's first Chinese resource file with no translation platform to maintain it. Recommendation in the file: take it, with the renaming, and accept the migration cost.

**#71, TV sidebar links.** Close. The maintainer already said it needs redoing, it conflicts with `main`, and nothing in the app reads `tvSidebarLinks` at all. It also reuses the `Section` model that P5.1 replaces, so rebasing now means rebasing again later.

## `app-side-work.md`

The running list of what `streamyfin/streamyfin` has to do, kept here rather than there so the whole chantier reads from one place. P2.1 through P2.4 from the plan, plus what the triage turned up:

- Offer Landscape Auto in the settings screen, now that the plugin can push it. The translation key already exists.
- Grey out the mute subtitle switch when locked. `SubtitleToggles.tsx:442` has no `disabled` binding, unlike the orientation control right next to it. The lock is still enforced centrally, so the switch simply snaps back with no explanation. Worth auditing every settings screen for the same gap.
- Decide whether an allow restart setting should exist at all before the plugin declares a key for it.

## `log.md`

What happened and why, newest first, so someone arriving in three months can catch up without reading pull request threads. Today's entry covers the scoping, `develop` becoming the integration branch, the CodeRabbit skip that made a missing review look like a passing check, the three P0 parts landing, and the findings from the dossier and the triage.

## Keeping it current

The README now says what to do when a pull request merges: tick #114, add the row to #121, log it if it changed a decision, move the app side item to Done. A dossier that drifts is worse than no dossier.

## Testing

Documentation only. Links and every file and line reference checked against the code on both repositories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded rewrite documentation with decision logs, work tracking, and pull-request triage guidance.
  * Added planning records for app-side settings, orientation, subtitle controls, and Seerr integration.
  * Documented completed work, compatibility findings, workflow guidance, follow-up items, and rewrite progress statuses.
  * Added an index of new rewrite planning and tracking documents.
  * Clarified valid Jellyfin item types for “Recently Added” configuration and where to find the full list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->