### PR TITLE
ci(release): build, package and publish both Jellyfin targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,22 @@ jobs:
       - name: Test
         run: dotnet test Jellyfin.Plugin.Streamyfin.Tests --configuration Release --no-build -p:JellyfinTarget=${{ matrix.target }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      # The release chain used to be exercised only by cutting a release. That is
+      # how a zip path pinned to net9.0 survived unnoticed: nothing ever built the
+      # other target's package. Packaging now runs on every pull request, with a
+      # placeholder version since a pull request checkout has no tags.
+      - name: Package
+        env:
+          VERSION: 0.0.0.0
+        run: |
+          make zip JELLYFIN_TARGET=${{ matrix.target }}
+          make update-manifest JELLYFIN_TARGET=${{ matrix.target }} DRY_RUN=1
+
       - name: Upload plugin
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,29 +8,118 @@ permissions:
   contents: write
 
 jobs:
-  main:
-    name: Create release
+  # The version is computed once and handed to every other job. Computing it per
+  # job would let two jobs disagree if a commit landed between them.
+  version:
+    name: Compute version
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
 
-      - name: build and release application
+      - id: compute
+        run: echo "version=$(node scripts/next-version.js)" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [jf11, jf12]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Stamp the version into the assembly
+        run: make update-version
+
+      - name: Test
+        run: make test JELLYFIN_TARGET=${{ matrix.target }}
+
+      - name: Build and package
         run: |
-          git config --global user.name 'streamyfin'
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          make release
+          make build JELLYFIN_TARGET=${{ matrix.target }}
+          make zip JELLYFIN_TARGET=${{ matrix.target }}
+          make print JELLYFIN_TARGET=${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: streamyfin-${{ matrix.target }}
+          path: dist/*.zip
+          if-no-files-found: error
+
+  release:
+    name: Publish
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Show what will be published
+        run: ls -l dist
+
+      # One tag and one release carrying both artifacts. Two releases would mean
+      # two changelogs for the same commit and two things for a user to choose
+      # between without knowing which server line they are on.
+      - name: Tag and release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name 'streamyfin'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          make update-version
+          git commit -m "new release: ${VERSION}" Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
+          git tag "${VERSION}"
+          git push origin HEAD:main --tags
+          gh release create "${VERSION}" dist/*.zip --generate-notes --verify-tag
+
+      # Each manifest gets its own entry, with the targetAbi the matching build
+      # was compiled against. The checksum is verified against the uploaded file
+      # before the manifest is written, so a failed upload cannot be published.
+      - name: Update both manifests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make update-manifest JELLYFIN_TARGET=jf11
+          make update-manifest JELLYFIN_TARGET=jf12
+          git commit -m "new release: ${VERSION} manifests" manifest.json manifest-jf12.json
+          git push origin HEAD:main

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,49 @@
-export VERSION := $(shell node scripts/next-version.js)
+# ?= rather than := so a caller that already computed the version, such as the
+# release workflow, stays authoritative. Recomputing per job lets two jobs
+# disagree if a commit lands between them.
+VERSION ?= $(shell node scripts/next-version.js)
+export VERSION
 ifeq ($(VERSION),)
 $(error Failed to compute VERSION via scripts/next-version.js)
 endif
+
+# Which Jellyfin line to build for. See Directory.Build.props.
+JELLYFIN_TARGET ?= jf11
+
+# Ask MSBuild what this target compiles to instead of repeating the mapping
+# here, where it would drift from Directory.Build.props the first time a target
+# moves to a new framework. That drift is exactly what pinned the old zip path
+# to net9.0 and would have broken the first multi target release.
+TFM = $(shell dotnet msbuild Jellyfin.Plugin.Streamyfin -getProperty:TargetFramework -p:JellyfinTarget=$(JELLYFIN_TARGET) -nologo)
+export JELLYFIN_ABI = $(shell dotnet msbuild Jellyfin.Plugin.Streamyfin -getProperty:JellyfinAbi -p:JellyfinTarget=$(JELLYFIN_TARGET) -nologo)
+
 export GITHUB_REPO := streamyfin/jellyfin-plugin-streamyfin
-export FILE := streamyfin-${VERSION}.zip
+export FILE := streamyfin-$(VERSION)-$(JELLYFIN_TARGET).zip
+
+# jf11 keeps manifest.json so servers already pointed at that URL keep working.
+export MANIFEST = $(if $(filter jf12,$(JELLYFIN_TARGET)),manifest-jf12.json,manifest.json)
 
 print:
-	echo ${VERSION}
+	@echo "version=$(VERSION) target=$(JELLYFIN_TARGET) tfm=$(TFM) abi=$(JELLYFIN_ABI) file=$(FILE) manifest=$(MANIFEST)"
 
-k: zip
+build:
+	dotnet build Jellyfin.Plugin.Streamyfin --configuration Release -p:JellyfinTarget=$(JELLYFIN_TARGET)
+
+test:
+	dotnet test Jellyfin.Plugin.Streamyfin.Tests -p:JellyfinTarget=$(JELLYFIN_TARGET)
 
 zip:
 	mkdir -p ./dist
-	zip -r -j "./dist/${FILE}" Jellyfin.Plugin.Streamyfin/bin/Release/net9.0/Jellyfin.Plugin.Streamyfin.dll packages/
-	cd Jellyfin.Plugin.Streamyfin/bin/Release/net9.0/ && find . -type d -not -path '.' -print | zip -ur "${GITHUB_WORKSPACE}/dist/${FILE}" -@
+	zip -r -j "./dist/$(FILE)" Jellyfin.Plugin.Streamyfin/bin/Release/$(TFM)/Jellyfin.Plugin.Streamyfin.dll packages/
+	cd Jellyfin.Plugin.Streamyfin/bin/Release/$(TFM)/ && find . -type d -not -path '.' -print | zip -ur "$(CURDIR)/dist/$(FILE)" -@
 
 csum:
-	md5sum "./dist/${FILE}"
-
-create-tag:
-	git tag ${VERSION}
-	git push origin ${VERSION}
-
-create-gh-release:
-	gh release create ${VERSION} "./dist/${FILE}" --generate-notes --verify-tag
+	md5sum "./dist/$(FILE)"
 
 update-version:
-	sed -i 's/\(.*\)<\(.*\)Version>\(.*\)<\/\(.*\)Version>/\1<\2Version>${VERSION}<\/\4Version>/g' Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
-  
+	sed -i 's/\(.*\)<\(.*\)Version>\(.*\)<\/\(.*\)Version>/\1<\2Version>$(VERSION)<\/\4Version>/g' Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
+
 update-manifest:
 	node scripts/validate-and-update-manifest.js
 
-test: 
-	dotnet test Jellyfin.Plugin.Streamyfin.Tests
-
-build: 
-	dotnet build Jellyfin.Plugin.Streamyfin --configuration Release
-  
-push-manifest:
-	git commit -m 'new release: ${VERSION}' manifest.json Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
-	git push origin main
-
-release: print update-version build zip create-tag create-gh-release update-manifest push-manifest
+.PHONY: print build test zip csum update-version update-manifest

--- a/manifest-jf12.json
+++ b/manifest-jf12.json
@@ -1,0 +1,12 @@
+[
+    {
+        "guid": "1e9e5d38-6e67-4615-8719-e98a5c34f004",
+        "name": "Streamyfin",
+        "overview": "",
+        "description": "",
+        "owner": "streamyfin",
+        "category": "General",
+        "imageUrl": "https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/logo.png",
+        "versions": []
+    }
+]

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
         "name": "Streamyfin",
         "overview": "",
         "description": "",
-        "owner": "lostb1t",
+        "owner": "streamyfin",
         "category": "General",
         "imageUrl": "https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/logo.png",
         "versions": [

--- a/scripts/validate-and-update-manifest.js
+++ b/scripts/validate-and-update-manifest.js
@@ -6,22 +6,32 @@ const { URL } = require('url');
 const repository = process.env.GITHUB_REPO;
 const version = process.env.VERSION;
 const file = process.env.FILE;
-const targetAbi = "10.11.11";
 
-console.log(file);
-// Read manifest.json
-const manifestPath = './manifest.json';
-if (!fs.existsSync(manifestPath)) {
-    console.error('manifest.json file not found');
-    process.exit(1);
+// The minimum server this build actually runs on, taken from the build rather
+// than written here. It used to be hardcoded to 10.11.11, which is why the
+// published manifest demanded a server three patches newer than necessary.
+const targetAbi = process.env.JELLYFIN_ABI;
+
+// jf11 keeps manifest.json so servers already configured with that URL keep
+// working. jf12 gets its own file, the same way the JavaScript Injector plugin
+// ships one manifest per Jellyfin line.
+const manifestPath = `./${process.env.MANIFEST || 'manifest.json'}`;
+
+const dryRun = process.env.DRY_RUN === '1';
+
+for (const [name, value] of Object.entries({ GITHUB_REPO: repository, VERSION: version, FILE: file, JELLYFIN_ABI: targetAbi })) {
+    if (!value) {
+        console.error(`${name} is not set. Run this through the Makefile, which computes all of them.`);
+        process.exit(1);
+    }
 }
 
-// Read README.md
-// const readmePath = './README.md';
-// if (!fs.existsSync(readmePath)) {
-//     console.error('README.md file not found');
-//     process.exit(1);
-// }
+console.log(`Updating ${manifestPath} with ${file} (targetAbi ${targetAbi})`);
+
+if (!fs.existsSync(manifestPath)) {
+    console.error(`${manifestPath} not found`);
+    process.exit(1);
+}
 
 const jsonData = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
@@ -37,18 +47,33 @@ const newVersion = {
 async function updateManifest() {
     await validVersion(newVersion);
 
-    // Add the new version to the manifest
+    // Drop any entry for this version before adding it. Without this, republishing
+    // a version leaves two entries for it and Jellyfin shows the plugin twice.
+    const before = jsonData[0].versions.length;
+    jsonData[0].versions = jsonData[0].versions.filter((v) => v.version !== newVersion.version);
+    const removed = before - jsonData[0].versions.length;
+    if (removed > 0) {
+        console.log(`Replaced ${removed} existing entr${removed === 1 ? 'y' : 'ies'} for ${newVersion.version}`);
+    }
+
     jsonData[0].versions.unshift(newVersion);
 
     // Write the updated manifest to file if validation is successful
     fs.writeFileSync(manifestPath, JSON.stringify(jsonData, null, 4));
     console.log('Manifest updated successfully.');
-    //updateReadMeVersion();
     process.exit(0); // Exit with no error
 }
 
 async function validVersion(version) {
     console.log(`Validating version ${version.version}...`);
+
+    // On a pull request the release does not exist yet, so there is nothing to
+    // download and compare against. Everything else still runs, which is the
+    // point: the packaging path gets exercised outside of a real release.
+    if (dryRun) {
+        console.log('DRY_RUN set, skipping the remote checksum verification.');
+        return;
+    }
 
     const isValidChecksum = await verifyChecksum(version.sourceUrl, version.checksum);
     if (!isValidChecksum) {
@@ -104,26 +129,6 @@ function getMD5FromFile() {
     const fileBuffer = fs.readFileSync(`./dist/${file}`);
     return crypto.createHash('md5').update(fileBuffer).digest('hex');
 }
-
-// function getReadMeVersion() {
-//     let parts = targetAbi.split('.').map(Number);
-//     parts.pop();
-//     return parts.join(".");
-// }
-
-// function updateReadMeVersion() {
-//     const newVersion = getReadMeVersion();
-//     const readMeContent = fs.readFileSync(readmePath, 'utf8');
-
-//     const updatedContent = readMeContent
-//         .replace(/Jellyfin.*\(or newer\)/, `Jellyfin ${newVersion} (or newer)`)
-//     if (readMeContent != updatedContent) {
-//         fs.writeFileSync(readmePath, updatedContent);
-//         console.log('Updated README with new Jellyfin version.');
-//     } else {
-//         console.log('README has already newest Jellyfin version.');
-//     }
-// }
 
 async function run() {
     await updateManifest();


### PR DESCRIPTION
Part of #114. Covers **P0.6, P0.7, P0.8 and P0.9**.

The release chain assumed a single artifact everywhere, so it had to move as one piece.

## What was broken

- **The zip path was hardcoded on `net9.0`**, twice, in the `Makefile`. The first multi target release would have packaged the wrong build for `jf12`, or nothing at all.
- **`targetAbi` was hardcoded to `10.11.11`** in `scripts/validate-and-update-manifest.js`. That is why the published manifest demands a server three patches newer than the plugin actually needs. It was never a decision, just the version that happened to be current.
- **Nothing removed an existing entry before adding one.** `versions.unshift(newVersion)` with no lookup, so republishing a version lists it twice and Jellyfin shows the plugin twice. It has not fired yet, the published manifest has 62 entries and 62 distinct versions, but only because nobody has republished.
- **`make release` tagged, released and pushed to `main`.** A Makefile target that pushes to the default branch is one typo away from a bad afternoon.

## What it does now

`release.yml` computes the version **once** and hands it to every job, because computing it per job lets two jobs disagree if a commit lands between them. It then builds and tests both targets in a matrix, and publishes **one tag and one release carrying both zips**. Two releases would mean two changelogs for the same commit and two things for a user to choose between without knowing which server line they are on.

Each manifest gets its own entry with the `targetAbi` its own build was compiled against, read from MSBuild rather than written down:

| Manifest | Line | Why |
|---|---|---|
| `manifest.json` | 10.11 | Unchanged URL, so every server already configured with it keeps working |
| `manifest-jf12.json` | 12 | New file, the way the JavaScript Injector plugin ships one manifest per line |

The `Makefile` keeps the mechanics and gives up tagging, releasing and pushing. It also stops repeating the target to framework mapping that `Directory.Build.props` already owns, and asks MSBuild instead:

```make
TFM = $(shell dotnet msbuild Jellyfin.Plugin.Streamyfin -getProperty:TargetFramework -p:JellyfinTarget=$(JELLYFIN_TARGET) -nologo)
```

That duplication is precisely what pinned the zip path to `net9.0` and would have broken the first release.

## The part that matters most

**Packaging now runs on every pull request**, in dry run, added to `build.yml`. The release chain being exercised only by cutting a release is how a zip path pinned to `net9.0` survived unnoticed. `DRY_RUN=1` skips the remote checksum verification, since on a pull request the release does not exist yet, and everything else still runs.

`manifest.json` also passes from a personal account to the organisation, which is P0.9.

## Testing

`make` is not available on this workstation, so the Makefile itself will first run for real in CI on this pull request, which is the point of adding the packaging step.

The manifest script was exercised locally against both manifests:

- dry run skips the remote verification and still writes
- running twice with the same version leaves **one** entry, logging `Replaced 1 existing entry for 9.9.9.9`
- `jf12` writes `manifest-jf12.json` with `targetAbi` 12.0.0.0 and the `-jf12` zip URL
- a missing environment variable fails immediately with a message naming it, rather than writing `undefined` into the manifest

Both manifests were restored afterwards, so the only change to `manifest.json` in this pull request is the owner.
