### PR TITLE
feat(settings): describe the settings and mark which ones hold a credential

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsSchemaTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsSchemaTests.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Jellyfin.Plugin.Streamyfin.Configuration;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// <c>SettingsSchema</c> reads the settings class so that nothing else has to repeat a
+/// property list. These tests are what keep the two in step: a setting added to the class
+/// and forgotten here, or a credential added without <c>[Secret]</c>, fails the build
+/// rather than shipping.
+/// </summary>
+public class SettingsSchemaTests
+{
+    /// <summary>
+    /// Every public property of the class is described. A setting that escapes the schema
+    /// is a setting the secret filter and the resolution engine cannot see.
+    /// </summary>
+    [Fact]
+    public void EverySettingIsDescribed()
+    {
+        var declared = typeof(Settings)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .OrderBy(n => n, System.StringComparer.Ordinal)
+            .ToArray();
+
+        var described = SettingsSchema.Descriptors
+            .Select(d => d.Property.Name)
+            .OrderBy(n => n, System.StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(declared, described);
+    }
+
+    /// <summary>
+    /// The Seerr admin key is the only credential in the settings today. This pins the set:
+    /// adding another one has to be a decision rather than an accident, because P1.4 filters
+    /// exactly what is listed here out of the response served to a non administrator.
+    /// </summary>
+    [Fact]
+    public void TheSeerrAdminKeyIsTheOnlySecret()
+    {
+        Assert.Equal(
+            new[] { "jellyseerrApiKey" },
+            SettingsSchema.Secrets.Select(s => s.Key).ToArray());
+    }
+
+    /// <summary>
+    /// The server URL sitting next to the key is not a credential. Marking it would hide a
+    /// setting an admin has to be able to read back.
+    /// </summary>
+    [Fact]
+    public void TheServerUrlIsNotSecret()
+    {
+        Assert.False(SettingsSchema.IsSecret("jellyseerrServerUrl"));
+    }
+
+    /// <summary>
+    /// A key nothing declares is not a setting, rather than a setting with no marker.
+    /// </summary>
+    [Fact]
+    public void AnUnknownKeyHasNoDescriptor()
+    {
+        Assert.Null(SettingsSchema.Find("thereIsNoSuchSetting"));
+        Assert.False(SettingsSchema.IsSecret("thereIsNoSuchSetting"));
+    }
+
+    /// <summary>
+    /// The value type is the one inside <c>Lockable</c>, not <c>Lockable</c> itself. Everything
+    /// that has to reason about what a setting holds reads this.
+    /// </summary>
+    [Theory]
+    [InlineData("subtitleSize", typeof(int))]
+    [InlineData("jellyseerrApiKey", typeof(string))]
+    [InlineData("hiddenLibraries", typeof(string[]))]
+    [InlineData("defaultVideoOrientation", typeof(OrientationLock))]
+    public void TheValueTypeIsUnwrapped(string key, System.Type expected)
+    {
+        var descriptor = SettingsSchema.Find(key);
+
+        Assert.NotNull(descriptor);
+        Assert.True(descriptor!.IsLockable);
+        Assert.Equal(expected, descriptor.ValueType);
+    }
+
+    /// <summary>
+    /// The label and the help text come from the property, so a form does not need a second
+    /// copy of them that then drifts.
+    /// </summary>
+    [Fact]
+    public void TheDescriptorCarriesTheLabel()
+    {
+        var descriptor = SettingsSchema.Find("jellyseerrApiKey");
+
+        Assert.NotNull(descriptor);
+        Assert.Equal("Jellyseerr API Key", descriptor!.DisplayName);
+        Assert.False(string.IsNullOrWhiteSpace(descriptor.Description));
+    }
+
+    /// <summary>
+    /// The generated schema says which fields are credentials, so a form can render a
+    /// password input. Without it a client has no way to tell the key from the URL next to it.
+    /// </summary>
+    [Fact]
+    public void TheGeneratedSchemaMarksTheSecret()
+    {
+        using var document = JsonDocument.Parse(SerializationHelper.GetJsonSchema<Config>());
+        var settings = document.RootElement
+            .GetProperty("definitions")
+            .GetProperty("Settings")
+            .GetProperty("properties");
+
+        Assert.True(settings.GetProperty("jellyseerrApiKey").GetProperty("x-secret").GetBoolean());
+        Assert.False(settings.GetProperty("jellyseerrServerUrl").TryGetProperty("x-secret", out _));
+    }
+
+    /// <summary>
+    /// The marker goes on the property and not on the shared definition the property points
+    /// at. <c>LockableOfString</c> is reached by the Seerr key and by three plain URLs, so
+    /// marking it there would turn every URL in the plugin into a secret.
+    /// </summary>
+    [Fact]
+    public void TheSharedLockableDefinitionIsNotMarked()
+    {
+        using var document = JsonDocument.Parse(SerializationHelper.GetJsonSchema<Config>());
+
+        var lockableOfString = document.RootElement
+            .GetProperty("definitions")
+            .GetProperty("LockableOfString");
+
+        Assert.False(lockableOfString.TryGetProperty("x-secret", out _));
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SecretAttribute.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SecretAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// Marks a setting whose value is a credential rather than a preference.
+/// </summary>
+/// <remarks>
+/// Secrecy is a property of the key, not of the value an admin happens to write,
+/// so it lives here rather than as a field on <see cref="Lockable{T}"/>. An admin
+/// cannot mark the Seerr admin key public, and a marked key costs nothing in the
+/// YAML.
+///
+/// Two things read this. The generated JSON schema carries it as <c>x-secret</c>,
+/// so a form renders the field as a password instead of plain text. P1.4 uses it
+/// to decide what leaves <c>GET /streamyfin/config</c> for a caller who is not an
+/// administrator, which is the finding at the top of
+/// <c>docs/rewrite/state-of-the-plugin.md</c>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+public sealed class SecretAttribute : Attribute
+{
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -298,6 +298,7 @@ public class Settings
 
     [NotNull]
     [Display(Name = "Jellyseerr API Key", Description = "Seerr admin API key (Seerr Settings > General). Lets Streamyfin sign each user in to Seerr without a password. **Warning: every authenticated Jellyfin user on this server can read this key and it grants full admin access to the Seerr API — only set it if you trust all of your users.** Requires a Seerr version with the /user/jellyfin/{id} route.")]
+    [Secret]
     public Lockable<string>? jellyseerrApiKey { get; set; }
 
     // Marlin Search

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsSchema.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsSchema.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// One setting, described rather than hard coded in the places that need it.
+/// </summary>
+/// <param name="Key">The key as it appears in the YAML and in the JSON payload.</param>
+/// <param name="Property">The property on <see cref="Settings"/> that holds it.</param>
+/// <param name="ValueType">The value's type, unwrapped from <see cref="Lockable{T}"/>.</param>
+/// <param name="IsLockable">Whether an admin can lock this setting against the user.</param>
+/// <param name="IsSecret">Whether the value is a credential. See <see cref="SecretAttribute"/>.</param>
+/// <param name="DisplayName">Label for a form, when the property carries one.</param>
+/// <param name="Description">Help text for a form, when the property carries one.</param>
+public sealed record SettingDescriptor(
+    string Key,
+    PropertyInfo Property,
+    Type ValueType,
+    bool IsLockable,
+    bool IsSecret,
+    string? DisplayName,
+    string? Description);
+
+/// <summary>
+/// The settings, as data.
+/// </summary>
+/// <remarks>
+/// <see cref="Settings"/> is a C# class, which is the right shape for an admin
+/// writing YAML and for the schema the form generates from. It is the wrong shape
+/// for anything that has to treat settings uniformly: filtering secrets out of a
+/// response, resolving a value across the server, group and user levels, or
+/// telling a client which keys exist.
+///
+/// This reads the class once and hands back a list. Anything that needs to walk
+/// the settings walks this rather than repeating a property list that then drifts
+/// the first time someone adds a key. <c>SettingsSchemaTests</c> is what keeps the
+/// two in step.
+/// </remarks>
+public static class SettingsSchema
+{
+    private static readonly List<SettingDescriptor> _descriptors = Describe();
+
+    private static readonly Dictionary<string, SettingDescriptor> _byKey =
+        _descriptors.ToDictionary(d => d.Key, StringComparer.Ordinal);
+
+    private static readonly List<SettingDescriptor> _secrets =
+        _descriptors.FindAll(d => d.IsSecret);
+
+    /// <summary>
+    /// Gets every setting, in the order the class declares them.
+    /// </summary>
+    public static IReadOnlyList<SettingDescriptor> Descriptors => _descriptors;
+
+    /// <summary>
+    /// Gets the settings whose values are credentials.
+    /// </summary>
+    public static IReadOnlyList<SettingDescriptor> Secrets => _secrets;
+
+    /// <summary>
+    /// Finds a setting by the key it carries in the YAML.
+    /// </summary>
+    /// <param name="key">The setting key.</param>
+    /// <returns>The descriptor, or null when no such setting exists.</returns>
+    public static SettingDescriptor? Find(string key) =>
+        key is not null && _byKey.TryGetValue(key, out var descriptor) ? descriptor : null;
+
+    /// <summary>
+    /// Whether a setting key holds a credential.
+    /// </summary>
+    /// <param name="key">The setting key.</param>
+    /// <returns>True when the key is marked secret.</returns>
+    public static bool IsSecret(string key) => Find(key)?.IsSecret == true;
+
+    private static List<SettingDescriptor> Describe()
+    {
+        return typeof(Settings)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetIndexParameters().Length == 0)
+            .Select(Describe)
+            .ToList();
+    }
+
+    private static SettingDescriptor Describe(PropertyInfo property)
+    {
+        var declared = property.PropertyType;
+        var underlying = Nullable.GetUnderlyingType(declared) ?? declared;
+
+        var lockable = underlying.IsGenericType
+                       && underlying.GetGenericTypeDefinition() == typeof(Lockable<>);
+
+        var valueType = lockable ? underlying.GetGenericArguments()[0] : underlying;
+        var display = property.GetCustomAttribute<DisplayAttribute>();
+
+        return new SettingDescriptor(
+            Key: property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name,
+            Property: property,
+            ValueType: valueType,
+            IsLockable: lockable,
+            IsSecret: property.GetCustomAttribute<SecretAttribute>() is not null,
+            DisplayName: display?.Name,
+            Description: display?.Description);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions.Json;
 using Jellyfin.Plugin.Streamyfin.Configuration;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
 using Newtonsoft.Json;
 using NJsonSchema;
 using NJsonSchema.Generation;
@@ -72,7 +73,49 @@ public class SerializationHelper
         settings.SerializerOptions.WriteIndented = true;
 #endif
         settings.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
-        return JsonSchemaGenerator.FromType<T>(settings).ToJson();
+
+        var schema = JsonSchemaGenerator.FromType<T>(settings);
+        MarkSecrets(schema);
+        return schema.ToJson();
+    }
+
+    /// <summary>
+    /// Flags the settings that hold a credential, as <c>x-secret</c>.
+    /// </summary>
+    /// <remarks>
+    /// A generated form has no other way to know that a field is a password rather
+    /// than a string. It goes on the property rather than on the shared
+    /// <c>LockableOfString</c> definition, which several plain URLs also point at.
+    /// The set comes from <see cref="SettingsSchema"/>, so marking a new key is one
+    /// attribute and nothing here changes.
+    /// </remarks>
+    private static void MarkSecrets(JsonSchema schema)
+    {
+        foreach (var candidate in SchemasCarryingSettings(schema))
+        {
+            foreach (var secret in SettingsSchema.Secrets)
+            {
+                if (!candidate.Properties.TryGetValue(secret.Key, out var property))
+                {
+                    continue;
+                }
+
+                property.ExtensionData ??= new Dictionary<string, object?>();
+                property.ExtensionData["x-secret"] = true;
+            }
+        }
+    }
+
+    private static IEnumerable<JsonSchema> SchemasCarryingSettings(JsonSchema schema)
+    {
+        // The root when the schema was generated from Settings itself, and the
+        // definition when it was generated from Config, which is the live case.
+        yield return schema;
+
+        if (schema.Definitions.TryGetValue(typeof(Configuration.Settings.Settings).Name, out var settings))
+        {
+            yield return settings;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #114. Covers **P1.1**.

P1 is the core of the rewrite and everything after it depends on the shape settled here. This is the first piece, and it deliberately changes nothing on the wire.

## The problem it solves

`Settings.cs` is a C# class with forty one properties. That is the right shape for an admin writing YAML and for the JSON schema the admin form generates from. It is the wrong shape for anything that has to treat settings uniformly, and the three parts after this one all do:

- **P1.3** resolves a value across the server, group and user levels.
- **P1.4** decides what leaves `GET /streamyfin/config` for a caller who is not an administrator.
- **P3.1** renders a form from the list of keys.

Without a description of the settings, each of those keeps its own property list, and the first one to drift is the one that leaks a key nobody remembered to add.

## What lands

`SettingsSchema` reads the class once and hands back a `SettingDescriptor` per key:

```csharp
public sealed record SettingDescriptor(
    string Key,
    PropertyInfo Property,
    Type ValueType,      // unwrapped from Lockable<T>
    bool IsLockable,
    bool IsSecret,
    string? DisplayName,
    string? Description);
```

`Find(key)`, `IsSecret(key)` and `Secrets` on top of it. The labels come from the `[Display]` attributes the properties already carry, so a form does not need a second copy of them.

## Why secrecy is an attribute

Secrecy belongs to the key, not to the value an admin happens to write, so it is `[Secret]` on the property rather than a third field on `Lockable<T>`. Two consequences worth stating:

- An admin cannot mark the Seerr admin key public by editing their YAML.
- A marked key costs nothing in the file, and the format every existing installation writes is unchanged.

`jellyseerrApiKey` is the only one today. A test pins that set, so adding another one is a decision rather than an accident, since P1.4 will filter exactly what is listed there.

## The schema marker, and the trap next to it

`GET /streamyfin/config/schema` now carries `x-secret` on the property:

```json
"jellyseerrApiKey": {
  "title": "Jellyseerr API Key",
  "oneOf": [{ "$ref": "#/definitions/LockableOfString" }],
  "x-secret": true
}
```

A client has no other way to tell a password field from the string next to it.

It goes on the **property**, not on the `LockableOfString` definition it points at. That definition is reached by the Seerr key and by `jellyseerrServerUrl`, `marlinServerUrl` and `streamyStatsServerUrl`, so marking it there would turn every URL in the plugin into a secret. There is a test asserting the definition stays unmarked, because that is the mistake this design exists to avoid.

## What does not change

The config endpoint still serves the whole configuration, key included, to every authenticated account. That is finding 1 in `docs/rewrite/state-of-the-plugin.md` and it is **P1.4**, not this pull request. Filtering the key out today would break Seerr for every non admin user, because the app reads that key to sign users in. The app has to move to authenticating with the user's own Jellyfin token first, which is `seerr#2244` and is tracked in `docs/rewrite/app-side-work.md`.

## Testing

`dotnet test` on both targets: **48 passed, 0 failed** on `jf11` and on `jf12`. Build clean, 0 warnings and 0 errors on both.

Eleven new tests, including the two that keep this honest: every public property of `Settings` is described, so a setting cannot escape the catalogue, and the secret set is exactly `jellyseerrApiKey`.

Verified on a real server rather than only in tests: a `jellyfin/jellyfin:10.11.11` running this build serves a schema that marks `jellyseerrApiKey`, leaves `jellyseerrServerUrl` unmarked, and leaves `LockableOfString` alone.
