### PR TITLE
feat(settings): group and per user targeting, and the engine that resolves them

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsGroupTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsGroupTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.Streamyfin.Configuration;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Storing the targeting levels, and reading them back through the resolution
+/// service, which is where the stored JSON meets the rule.
+/// </summary>
+public class SettingsGroupTests : IDisposable
+{
+    private readonly string _directory;
+    private readonly PluginDatabase _db;
+    private readonly SerializationHelper _serialization = new();
+    private readonly SettingsResolutionService _resolution;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SettingsGroupTests"/> class.
+    /// </summary>
+    public SettingsGroupTests()
+    {
+        _directory = TestDirectory.Create();
+        _db = new PluginDatabase(_directory);
+        _resolution = new SettingsResolutionService(_serialization);
+    }
+
+    /// <summary>
+    /// A group round trips, including the settings it carries.
+    /// </summary>
+    [Fact]
+    public void AGroupRoundTrips()
+    {
+        var saved = _db.SaveSettingsGroup(new SettingsGroup
+        {
+            Name = "Kids",
+            Priority = 5,
+            SettingsJson = _serialization.SerializeToJson(new Settings
+            {
+                subtitleSize = new Lockable<int> { locked = true, value = 120 }
+            })
+        });
+
+        Assert.NotEqual(Guid.Empty, saved.Id);
+
+        var read = _db.GetSettingsGroup(saved.Id);
+
+        Assert.NotNull(read);
+        Assert.Equal("Kids", read!.Name);
+        Assert.Equal(5, read.Priority);
+
+        var settings = _serialization.DeserializeJson<Settings>(read.SettingsJson);
+        Assert.Equal(120, settings?.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// Saving with an id updates in place rather than adding a second group.
+    /// </summary>
+    [Fact]
+    public void SavingAnExistingGroupUpdatesIt()
+    {
+        var saved = _db.SaveSettingsGroup(new SettingsGroup { Name = "Kids", Priority = 1 });
+
+        _db.SaveSettingsGroup(new SettingsGroup { Id = saved.Id, Name = "Children", Priority = 2 });
+
+        Assert.Single(_db.GetSettingsGroups());
+        Assert.Equal("Children", _db.GetSettingsGroup(saved.Id)?.Name);
+    }
+
+    /// <summary>
+    /// Deleting a group takes its memberships with it, in one transaction. Rows left
+    /// behind would resolve to nothing and would come back if the id were reused.
+    /// </summary>
+    [Fact]
+    public void DeletingAGroupTakesItsMembershipsWithIt()
+    {
+        var userId = Guid.NewGuid();
+        var group = _db.SaveSettingsGroup(new SettingsGroup { Name = "Kids" });
+        _db.SetGroupMembers(group.Id, [userId]);
+
+        _db.RemoveSettingsGroup(group.Id);
+
+        Assert.Empty(_db.GetSettingsGroups());
+        Assert.Empty(_db.GetGroupsForUser(userId));
+        Assert.Empty(_db.GetGroupMembers(group.Id));
+    }
+
+    /// <summary>
+    /// Setting the members replaces them, and the same user added twice is one row.
+    /// </summary>
+    [Fact]
+    public void SettingMembersReplacesThemAndDeduplicates()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        var group = _db.SaveSettingsGroup(new SettingsGroup { Name = "Kids" });
+
+        _db.SetGroupMembers(group.Id, [alice, alice, bob]);
+        Assert.Equal(2, _db.GetGroupMembers(group.Id).Count);
+
+        _db.SetGroupMembers(group.Id, [bob]);
+        Assert.Equal([bob], _db.GetGroupMembers(group.Id));
+    }
+
+    /// <summary>
+    /// A user's groups come back in layer order, lowest priority first.
+    /// </summary>
+    [Fact]
+    public void AUsersGroupsComeBackInLayerOrder()
+    {
+        var userId = Guid.NewGuid();
+        var low = _db.SaveSettingsGroup(new SettingsGroup { Name = "Everyone", Priority = 1 });
+        var high = _db.SaveSettingsGroup(new SettingsGroup { Name = "Staff", Priority = 10 });
+
+        _db.SetGroupMembers(low.Id, [userId]);
+        _db.SetGroupMembers(high.Id, [userId]);
+
+        var groups = _db.GetGroupsForUser(userId);
+
+        Assert.Equal(["Everyone", "Staff"], groups.Select(g => g.Name));
+    }
+
+    /// <summary>
+    /// The three levels resolve through the service the way they resolve in the rule.
+    /// </summary>
+    [Fact]
+    public void TheThreeLevelsResolveEndToEnd()
+    {
+        var userId = Guid.NewGuid();
+
+        var group = _db.SaveSettingsGroup(new SettingsGroup
+        {
+            Name = "Staff",
+            Priority = 1,
+            SettingsJson = _serialization.SerializeToJson(new Settings
+            {
+                subtitleSize = new Lockable<int> { locked = false, value = 60 }
+            })
+        });
+        _db.SetGroupMembers(group.Id, [userId]);
+
+        _db.SaveUserSettingsOverride(userId, _serialization.SerializeToJson(new Settings
+        {
+            forwardSkipTime = new Lockable<int> { locked = true, value = 5 }
+        }));
+
+        var global = new Settings
+        {
+            subtitleSize = new Lockable<int> { locked = true, value = 80 },
+            forwardSkipTime = new Lockable<int> { locked = false, value = 30 },
+            rewindSkipTime = new Lockable<int> { locked = false, value = 10 }
+        };
+
+        var resolved = _resolution.Resolve(
+            global,
+            _db.GetGroupsForUser(userId),
+            _db.GetUserSettingsOverride(userId));
+
+        // The group unlocked and shrank the subtitles.
+        Assert.Equal(60, resolved.subtitleSize?.value);
+        Assert.False(resolved.subtitleSize?.locked);
+
+        // The user level locked the skip time.
+        Assert.Equal(5, resolved.forwardSkipTime?.value);
+        Assert.True(resolved.forwardSkipTime?.locked);
+
+        // Nobody spoke about the rewind, so the server's value stands.
+        Assert.Equal(10, resolved.rewindSkipTime?.value);
+    }
+
+    /// <summary>
+    /// A level whose JSON cannot be read costs that level, not every setting for
+    /// every user in it. This runs during a request, so throwing would turn one
+    /// corrupted row into a broken settings endpoint.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableLevelIsSkippedRatherThanThrown()
+    {
+        var userId = Guid.NewGuid();
+        var group = _db.SaveSettingsGroup(new SettingsGroup
+        {
+            Name = "Broken",
+            SettingsJson = "{ this is not json"
+        });
+        _db.SetGroupMembers(group.Id, [userId]);
+
+        var resolved = _resolution.Resolve(
+            new Settings { subtitleSize = new Lockable<int> { locked = true, value = 80 } },
+            _db.GetGroupsForUser(userId),
+            null);
+
+        Assert.Equal(80, resolved.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// The settings served as numbers survive being stored and read back. The plugin
+    /// writes <c>OrientationLock</c>, <c>Bitrate</c> and <c>SubtitlePlaybackMode</c> as
+    /// numbers, and the YAML reader the rest of the plugin uses expects the member
+    /// name, so a level stored as JSON has to come back through the JSON reader.
+    /// </summary>
+    [Fact]
+    public void TheNumericEnumSettingsSurviveTheRoundTrip()
+    {
+        var stored = _serialization.SerializeToJson(new Settings
+        {
+            defaultVideoOrientation = new Lockable<OrientationLock> { locked = true, value = OrientationLock.Landscape },
+            subtitleMode = new Lockable<SubtitlePlaybackMode> { locked = false, value = SubtitlePlaybackMode.Smart }
+        });
+
+        var read = _serialization.DeserializeJson<Settings>(stored);
+
+        Assert.Equal(OrientationLock.Landscape, read?.defaultVideoOrientation?.value);
+        Assert.Equal(SubtitlePlaybackMode.Smart, read?.subtitleMode?.value);
+    }
+
+    /// <summary>
+    /// Clearing a user's override leaves them on their groups.
+    /// </summary>
+    [Fact]
+    public void ClearingAUserOverrideLeavesTheirGroups()
+    {
+        var userId = Guid.NewGuid();
+        _db.SaveUserSettingsOverride(userId, "{}");
+
+        _db.RemoveUserSettingsOverride(userId);
+
+        Assert.Null(_db.GetUserSettingsOverride(userId));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        TestDirectory.Delete(_directory);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsGroupTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsGroupTests.cs
@@ -219,17 +219,56 @@ public class SettingsGroupTests : IDisposable
     }
 
     /// <summary>
-    /// Clearing a user's override leaves them on their groups.
+    /// Clearing a user's override leaves them on their groups. The two levels are
+    /// stored apart and have to stay apart: taking a targeted setting back from
+    /// someone should not quietly drop them out of every group they are in.
     /// </summary>
     [Fact]
     public void ClearingAUserOverrideLeavesTheirGroups()
     {
         var userId = Guid.NewGuid();
+        var group = _db.SaveSettingsGroup(new SettingsGroup { Name = "Staff" });
+        _db.SetGroupMembers(group.Id, [userId]);
         _db.SaveUserSettingsOverride(userId, "{}");
 
         _db.RemoveUserSettingsOverride(userId);
 
         Assert.Null(_db.GetUserSettingsOverride(userId));
+        Assert.Equal(["Staff"], _db.GetGroupsForUser(userId).Select(g => g.Name));
+    }
+
+    /// <summary>
+    /// A stored level that cannot be read comes back as nothing rather than throwing,
+    /// on every path that reads one.
+    /// </summary>
+    /// <remarks>
+    /// Nothing validates the JSON on the way in, so a row edited outside the plugin
+    /// or a partial write can leave one that does not parse. Resolution skipping it
+    /// is not enough on its own: the administration API reads the same rows to list
+    /// the groups, and throwing there would make <c>GET groups</c> fail as a whole,
+    /// so an administrator could no longer see the group in order to repair it.
+    /// </remarks>
+    [Theory]
+    [InlineData("{ this is not json")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnUnreadableLevelReadsAsNothing(string stored)
+    {
+        Assert.Null(_resolution.ReadLevel(stored, "a test"));
+    }
+
+    /// <summary>
+    /// A readable level still comes back through the same call.
+    /// </summary>
+    [Fact]
+    public void AReadableLevelComesBack()
+    {
+        var stored = _serialization.SerializeToJson(new Settings
+        {
+            subtitleSize = new Lockable<int> { locked = true, value = 42 }
+        });
+
+        Assert.Equal(42, _resolution.ReadLevel(stored, "a test")?.subtitleSize?.value);
     }
 
     /// <inheritdoc/>

--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsResolverTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsResolverTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Precedence across the three targeting levels: what the server declares for
+/// everyone, the groups an administrator defines, and anything aimed at one user.
+///
+/// The rule is that the most specific level which says something about a key wins,
+/// and that includes the lock. Not "the most restrictive lock wins": the shape the
+/// maintainers proposed in issue #29 has an override setting <c>lock: false</c> to
+/// hand a setting back to named users, and a resolver that could only tighten would
+/// make that impossible.
+/// </summary>
+public class SettingsResolverTests
+{
+    private static Settings Locked(int size) => new()
+    {
+        subtitleSize = new Lockable<int> { locked = true, value = size }
+    };
+
+    private static Settings Free(int size) => new()
+    {
+        subtitleSize = new Lockable<int> { locked = false, value = size }
+    };
+
+    /// <summary>
+    /// A key only the server sets comes through untouched.
+    /// </summary>
+    [Fact]
+    public void TheServerLevelAppliesWhenNothingElseSpeaks()
+    {
+        var resolved = SettingsResolver.Resolve(Locked(80), null, null);
+
+        Assert.Equal(80, resolved.subtitleSize?.value);
+        Assert.True(resolved.subtitleSize?.locked);
+    }
+
+    /// <summary>
+    /// A group beats the server.
+    /// </summary>
+    [Fact]
+    public void AGroupBeatsTheServer()
+    {
+        var resolved = SettingsResolver.Resolve(Locked(80), Locked(60));
+
+        Assert.Equal(60, resolved.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// A user beats a group, which beats the server.
+    /// </summary>
+    [Fact]
+    public void TheUserLevelBeatsEverything()
+    {
+        var resolved = SettingsResolver.Resolve(Locked(80), Locked(60), Locked(40));
+
+        Assert.Equal(40, resolved.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// A more specific level can unlock what the server locked. This is the case from
+    /// issue #29 and the reason precedence is by specificity rather than by
+    /// restrictiveness.
+    /// </summary>
+    [Fact]
+    public void AMoreSpecificLevelCanUnlock()
+    {
+        var resolved = SettingsResolver.Resolve(Locked(80), Free(80));
+
+        Assert.False(resolved.subtitleSize?.locked);
+        Assert.Equal(80, resolved.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// Levels are merged per key, not wholesale. A group that speaks about one setting
+    /// does not silently drop the forty others the server declared.
+    /// </summary>
+    [Fact]
+    public void LevelsMergePerKeyRatherThanReplacing()
+    {
+        var global = new Settings
+        {
+            subtitleSize = new Lockable<int> { locked = true, value = 80 },
+            forwardSkipTime = new Lockable<int> { locked = false, value = 30 }
+        };
+
+        var group = new Settings
+        {
+            subtitleSize = new Lockable<int> { locked = false, value = 60 }
+        };
+
+        var resolved = SettingsResolver.Resolve(global, group);
+
+        Assert.Equal(60, resolved.subtitleSize?.value);
+        Assert.Equal(30, resolved.forwardSkipTime?.value);
+    }
+
+    /// <summary>
+    /// A key nobody sets stays unset, which the client reads as the server having no
+    /// opinion. Filling it with a default here would take the choice away from the
+    /// user without anyone deciding to.
+    /// </summary>
+    [Fact]
+    public void AKeyNobodySetsStaysUnset()
+    {
+        var resolved = SettingsResolver.Resolve(Locked(80));
+
+        Assert.Null(resolved.rewindSkipTime);
+    }
+
+    /// <summary>
+    /// Absent levels are skipped rather than treated as empty ones that clear
+    /// everything above them.
+    /// </summary>
+    [Fact]
+    public void NullLevelsAreSkipped()
+    {
+        var resolved = SettingsResolver.Resolve(null, Locked(60), null);
+
+        Assert.Equal(60, resolved.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// Resolving nothing is an empty set rather than a crash.
+    /// </summary>
+    [Fact]
+    public void ResolvingNothingGivesAnEmptySet()
+    {
+        var resolved = SettingsResolver.Resolve();
+
+        Assert.All(
+            SettingsSchema.Descriptors,
+            d => Assert.Null(d.Property.GetValue(resolved)));
+    }
+
+    /// <summary>
+    /// The result is a new object. Resolving must not write into the plugin's live
+    /// configuration, which is a singleton every request shares.
+    /// </summary>
+    [Fact]
+    public void ResolvingDoesNotMutateTheLevels()
+    {
+        var global = Locked(80);
+
+        var resolved = SettingsResolver.Resolve(global, Locked(60));
+
+        Assert.Equal(80, global.subtitleSize?.value);
+        Assert.NotSame(global, resolved);
+    }
+
+    /// <summary>
+    /// A higher priority is layered later, so it wins.
+    /// </summary>
+    [Fact]
+    public void AHigherPriorityGroupWins()
+    {
+        var groups = new[]
+        {
+            new SettingsGroup { Id = Guid.NewGuid(), Name = "b", Priority = 10 },
+            new SettingsGroup { Id = Guid.NewGuid(), Name = "a", Priority = 1 }
+        };
+
+        var ordered = SettingsResolver.InLayerOrder(groups);
+
+        Assert.Equal("a", ordered[0].Name);
+        Assert.Equal("b", ordered[1].Name);
+    }
+
+    /// <summary>
+    /// Groups sharing a priority are ordered by id. Arbitrary, but the same caller in
+    /// the same groups has to resolve to the same answer every time rather than to
+    /// whatever the database returned first.
+    /// </summary>
+    [Fact]
+    public void GroupsOnTheSamePriorityAreOrderedStably()
+    {
+        var first = new SettingsGroup { Id = new Guid("00000000-0000-0000-0000-000000000001"), Name = "one" };
+        var second = new SettingsGroup { Id = new Guid("00000000-0000-0000-0000-000000000002"), Name = "two" };
+
+        var oneWay = SettingsResolver.InLayerOrder(new[] { second, first }).Select(g => g.Name);
+        var other = SettingsResolver.InLayerOrder(new[] { first, second }).Select(g => g.Name);
+
+        Assert.Equal(oneWay, other);
+        Assert.Equal("one", oneWay.First());
+    }
+
+    /// <summary>
+    /// Redacting drops the credentials and leaves everything else alone. The key is
+    /// absent rather than blanked, so a client cannot tell an administrator who
+    /// cleared the field from a user who may not see it, and cannot push an empty
+    /// string back as though it were the real value.
+    /// </summary>
+    [Fact]
+    public void RedactingRemovesOnlyTheSecrets()
+    {
+        var settings = new Settings
+        {
+            jellyseerrApiKey = new Lockable<string> { locked = true, value = "a-real-key" },
+            jellyseerrServerUrl = new Lockable<string> { locked = true, value = "https://seerr.example" },
+            subtitleSize = new Lockable<int> { locked = false, value = 80 }
+        };
+
+        var redacted = SettingsResolver.Redact(settings);
+
+        Assert.Null(redacted.jellyseerrApiKey);
+        Assert.Equal("https://seerr.example", redacted.jellyseerrServerUrl?.value);
+        Assert.Equal(80, redacted.subtitleSize?.value);
+        Assert.Equal("a-real-key", settings.jellyseerrApiKey?.value);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Api/SettingsGroupModels.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/SettingsGroupModels.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Streamyfin.Api;
+
+/// <summary>
+/// A settings group, as the API returns it.
+/// </summary>
+/// <remarks>
+/// Separate from the stored entity because the stored one keeps its settings as a
+/// JSON string, and an administrator's client should receive settings rather than a
+/// string containing settings.
+/// </remarks>
+public class SettingsGroupDto
+{
+    /// <summary>
+    /// Gets or sets the group id. Absent when creating.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets which group wins when a user is in more than one. Higher wins.
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public int Priority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings this group overrides. Only the keys it means to
+    /// change need to be present.
+    /// </summary>
+    [JsonPropertyName("settings")]
+    public Configuration.Settings.Settings? Settings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Jellyfin users in the group.
+    /// </summary>
+    [JsonPropertyName("userIds")]
+    public List<Guid> UserIds { get; set; } = [];
+}
+
+/// <summary>
+/// The settings an administrator targets at one user.
+/// </summary>
+public class UserSettingsOverrideDto
+{
+    /// <summary>
+    /// Gets or sets the settings. Only the keys being overridden need to be present.
+    /// </summary>
+    [JsonPropertyName("settings")]
+    public Configuration.Settings.Settings? Settings { get; set; }
+}
+
+/// <summary>
+/// Who is in a group.
+/// </summary>
+public class SettingsGroupMembersDto
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin users who should be in it afterwards.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("userIds")]
+    public List<Guid> UserIds { get; set; } = [];
+}

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -494,14 +494,15 @@ public class StreamyfinController : ControllerBase
     return new JsonStringResult(_serializationHelperService.SerializeToJson(resolved));
   }
 
+  // Through the same tolerant read the resolution uses. Nothing validates the JSON
+  // on the way in, and a group whose settings cannot be read has to still appear in
+  // the list, or an administrator cannot see it to repair it.
   private SettingsGroupDto ToDto(SettingsGroup group, List<Guid> members) => new()
   {
     Id = group.Id,
     Name = group.Name,
     Priority = group.Priority,
-    Settings = string.IsNullOrWhiteSpace(group.SettingsJson)
-      ? null
-      : _serializationHelperService.DeserializeJson<Configuration.Settings.Settings>(group.SettingsJson),
+    Settings = Resolution.ReadLevel(group.SettingsJson, $"group {group.Name}"),
     UserIds = members
   };
 

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -284,9 +284,17 @@ public class StreamyfinController : ControllerBase
   // resolved set.
 
   private const string UserIdClaim = "Jellyfin-UserId";
+  private const string IsApiKeyClaim = "Jellyfin-IsApiKey";
 
   private Guid CallerId =>
     Guid.TryParse(User?.FindFirst(UserIdClaim)?.Value, out var id) ? id : Guid.Empty;
+
+  // An API key is granted by an administrator and carries no user, which is why
+  // Jellyfin's own RequiresElevation accepts one. Treated the same here, or the
+  // routes an admin can call with their account would answer differently to the
+  // key they created for a script.
+  private bool CallerIsApiKey =>
+    bool.TryParse(User?.FindFirst(IsApiKeyClaim)?.Value, out var isApiKey) && isApiKey;
 
   private SettingsResolutionService Resolution =>
     new(_serializationHelperService, _loggerFactory.CreateLogger<SettingsResolutionService>());
@@ -472,6 +480,13 @@ public class StreamyfinController : ControllerBase
   /// P1.4, which is about retiring the behaviour of <c>GET config</c> and dealing
   /// with what the app does about it. It is this route not being a second way to
   /// read the Seerr key.
+  ///
+  /// <para>
+  /// A caller authenticating with an API key has no user, so there is nothing to
+  /// resolve beyond what the server declares for everyone. The key is granted by an
+  /// administrator, and Jellyfin's own elevation policy accepts one, so it is treated
+  /// as elevated here too rather than as an anonymous caller.
+  /// </para>
   /// </remarks>
   [HttpGet("config/resolved")]
   [Authorize]
@@ -486,7 +501,7 @@ public class StreamyfinController : ControllerBase
       database.GetGroupsForUser(callerId),
       database.GetUserSettingsOverride(callerId));
 
-    if (!_userManager.IsAdministrator(callerId))
+    if (!CallerIsApiKey && !_userManager.IsAdministrator(callerId))
     {
       resolved = SettingsResolver.Redact(resolved);
     }

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Jellyfin.Plugin.Streamyfin.Configuration;
 using Jellyfin.Plugin.Streamyfin.Extensions;
 using Jellyfin.Plugin.Streamyfin.PushNotifications;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
 using Jellyfin.Plugin.Streamyfin.Db;
 using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
 using MediaBrowser.Common.Api;
@@ -274,4 +275,235 @@ public class StreamyfinController : ControllerBase
     task.Wait();
     return new JsonResult(_serializationHelperService.ToJson(task.Result));
   }
+
+  // region Settings groups
+  //
+  // The three targeting levels of P1: what the server declares for everyone, the
+  // groups an administrator defines, and anything aimed at one user. Everything
+  // that writes is elevation only. The one route that reads is the caller's own
+  // resolved set.
+
+  private const string UserIdClaim = "Jellyfin-UserId";
+
+  private Guid CallerId =>
+    Guid.TryParse(User?.FindFirst(UserIdClaim)?.Value, out var id) ? id : Guid.Empty;
+
+  private SettingsResolutionService Resolution =>
+    new(_serializationHelperService, _loggerFactory.CreateLogger<SettingsResolutionService>());
+
+  /// <summary>
+  /// Lists the settings groups.
+  /// </summary>
+  /// <returns>The groups, least specific first, each with its members.</returns>
+  [HttpGet("groups")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  public ActionResult<List<SettingsGroupDto>> GetSettingsGroups()
+  {
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    return database.GetSettingsGroups()
+      .Select(group => ToDto(group, database.GetGroupMembers(group.Id)))
+      .ToList();
+  }
+
+  /// <summary>
+  /// Creates a settings group.
+  /// </summary>
+  /// <param name="request">The group to create. Its id is ignored.</param>
+  /// <returns>The created group.</returns>
+  [HttpPost("groups")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status400BadRequest)]
+  public ActionResult<SettingsGroupDto> CreateSettingsGroup([FromBody, Required] SettingsGroupDto request)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+
+    if (string.IsNullOrWhiteSpace(request.Name))
+    {
+      return BadRequest("A group needs a name");
+    }
+
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    var stored = database.SaveSettingsGroup(new SettingsGroup
+    {
+      Id = Guid.Empty,
+      Name = request.Name,
+      Priority = request.Priority,
+      SettingsJson = _serializationHelperService.SerializeToJson(request.Settings ?? new Configuration.Settings.Settings())
+    });
+
+    database.SetGroupMembers(stored.Id, request.UserIds);
+
+    return ToDto(stored, database.GetGroupMembers(stored.Id));
+  }
+
+  /// <summary>
+  /// Updates a settings group.
+  /// </summary>
+  /// <param name="id">The group id.</param>
+  /// <param name="request">What it should become. Members are left alone.</param>
+  /// <returns>The updated group.</returns>
+  [HttpPut("groups/{id}")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public ActionResult<SettingsGroupDto> UpdateSettingsGroup(
+    [FromRoute, Required] Guid id,
+    [FromBody, Required] SettingsGroupDto request)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+
+    if (string.IsNullOrWhiteSpace(request.Name))
+    {
+      return BadRequest("A group needs a name");
+    }
+
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    if (database.GetSettingsGroup(id) is null)
+    {
+      return NotFound();
+    }
+
+    var stored = database.SaveSettingsGroup(new SettingsGroup
+    {
+      Id = id,
+      Name = request.Name,
+      Priority = request.Priority,
+      SettingsJson = _serializationHelperService.SerializeToJson(request.Settings ?? new Configuration.Settings.Settings())
+    });
+
+    return ToDto(stored, database.GetGroupMembers(id));
+  }
+
+  /// <summary>
+  /// Deletes a settings group and everyone's membership of it.
+  /// </summary>
+  /// <param name="id">The group id.</param>
+  /// <returns>No content.</returns>
+  [HttpDelete("groups/{id}")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status204NoContent)]
+  public ActionResult DeleteSettingsGroup([FromRoute, Required] Guid id)
+  {
+    StreamyfinPlugin.Instance!.Database.RemoveSettingsGroup(id);
+    return NoContent();
+  }
+
+  /// <summary>
+  /// Replaces the membership of a group.
+  /// </summary>
+  /// <param name="id">The group id.</param>
+  /// <param name="request">Who should be in it afterwards.</param>
+  /// <returns>The group, with its new members.</returns>
+  [HttpPut("groups/{id}/members")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public ActionResult<SettingsGroupDto> SetSettingsGroupMembers(
+    [FromRoute, Required] Guid id,
+    [FromBody, Required] SettingsGroupMembersDto request)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+
+    var database = StreamyfinPlugin.Instance!.Database;
+    var group = database.GetSettingsGroup(id);
+
+    if (group is null)
+    {
+      return NotFound();
+    }
+
+    database.SetGroupMembers(id, request.UserIds);
+    return ToDto(group, database.GetGroupMembers(id));
+  }
+
+  /// <summary>
+  /// Sets the settings targeted at one user.
+  /// </summary>
+  /// <param name="userId">The Jellyfin user id.</param>
+  /// <param name="request">The settings. Send an empty body to clear them.</param>
+  /// <returns>No content.</returns>
+  [HttpPut("users/{userId}/settings")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status204NoContent)]
+  public ActionResult SetUserSettingsOverride(
+    [FromRoute, Required] Guid userId,
+    [FromBody, Required] UserSettingsOverrideDto request)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    if (request.Settings is null)
+    {
+      database.RemoveUserSettingsOverride(userId);
+      return NoContent();
+    }
+
+    database.SaveUserSettingsOverride(userId, _serializationHelperService.SerializeToJson(request.Settings));
+    return NoContent();
+  }
+
+  /// <summary>
+  /// Clears the settings targeted at one user.
+  /// </summary>
+  /// <param name="userId">The Jellyfin user id.</param>
+  /// <returns>No content.</returns>
+  [HttpDelete("users/{userId}/settings")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status204NoContent)]
+  public ActionResult ClearUserSettingsOverride([FromRoute, Required] Guid userId)
+  {
+    StreamyfinPlugin.Instance!.Database.RemoveUserSettingsOverride(userId);
+    return NoContent();
+  }
+
+  /// <summary>
+  /// The settings the calling user actually gets, with the three levels resolved.
+  /// </summary>
+  /// <returns>The resolved settings.</returns>
+  /// <remarks>
+  /// Credentials are stripped unless the caller administers the server. That is not
+  /// P1.4, which is about retiring the behaviour of <c>GET config</c> and dealing
+  /// with what the app does about it. It is this route not being a second way to
+  /// read the Seerr key.
+  /// </remarks>
+  [HttpGet("config/resolved")]
+  [Authorize]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  public ActionResult GetResolvedSettings()
+  {
+    var callerId = CallerId;
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    var resolved = Resolution.Resolve(
+      StreamyfinPlugin.Instance!.Configuration.Config?.settings,
+      database.GetGroupsForUser(callerId),
+      database.GetUserSettingsOverride(callerId));
+
+    if (!_userManager.IsAdministrator(callerId))
+    {
+      resolved = SettingsResolver.Redact(resolved);
+    }
+
+    return new JsonStringResult(_serializationHelperService.SerializeToJson(resolved));
+  }
+
+  private SettingsGroupDto ToDto(SettingsGroup group, List<Guid> members) => new()
+  {
+    Id = group.Id,
+    Name = group.Name,
+    Priority = group.Priority,
+    Settings = string.IsNullOrWhiteSpace(group.SettingsJson)
+      ? null
+      : _serializationHelperService.DeserializeJson<Configuration.Settings.Settings>(group.SettingsJson),
+    UserIds = members
+  };
+
+  // endregion Settings groups
 }

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
@@ -43,18 +43,33 @@ public sealed class SettingsResolutionService(
 
         foreach (var group in SettingsResolver.InLayerOrder(groups ?? []))
         {
-            levels.Add(Read(group.SettingsJson, $"group {group.Name}"));
+            levels.Add(ReadLevel(group.SettingsJson, $"group {group.Name}"));
         }
 
         if (userOverride is not null)
         {
-            levels.Add(Read(userOverride.SettingsJson, $"user {userOverride.UserId}"));
+            levels.Add(ReadLevel(userOverride.SettingsJson, $"user {userOverride.UserId}"));
         }
 
         return SettingsResolver.Resolve([.. levels]);
     }
 
-    private Settings? Read(string json, string what)
+    /// <summary>
+    /// Reads one stored level, tolerating a level that cannot be read.
+    /// </summary>
+    /// <param name="json">The stored JSON.</param>
+    /// <param name="what">What it belongs to, for the log line.</param>
+    /// <returns>The settings, or <c>null</c> when there are none or they are unreadable.</returns>
+    /// <remarks>
+    /// Every path that reads a stored level goes through here, resolution and the
+    /// administration API alike. Nothing validates the JSON on the way in, so a row
+    /// edited outside the plugin, or a partial write, can leave one that does not
+    /// parse. Throwing would cost far more than the level itself: on the resolution
+    /// path it would break the settings endpoint for everyone in the group, and on
+    /// the administration path it would make <c>GET groups</c> fail as a whole, so an
+    /// administrator could no longer list or repair the group that caused it.
+    /// </remarks>
+    public Settings? ReadLevel(string? json, string what)
     {
         if (string.IsNullOrWhiteSpace(json))
         {

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// Turns what is stored into the settings one caller actually receives.
+/// </summary>
+/// <remarks>
+/// <see cref="SettingsResolver"/> is the rule and knows nothing about storage. This
+/// reads the stored levels, which are JSON, and hands them to it in order.
+///
+/// <para>
+/// A level that cannot be read is skipped with a warning rather than thrown. A group
+/// whose JSON someone corrupted should cost that group's overrides, not every
+/// setting for every user in it.
+/// </para>
+/// </remarks>
+/// <param name="serialization">The plugin's serializer.</param>
+/// <param name="logger">Optional logger.</param>
+public sealed class SettingsResolutionService(
+    SerializationHelper serialization,
+    ILogger<SettingsResolutionService>? logger = null)
+{
+    private readonly SerializationHelper _serialization = serialization;
+    private readonly ILogger<SettingsResolutionService>? _logger = logger;
+
+    /// <summary>
+    /// Resolves the three levels for one caller.
+    /// </summary>
+    /// <param name="global">What the server declares for everyone.</param>
+    /// <param name="groups">The caller's groups, least specific first.</param>
+    /// <param name="userOverride">Anything targeted at the caller alone.</param>
+    /// <returns>The settings the caller receives.</returns>
+    public Settings Resolve(
+        Settings? global,
+        IEnumerable<SettingsGroup>? groups,
+        UserSettingsOverride? userOverride)
+    {
+        var levels = new List<Settings?> { global };
+
+        foreach (var group in SettingsResolver.InLayerOrder(groups ?? []))
+        {
+            levels.Add(Read(group.SettingsJson, $"group {group.Name}"));
+        }
+
+        if (userOverride is not null)
+        {
+            levels.Add(Read(userOverride.SettingsJson, $"user {userOverride.UserId}"));
+        }
+
+        return SettingsResolver.Resolve([.. levels]);
+    }
+
+    private Settings? Read(string json, string what)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return _serialization.DeserializeJson<Settings>(json);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            _logger?.LogWarning(
+                ex,
+                "Could not read the settings stored for {What}. That level was skipped",
+                what);
+            return null;
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolver.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolver.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// Flattens the targeting levels into the one set of settings a caller receives.
+/// </summary>
+/// <remarks>
+/// Three levels, least specific first: what the server declares for everyone, then
+/// the groups the caller belongs to, then anything targeted at the caller alone.
+/// Each level is a <see cref="Settings"/> with only the keys it means to say
+/// something about filled in, which works because every property is nullable.
+///
+/// <para>
+/// The most specific level that sets a key wins, and that includes the lock. It is
+/// not "the most restrictive lock wins": the shape the maintainers proposed in
+/// issue #29 has an override setting <c>lock: false</c> to hand a setting back to
+/// named users, and a resolver that could only tighten would make that impossible.
+/// </para>
+///
+/// <para>
+/// A level sets a key or it does not. There is no way to override the lock while
+/// leaving the value alone, because <see cref="Lockable{T}"/> carries both and an
+/// absent value is indistinguishable from <c>false</c> or <c>0</c>. That matches
+/// the proposal, where every override states both.
+/// </para>
+/// </remarks>
+public static class SettingsResolver
+{
+    /// <summary>
+    /// Resolves the levels into one set of settings.
+    /// </summary>
+    /// <param name="levels">The levels, least specific first. Nulls are skipped.</param>
+    /// <returns>
+    /// A new <see cref="Settings"/> holding, for each key, the value from the most
+    /// specific level that set it. A key no level sets stays null, which the client
+    /// reads as "the server has no opinion".
+    /// </returns>
+    public static Settings Resolve(params Settings?[] levels)
+    {
+        var resolved = new Settings();
+
+        if (levels is null)
+        {
+            return resolved;
+        }
+
+        var present = levels.Where(level => level is not null).ToList();
+
+        foreach (var descriptor in SettingsSchema.Descriptors)
+        {
+            // Walk from the most specific level back, and stop at the first one that
+            // has something to say about this key.
+            for (var i = present.Count - 1; i >= 0; i--)
+            {
+                var value = descriptor.Property.GetValue(present[i]);
+                if (value is null)
+                {
+                    continue;
+                }
+
+                descriptor.Property.SetValue(resolved, value);
+                break;
+            }
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Removes the settings that hold a credential.
+    /// </summary>
+    /// <param name="settings">The settings to redact. Not modified.</param>
+    /// <returns>A copy with every key marked <see cref="SecretAttribute"/> left unset.</returns>
+    /// <remarks>
+    /// A redacted key is absent rather than blanked, so a client cannot tell an
+    /// administrator who cleared the field from a user who is not allowed to see it,
+    /// and neither can it push an empty string back as if it were the real value.
+    /// </remarks>
+    public static Settings Redact(Settings? settings)
+    {
+        var redacted = Resolve(settings);
+
+        foreach (var secret in SettingsSchema.Secrets)
+        {
+            secret.Property.SetValue(redacted, null);
+        }
+
+        return redacted;
+    }
+
+    /// <summary>
+    /// Which of a caller's groups apply, in the order they should be layered.
+    /// </summary>
+    /// <param name="groups">The groups the caller belongs to.</param>
+    /// <returns>The same groups, least specific first.</returns>
+    /// <remarks>
+    /// A higher priority wins, so it is layered later. Two groups on the same
+    /// priority are ordered by id, which is arbitrary but stable: the same caller in
+    /// the same groups always resolves to the same answer, rather than to whatever
+    /// the database happened to return first.
+    /// </remarks>
+    public static IReadOnlyList<T> InLayerOrder<T>(IEnumerable<T> groups)
+        where T : Db.SettingsGroup =>
+        groups is null
+            ? []
+            : groups.OrderBy(g => g.Priority).ThenBy(g => g.Id).ToList();
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -170,6 +171,201 @@ public class PluginDatabase
     {
         using var context = CreateContext();
         context.DeviceTokens.RemoveRange(context.DeviceTokens);
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Gets every settings group.
+    /// </summary>
+    /// <returns>The groups, in layer order.</returns>
+    public List<SettingsGroup> GetSettingsGroups()
+    {
+        using var context = CreateContext();
+        return SettingsResolver.InLayerOrder(context.SettingsGroups.AsNoTracking().ToList()).ToList();
+    }
+
+    /// <summary>
+    /// Gets one settings group.
+    /// </summary>
+    /// <param name="id">The group id.</param>
+    /// <returns>The group, or <c>null</c> when there is no such group.</returns>
+    public SettingsGroup? GetSettingsGroup(Guid id)
+    {
+        using var context = CreateContext();
+        return context.SettingsGroups.AsNoTracking().FirstOrDefault(g => g.Id == id);
+    }
+
+    /// <summary>
+    /// Creates or updates a settings group.
+    /// </summary>
+    /// <param name="group">The group. An empty id means create.</param>
+    /// <returns>The stored group, with its id.</returns>
+    public SettingsGroup SaveSettingsGroup(SettingsGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        using var context = CreateContext();
+
+        if (group.Id == Guid.Empty)
+        {
+            group.Id = Guid.NewGuid();
+            context.SettingsGroups.Add(group);
+        }
+        else
+        {
+            var existing = context.SettingsGroups.FirstOrDefault(g => g.Id == group.Id);
+            if (existing is null)
+            {
+                context.SettingsGroups.Add(group);
+            }
+            else
+            {
+                existing.Name = group.Name;
+                existing.Priority = group.Priority;
+                existing.SettingsJson = group.SettingsJson;
+            }
+        }
+
+        context.SaveChanges();
+        return group;
+    }
+
+    /// <summary>
+    /// Deletes a settings group and everyone's membership of it.
+    /// </summary>
+    /// <param name="id">The group id.</param>
+    /// <remarks>
+    /// Both in one transaction. A group deleted while its memberships survive would
+    /// leave rows that resolve to nothing and reappear if the id were ever reused.
+    /// </remarks>
+    public void RemoveSettingsGroup(Guid id)
+    {
+        using var context = CreateContext();
+
+        var existing = context.SettingsGroups.FirstOrDefault(g => g.Id == id);
+        if (existing is null)
+        {
+            return;
+        }
+
+        context.SettingsGroupMembers.RemoveRange(
+            context.SettingsGroupMembers.Where(m => m.GroupId == id));
+        context.SettingsGroups.Remove(existing);
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Gets the members of a group.
+    /// </summary>
+    /// <param name="groupId">The group id.</param>
+    /// <returns>The Jellyfin user ids.</returns>
+    public List<Guid> GetGroupMembers(Guid groupId)
+    {
+        using var context = CreateContext();
+        return context.SettingsGroupMembers.AsNoTracking()
+            .Where(m => m.GroupId == groupId)
+            .Select(m => m.UserId)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Replaces the membership of a group.
+    /// </summary>
+    /// <param name="groupId">The group id.</param>
+    /// <param name="userIds">Who should be in it afterwards.</param>
+    public void SetGroupMembers(Guid groupId, IEnumerable<Guid> userIds)
+    {
+        using var context = CreateContext();
+
+        context.SettingsGroupMembers.RemoveRange(
+            context.SettingsGroupMembers.Where(m => m.GroupId == groupId));
+
+        foreach (var userId in (userIds ?? []).Distinct())
+        {
+            context.SettingsGroupMembers.Add(new SettingsGroupMember
+            {
+                GroupId = groupId,
+                UserId = userId
+            });
+        }
+
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Gets the groups a user belongs to.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user id.</param>
+    /// <returns>The groups, least specific first.</returns>
+    public List<SettingsGroup> GetGroupsForUser(Guid userId)
+    {
+        using var context = CreateContext();
+
+        var groups = context.SettingsGroupMembers.AsNoTracking()
+            .Where(m => m.UserId == userId)
+            .Join(
+                context.SettingsGroups.AsNoTracking(),
+                m => m.GroupId,
+                g => g.Id,
+                (_, g) => g)
+            .ToList();
+
+        return SettingsResolver.InLayerOrder(groups).ToList();
+    }
+
+    /// <summary>
+    /// Gets the settings targeted at one user.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user id.</param>
+    /// <returns>The override, or <c>null</c> when there is none.</returns>
+    public UserSettingsOverride? GetUserSettingsOverride(Guid userId)
+    {
+        using var context = CreateContext();
+        return context.UserSettingsOverrides.AsNoTracking()
+            .FirstOrDefault(o => o.UserId == userId);
+    }
+
+    /// <summary>
+    /// Sets the settings targeted at one user.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user id.</param>
+    /// <param name="settingsJson">A partial set of settings, as JSON.</param>
+    public void SaveUserSettingsOverride(Guid userId, string settingsJson)
+    {
+        using var context = CreateContext();
+
+        var existing = context.UserSettingsOverrides.FirstOrDefault(o => o.UserId == userId);
+        if (existing is null)
+        {
+            context.UserSettingsOverrides.Add(new UserSettingsOverride
+            {
+                UserId = userId,
+                SettingsJson = settingsJson
+            });
+        }
+        else
+        {
+            existing.SettingsJson = settingsJson;
+        }
+
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Clears the settings targeted at one user.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user id.</param>
+    public void RemoveUserSettingsOverride(Guid userId)
+    {
+        using var context = CreateContext();
+
+        var existing = context.UserSettingsOverrides.FirstOrDefault(o => o.UserId == userId);
+        if (existing is null)
+        {
+            return;
+        }
+
+        context.UserSettingsOverrides.Remove(existing);
         context.SaveChanges();
     }
 

--- a/Jellyfin.Plugin.Streamyfin/Db/SettingsGroup.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/SettingsGroup.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Jellyfin.Plugin.Streamyfin.Db;
+
+/// <summary>
+/// A named set of users an administrator can target settings at.
+/// </summary>
+/// <remarks>
+/// Jellyfin has a <c>Group</c> entity of its own, with permissions and preferences,
+/// but nothing uses it: no manager, no controller, no route. So the plugin defines
+/// its own rather than building on something the server does not expose. If that
+/// ever changes, this table is what maps onto it.
+/// </remarks>
+public class SettingsGroup
+{
+    /// <summary>
+    /// Gets or sets the group id.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name an administrator sees.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets which group wins when a user is in more than one.
+    /// </summary>
+    /// <remarks>
+    /// Higher wins, because it is layered later. Groups sharing a priority are
+    /// ordered by id, which is arbitrary but stable, so the same user always
+    /// resolves to the same answer instead of to whatever the database returned
+    /// first.
+    /// </remarks>
+    public int Priority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings this group says something about, as JSON.
+    /// </summary>
+    /// <remarks>
+    /// A partial <c>Settings</c>: only the keys the group means to override are
+    /// filled in, which works because every property on it is nullable. Stored as
+    /// JSON rather than as forty one columns, so adding a setting does not mean a
+    /// migration.
+    /// </remarks>
+    public string SettingsJson { get; set; } = "{}";
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/SettingsGroupMember.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/SettingsGroupMember.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Jellyfin.Plugin.Streamyfin.Db;
+
+/// <summary>
+/// One Jellyfin user's membership of one <see cref="SettingsGroup"/>.
+/// </summary>
+/// <remarks>
+/// A row rather than a list on the group, so a user's groups can be looked up
+/// without reading every group. Membership is by Jellyfin user id: a user deleted
+/// on the server leaves a row behind, which resolves to nothing and costs nothing.
+/// </remarks>
+public class SettingsGroupMember
+{
+    /// <summary>
+    /// Gets or sets the group.
+    /// </summary>
+    public Guid GroupId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Jellyfin user.
+    /// </summary>
+    public Guid UserId { get; set; }
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/StreamyfinDbContext.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/StreamyfinDbContext.cs
@@ -25,6 +25,9 @@ public class StreamyfinDbContext : DbContext
         _dbPath = dbPath;
         DeviceTokens = Set<DeviceToken>();
         ImportMarkers = Set<ImportMarker>();
+        SettingsGroups = Set<SettingsGroup>();
+        SettingsGroupMembers = Set<SettingsGroupMember>();
+        UserSettingsOverrides = Set<UserSettingsOverride>();
     }
 
     /// <summary>
@@ -37,6 +40,9 @@ public class StreamyfinDbContext : DbContext
         _dbPath = null;
         DeviceTokens = Set<DeviceToken>();
         ImportMarkers = Set<ImportMarker>();
+        SettingsGroups = Set<SettingsGroup>();
+        SettingsGroupMembers = Set<SettingsGroupMember>();
+        UserSettingsOverrides = Set<UserSettingsOverride>();
     }
 
     /// <summary>
@@ -48,6 +54,21 @@ public class StreamyfinDbContext : DbContext
     /// Gets or sets the record of one time imports that have already run.
     /// </summary>
     public DbSet<ImportMarker> ImportMarkers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the groups an administrator can target settings at.
+    /// </summary>
+    public DbSet<SettingsGroup> SettingsGroups { get; set; }
+
+    /// <summary>
+    /// Gets or sets which users belong to which group.
+    /// </summary>
+    public DbSet<SettingsGroupMember> SettingsGroupMembers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings targeted at a single user.
+    /// </summary>
+    public DbSet<UserSettingsOverride> UserSettingsOverrides { get; set; }
 
     /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -74,6 +95,30 @@ public class StreamyfinDbContext : DbContext
         {
             entity.ToTable("ImportMarkers");
             entity.HasKey(m => m.Name);
+        });
+
+        modelBuilder.Entity<SettingsGroup>(entity =>
+        {
+            entity.ToTable("SettingsGroups");
+            entity.HasKey(g => g.Id);
+            entity.Property(g => g.Name).IsRequired();
+            entity.Property(g => g.SettingsJson).IsRequired();
+            // Two groups with the same name are two groups an admin cannot tell apart.
+            entity.HasIndex(g => g.Name).IsUnique();
+        });
+
+        modelBuilder.Entity<SettingsGroupMember>(entity =>
+        {
+            entity.ToTable("SettingsGroupMembers");
+            entity.HasKey(m => new { m.GroupId, m.UserId });
+            entity.HasIndex(m => m.UserId);
+        });
+
+        modelBuilder.Entity<UserSettingsOverride>(entity =>
+        {
+            entity.ToTable("UserSettingsOverrides");
+            entity.HasKey(o => o.UserId);
+            entity.Property(o => o.SettingsJson).IsRequired();
         });
 
         base.OnModelCreating(modelBuilder);

--- a/Jellyfin.Plugin.Streamyfin/Db/UserSettingsOverride.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/UserSettingsOverride.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Jellyfin.Plugin.Streamyfin.Db;
+
+/// <summary>
+/// Settings an administrator targets at one user, above every group they are in.
+/// </summary>
+/// <remarks>
+/// This is the third targeting level, and it is still the administrator speaking.
+/// A user's own preferences live in the app, and what this level decides is what
+/// the app is allowed to let them change.
+/// </remarks>
+public class UserSettingsOverride
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin user.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings targeted at them, as JSON.
+    /// </summary>
+    /// <remarks>
+    /// A partial <c>Settings</c>, same shape as <see cref="SettingsGroup.SettingsJson"/>.
+    /// </remarks>
+    public string SettingsJson { get; set; } = "{}";
+}

--- a/Jellyfin.Plugin.Streamyfin/Extensions/UserManagerExtensions.cs
+++ b/Jellyfin.Plugin.Streamyfin/Extensions/UserManagerExtensions.cs
@@ -32,6 +32,9 @@ public static class UserManagerExtensions
     /// answers to it would be a security bug rather than an inconsistency.
     /// </remarks>
     public static bool IsAdministrator(this IUserManager? manager, Guid userId) =>
+        // An empty id is not a user with no permissions, it is the absence of a user,
+        // which is what an API key call looks like. GetUserById throws on it.
+        !userId.Equals(default) &&
         manager?.GetUserById(userId)?
             .Permissions.Any(p => p.Kind == PermissionKind.IsAdministrator && p.Value) == true;
 }

--- a/Jellyfin.Plugin.Streamyfin/Extensions/UserManagerExtensions.cs
+++ b/Jellyfin.Plugin.Streamyfin/Extensions/UserManagerExtensions.cs
@@ -19,4 +19,19 @@ public static class UserManagerExtensions
 
     public static List<string> GetAdminTokens(this IUserManager? manager) => 
         manager?.GetAdminDeviceTokens().Select(deviceToken => deviceToken.Token).ToList() ?? [];
+
+    /// <summary>
+    /// Whether a user administers this server.
+    /// </summary>
+    /// <param name="manager">The user manager.</param>
+    /// <param name="userId">The Jellyfin user id.</param>
+    /// <returns>True when the user holds the administrator permission.</returns>
+    /// <remarks>
+    /// Read from the permission rather than from a role claim, because the same
+    /// question is asked here and in <c>GetAdminDeviceTokens</c> and two different
+    /// answers to it would be a security bug rather than an inconsistency.
+    /// </remarks>
+    public static bool IsAdministrator(this IUserManager? manager, Guid userId) =>
+        manager?.GetUserById(userId)?
+            .Permissions.Any(p => p.Kind == PermissionKind.IsAdministrator && p.Value) == true;
 }

--- a/Jellyfin.Plugin.Streamyfin/Migrations/20260825183813_AddSettingsGroups.Designer.cs
+++ b/Jellyfin.Plugin.Streamyfin/Migrations/20260825183813_AddSettingsGroups.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Jellyfin.Plugin.Streamyfin.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jellyfin.Plugin.Streamyfin.Migrations
 {
     [DbContext(typeof(StreamyfinDbContext))]
-    partial class StreamyfinDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825183813_AddSettingsGroups")]
+    partial class AddSettingsGroups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.11");

--- a/Jellyfin.Plugin.Streamyfin/Migrations/20260825183813_AddSettingsGroups.cs
+++ b/Jellyfin.Plugin.Streamyfin/Migrations/20260825183813_AddSettingsGroups.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jellyfin.Plugin.Streamyfin.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSettingsGroups : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SettingsGroupMembers",
+                columns: table => new
+                {
+                    GroupId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UserId = table.Column<Guid>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SettingsGroupMembers", x => new { x.GroupId, x.UserId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SettingsGroups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Priority = table.Column<int>(type: "INTEGER", nullable: false),
+                    SettingsJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SettingsGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserSettingsOverrides",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    SettingsJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSettingsOverrides", x => x.UserId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SettingsGroupMembers_UserId",
+                table: "SettingsGroupMembers",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SettingsGroups_Name",
+                table: "SettingsGroups",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SettingsGroupMembers");
+
+            migrationBuilder.DropTable(
+                name: "SettingsGroups");
+
+            migrationBuilder.DropTable(
+                name: "UserSettingsOverrides");
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
@@ -146,6 +146,23 @@ public class SerializationHelper
     /// </summary>
     public T Deserialize<T>(string value) => _deserializer.Deserialize<T>(value);
 
+    /// <summary>
+    /// Deserialize Json, with the same options <see cref="SerializeToJson{T}"/> writes it.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Deserialize{T}"/> goes through YamlDotNet, and YAML is a superset of
+    /// JSON, so it reads most of it. It does not read all of it: the converters
+    /// registered here write <c>OrientationLock</c>, <c>Bitrate</c> and
+    /// <c>SubtitlePlaybackMode</c> as numbers, and YamlDotNet expects the member name.
+    /// Anything stored with <see cref="SerializeToJson{T}"/> has to come back through
+    /// this, or those three settings do not survive the round trip.
+    /// </remarks>
+    /// <typeparam name="T">What to read it as.</typeparam>
+    /// <param name="value">The JSON.</param>
+    /// <returns>The value, or <c>null</c> for a JSON null.</returns>
+    public T? DeserializeJson<T>(string value) =>
+        JsonSerializer.Deserialize<T>(value, GetJsonSerializerOptions());
+
     public static ICollection<ITypeMapper> HTMLFormTypeMappers() => new Collection<ITypeMapper>(new List<ITypeMapper>
         {
             new PrimitiveTypeMapper(


### PR DESCRIPTION
Part of #114. Covers **P1.2 and P1.3**.

They land together because neither is worth anything alone. Groups with no resolution are rows nobody reads, and a resolver with nothing to resolve is dead code. Same reasoning that put P0.3 to P0.5 in one pull request.

## The three levels

Least specific first: what the server declares for everyone, the groups an administrator defines, then anything aimed at one user. Each level is a `Settings` with only the keys it means to speak about filled in, which works because every property on it is already nullable. No string keyed map, no second schema, and `json-editor` still generates a form from the same type in P3.

Resolution walks `SettingsSchema` from #128 and takes, per key, the value from the most specific level that set it.

## The rule, and why it is not "most restrictive wins"

**The most specific level wins, and that includes the lock.** I had it the other way round at first. The shape the maintainers proposed in [#29](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/29), which `plan.md` quotes as evidence the design is not being imposed from outside, has an override setting `lock: false` to hand a setting back to named users:

```yaml
settings:
  notification_new_movie:
    lock: true
    value: true
    overrides:
      - users: [john, simon]
        lock: false
        value: true
```

A resolver that could only tighten would make that impossible. There is a test named after the case.

A level sets a key or it does not. There is no way to override the lock and leave the value alone, because `Lockable<T>` carries both and an absent value cannot be told apart from `false` or `0`. That matches the proposal, where every override states both.

Two groups on the same user are ordered by priority, and ties by id. Arbitrary, but stable: the same user in the same groups has to resolve to the same answer every time rather than to whatever the database returned first.

## Storage

Three tables and one migration.

| Table | Holds |
|---|---|
| `SettingsGroups` | name, priority, and the overrides as JSON |
| `SettingsGroupMembers` | which Jellyfin users are in which group |
| `UserSettingsOverrides` | what is aimed at one user |

A group keeps its overrides as **JSON rather than as forty one columns**, so adding a setting is not a migration. Deleting a group takes its memberships with it in one transaction, since rows left behind resolve to nothing and would come back if the id were reused. A level whose JSON cannot be read is skipped with a warning rather than thrown: this runs inside a request, and one corrupted row should cost that group's overrides, not every setting for every user in it.

## A gap in the serializer, found on the way

`SerializationHelper` had `SerializeToJson` and no JSON reader. `Deserialize` goes through YamlDotNet, and YAML reads most JSON, but not the three settings this plugin deliberately writes as **numbers**: `OrientationLock`, `Bitrate` and `SubtitlePlaybackMode`. Anything stored with `SerializeToJson` has to come back through a matching reader or those three do not survive the round trip. `DeserializeJson` is that reader, and there is a test for exactly those settings.

## Routes

Everything that writes is `RequiresElevation`.

| Route | |
|---|---|
| `GET/POST /streamyfin/groups` | list, create |
| `PUT/DELETE /streamyfin/groups/{id}` | update, delete |
| `PUT /streamyfin/groups/{id}/members` | replace the membership |
| `PUT/DELETE /streamyfin/users/{userId}/settings` | the per user level |
| `GET /streamyfin/config/resolved` | **the caller's own resolved settings** |

`config/resolved` strips credentials unless the caller administers the server. That is **not P1.4**, which is about retiring what `GET config` does and dealing with what the app does about it. It is this route not being a second way to read the Seerr key. `GET config` is untouched and still serves everything to everyone, exactly as before.

`GET config/resolved` is also not P1.6. That part reorganises the routes and shims the old ones; this adds one additive route so the feature has a consumer.

## Testing

`dotnet test` on both targets: **72 passed, 0 failed** on `jf11` and on `jf12`, 0 warnings and 0 errors on both. Twenty one new tests, covering each precedence case, the unlock case from #29, stable group ordering, redaction, and an unreadable level.

Verified on a real Jellyfin 10.11.11 rather than only in tests:

- The migration applies to a database that already had `InitialCreate`, adding the three tables and their indexes **without losing the rows already there**.
- Over HTTP, a `subtitleSize` locked at 80 for everyone resolves to **200 locked** for a user targeted directly, to **60 unlocked** once that override is removed and their group takes over, and back to **80 locked** for a user in no group.
- `jellyseerrApiKey` is **absent** from `config/resolved` for a non administrator and present for an administrator, while the old `GET config` still hands it to both, which is the finding P1.4 exists to close.
- The group routes answer **403** to a non administrator.
- No error in the server log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added administrator-managed settings groups with priorities and user membership.
  - Added per-user settings overrides.
  - Added effective-settings resolution across server, group, and user levels.
  - Added API support to create, update, delete, and manage settings groups and overrides.
  - Sensitive credentials are redacted for non-administrator access.

- **Bug Fixes**
  - Invalid or unreadable settings levels are skipped without preventing resolution.
  - Settings values now merge predictably, with more-specific values taking precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->