### PR TITLE
feat(dashboard): give the plugin an entry in the left menu, with its logo

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/DrawerLogoPatchTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/DrawerLogoPatchTests.cs
@@ -1,0 +1,95 @@
+using Jellyfin.Plugin.Streamyfin.Injection;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// The stylesheet that puts the plugin's logo on its drawer row.
+///
+/// The dashboard renders a plugin's icon through MUI's icon font component, so
+/// <c>MenuIcon</c> can only be a Material ligature and an image has to come from
+/// outside the plugin's own pages. File Transformation is that outside.
+/// </summary>
+public class DrawerLogoPatchTests
+{
+    private const string Document = "<html><head><title>Jellyfin</title></head><body></body></html>";
+
+    /// <summary>
+    /// The stylesheet lands inside the head, before it closes.
+    /// </summary>
+    [Fact]
+    public void TheStyleGoesInsideTheHead()
+    {
+        var patched = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+
+        var style = patched.IndexOf("<style id=\"streamyfin-drawer-logo\"", System.StringComparison.Ordinal);
+        var headClose = patched.IndexOf("</head>", System.StringComparison.Ordinal);
+
+        Assert.True(style > 0, "the stylesheet is missing");
+        Assert.True(style < headClose, "the stylesheet landed outside the head");
+    }
+
+    /// <summary>
+    /// Patching an already patched document changes nothing. The transformation runs on
+    /// every request for the page, so appending each time would grow the document without
+    /// bound for as long as the server is up.
+    /// </summary>
+    [Fact]
+    public void PatchingTwiceIsTheSameAsPatchingOnce()
+    {
+        var once = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+        var twice = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = once });
+
+        Assert.Equal(once, twice);
+    }
+
+    /// <summary>
+    /// The rule points at the image Jellyfin already serves for the plugin, by id and by
+    /// version. The id alone answers 405, so the version is not optional.
+    /// </summary>
+    [Fact]
+    public void TheRulePointsAtThePluginsOwnImage()
+    {
+        var patched = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+
+        var version = typeof(StreamyfinPlugin).Assembly.GetName().Version!.ToString();
+
+        Assert.Contains($"/Plugins/1e9e5d386e6746158719e98a5c34f004/{version}/Image", patched, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The rule targets the drawer row for the landing page, which is the row that asks
+    /// for a menu entry.
+    /// </summary>
+    [Fact]
+    public void TheRuleTargetsTheDrawerRow()
+    {
+        var patched = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+
+        Assert.Contains("configurationpage?name=Application", patched, System.StringComparison.Ordinal);
+        Assert.Contains(".MuiIcon-root", patched, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Nothing to patch is not a failure. A callback that threw would take the web client's
+    /// entry point down with it, which is a far worse outcome than a Material icon.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NothingToPatchIsNotAFailure(string? contents)
+    {
+        Assert.Equal(string.Empty, DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = contents }));
+    }
+
+    /// <summary>
+    /// A document with no head is served unchanged rather than mangled.
+    /// </summary>
+    [Fact]
+    public void ADocumentWithNoHeadIsLeftAlone()
+    {
+        const string Fragment = "<html><body>no head here</body></html>";
+
+        Assert.Equal(Fragment, DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Fragment }));
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/DrawerLogoPatchTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/DrawerLogoPatchTests.cs
@@ -12,6 +12,8 @@ namespace Jellyfin.Plugin.Streamyfin.Tests;
 /// </summary>
 public class DrawerLogoPatchTests
 {
+    private const string LandingPage = "Application";
+
     private const string Document = "<html><head><title>Jellyfin</title></head><body></body></html>";
 
     /// <summary>
@@ -20,7 +22,7 @@ public class DrawerLogoPatchTests
     [Fact]
     public void TheStyleGoesInsideTheHead()
     {
-        var patched = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+        var patched = DrawerLogoPatch.Inject(Document, LandingPage);
 
         var style = patched.IndexOf("<style id=\"streamyfin-drawer-logo\"", System.StringComparison.Ordinal);
         var headClose = patched.IndexOf("</head>", System.StringComparison.Ordinal);
@@ -37,8 +39,8 @@ public class DrawerLogoPatchTests
     [Fact]
     public void PatchingTwiceIsTheSameAsPatchingOnce()
     {
-        var once = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
-        var twice = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = once });
+        var once = DrawerLogoPatch.Inject(Document, LandingPage);
+        var twice = DrawerLogoPatch.Inject(once, LandingPage);
 
         Assert.Equal(once, twice);
     }
@@ -50,7 +52,7 @@ public class DrawerLogoPatchTests
     [Fact]
     public void TheRulePointsAtThePluginsOwnImage()
     {
-        var patched = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+        var patched = DrawerLogoPatch.Inject(Document, LandingPage);
 
         var version = typeof(StreamyfinPlugin).Assembly.GetName().Version!.ToString();
 
@@ -58,16 +60,46 @@ public class DrawerLogoPatchTests
     }
 
     /// <summary>
-    /// The rule targets the drawer row for the landing page, which is the row that asks
-    /// for a menu entry.
+    /// The rule targets the drawer row for the landing page, and only inside the drawer's
+    /// plugin list. The page name follows <c>Other.HomePage</c>, so it is read from the
+    /// same place the menu entry is decided rather than written down twice.
     /// </summary>
     [Fact]
     public void TheRuleTargetsTheDrawerRow()
     {
-        var patched = DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Document });
+        var patched = DrawerLogoPatch.Inject(Document, LandingPage);
 
-        Assert.Contains("configurationpage?name=Application", patched, System.StringComparison.Ordinal);
+        Assert.Contains(
+            $"configurationpage?name={LandingPage}",
+            patched,
+            System.StringComparison.Ordinal);
+        Assert.Contains("[aria-labelledby=\"plugins-subheader\"]", patched, System.StringComparison.Ordinal);
         Assert.Contains(".MuiIcon-root", patched, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The rule follows the home page setting rather than a fixed page. An administrator
+    /// who lands on the YAML editor gets the row they actually have.
+    /// </summary>
+    [Fact]
+    public void TheRuleFollowsTheHomePageSetting()
+    {
+        var patched = DrawerLogoPatch.Inject(Document, "Yaml");
+
+        Assert.Contains("configurationpage?name=Yaml", patched, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("configurationpage?name=Application", patched, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// With no row to aim at, nothing is injected rather than a rule aimed at nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoLandingPageMeansNoInjection(string? landingPage)
+    {
+        Assert.Equal(Document, DrawerLogoPatch.Inject(Document, landingPage));
     }
 
     /// <summary>
@@ -79,7 +111,7 @@ public class DrawerLogoPatchTests
     [InlineData("")]
     public void NothingToPatchIsNotAFailure(string? contents)
     {
-        Assert.Equal(string.Empty, DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = contents }));
+        Assert.Equal(string.Empty, DrawerLogoPatch.Inject(contents, LandingPage));
     }
 
     /// <summary>
@@ -90,6 +122,6 @@ public class DrawerLogoPatchTests
     {
         const string Fragment = "<html><body>no head here</body></html>";
 
-        Assert.Equal(Fragment, DrawerLogoPatch.IndexHtml(new FileTransformationPayload { Contents = Fragment }));
+        Assert.Equal(Fragment, DrawerLogoPatch.Inject(Fragment, LandingPage));
     }
 }

--- a/Jellyfin.Plugin.Streamyfin.Tests/PluginPagesTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PluginPagesTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Page ordering, which decides two things at once: the page the dashboard opens the
+/// plugin on, and the page its entry in the left menu points at.
+/// </summary>
+public class PluginPagesTests
+{
+    private static List<PluginPageInfo> Pages() =>
+    [
+        new() { Name = "Application" },
+        new() { Name = "Application.js" },
+        new() { Name = "Notifications" },
+        new() { Name = "Yaml" }
+    ];
+
+    /// <summary>
+    /// With no preference the declared order stands.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoHomePageLeavesTheOrderAlone(string? homePage)
+    {
+        var ordered = StreamyfinPlugin.OrderedPages(Pages(), homePage);
+
+        Assert.Equal(
+            ["Application", "Application.js", "Notifications", "Yaml"],
+            ordered.Select(p => p.Name));
+    }
+
+    /// <summary>
+    /// The chosen page comes first, and every other page is still served. The dashboard
+    /// opens the plugin on the first page it is given, so this setting is the whole
+    /// mechanism behind it.
+    /// </summary>
+    [Fact]
+    public void TheChosenHomePageComesFirst()
+    {
+        var ordered = StreamyfinPlugin.OrderedPages(Pages(), "Yaml");
+
+        Assert.Equal(
+            ["Yaml", "Application", "Application.js", "Notifications"],
+            ordered.Select(p => p.Name));
+    }
+
+    /// <summary>
+    /// A home page naming something that no longer exists serves the pages in their
+    /// declared order rather than serving none. A renamed page or a typo in the YAML
+    /// should cost the preference, not the admin interface.
+    /// </summary>
+    [Fact]
+    public void AnUnknownHomePageFallsBackToTheDeclaredOrder()
+    {
+        var ordered = StreamyfinPlugin.OrderedPages(Pages(), "APageThatWasRenamed");
+
+        Assert.Equal(
+            ["Application", "Application.js", "Notifications", "Yaml"],
+            ordered.Select(p => p.Name));
+    }
+
+    /// <summary>
+    /// Exactly one page asks for a menu entry, and it is the one the admin lands on.
+    /// The dashboard renders one entry per page that asks, so marking them all would
+    /// put four Streamyfin rows in the drawer.
+    /// </summary>
+    [Fact]
+    public void OnlyTheLandingPageAsksForAMenuEntry()
+    {
+        var plugin = (IHasWebPages)FormatterServices_CreateUninitialized();
+
+        var pages = plugin.GetPages().ToList();
+        var inMenu = pages.Where(p => p.EnableInMainMenu).ToList();
+
+        Assert.Single(inMenu);
+        Assert.Equal(pages[0].Name, inMenu[0].Name);
+        Assert.Equal(StreamyfinPlugin.MenuDisplayName, inMenu[0].DisplayName);
+        Assert.Equal(StreamyfinPlugin.MenuIcon, inMenu[0].MenuIcon);
+    }
+
+    // The plugin's constructor needs the server, which a unit test has no business
+    // starting. GetPages only reads Instance through a null conditional, so an
+    // uninitialized instance answers the question this test asks.
+    private static object FormatterServices_CreateUninitialized() =>
+        System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(StreamyfinPlugin));
+}

--- a/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoPatch.cs
+++ b/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoPatch.cs
@@ -22,34 +22,50 @@ namespace Jellyfin.Plugin.Streamyfin.Injection;
 public static class DrawerLogoPatch
 {
     /// <summary>
-    /// Where the drawer row for the landing page points. See <c>getPluginUrl</c> in
-    /// <c>src/utils/dashboard.js</c>, which builds <c>configurationpage?name=</c> plus the
-    /// page name.
-    /// </summary>
-    private const string LandingPageName = "Application";
-
-    /// <summary>
     /// Injects the stylesheet into the web client's entry point.
     /// </summary>
     /// <param name="payload">The file as it stands.</param>
     /// <returns>The file with the stylesheet before its closing head tag.</returns>
-    public static string IndexHtml(FileTransformationPayload payload)
-    {
-        var contents = payload?.Contents ?? string.Empty;
+    /// <remarks>
+    /// The signature is fixed by File Transformation, which passes the payload and
+    /// nothing else. The rule itself is <see cref="Inject"/>, which takes the row it
+    /// aims at, so it can be exercised without a running server.
+    /// </remarks>
+    public static string IndexHtml(FileTransformationPayload payload) =>
+        Inject(payload?.Contents, StreamyfinPlugin.LandingPageName);
 
-        if (contents.Length == 0 || contents.Contains(Marker, StringComparison.Ordinal))
+    /// <summary>
+    /// Puts the stylesheet in a document, aimed at one drawer row.
+    /// </summary>
+    /// <param name="contents">The document.</param>
+    /// <param name="landingPage">
+    /// The page the drawer row points at, which follows <c>Other.HomePage</c>. Nothing is
+    /// injected without one: a rule aimed at a row that is not rendered would fail
+    /// silently, with no logo and nothing to say why.
+    /// </param>
+    /// <returns>The document, patched or unchanged.</returns>
+    internal static string Inject(string? contents, string? landingPage)
+    {
+        var document = contents ?? string.Empty;
+
+        if (document.Length == 0 || string.IsNullOrWhiteSpace(landingPage))
+        {
+            return document;
+        }
+
+        if (document.Contains(Marker, StringComparison.Ordinal))
         {
             // Already patched. The transformation runs per request, and appending a
             // second copy on every page load would grow the document without bound.
-            return contents;
+            return document;
         }
 
-        return Regex.Replace(contents, "(</head>)", Style() + "$1", RegexOptions.IgnoreCase);
+        return Regex.Replace(document, "(</head>)", Style(landingPage) + "$1", RegexOptions.IgnoreCase);
     }
 
     private const string Marker = "streamyfin-drawer-logo";
 
-    private static string Style()
+    private static string Style(string landingPage)
     {
         var version = typeof(StreamyfinPlugin).Assembly.GetName().Version?.ToString() ?? "0.0.0.0";
         var id = StreamyfinPlugin.PluginId.ToString("N", CultureInfo.InvariantCulture);
@@ -60,15 +76,16 @@ public static class DrawerLogoPatch
             CultureInfo.InvariantCulture,
             $"/Plugins/{id}/{version}/Image");
 
-        // Matched on the link rather than on anything identifying the plugin, because the
-        // drawer renders nothing else to go on. A page called Application belonging to
-        // another plugin, and also asking for a drawer row, would pick this up. The cost
-        // of that collision is a wrong icon.
+        // Scoped to the drawer's plugin list, which jellyfin-web labels
+        // plugins-subheader, so the rule cannot reach a link anywhere else in the app.
+        // Inside that list it still matches on the page name, because the drawer renders
+        // nothing identifying the plugin. Another plugin with a page of the same name,
+        // also asking for a drawer row, would pick this up. The cost is a wrong icon.
         return string.Create(
             CultureInfo.InvariantCulture,
             $$"""
             <style id="{{Marker}}">
-            a[href*="configurationpage?name={{LandingPageName}}"] .MuiIcon-root {
+            [aria-labelledby="plugins-subheader"] a[href*="configurationpage?name={{landingPage}}"] .MuiIcon-root {
                 font-size: 0;
                 width: 1.5rem;
                 height: 1.5rem;

--- a/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoPatch.cs
+++ b/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoPatch.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Jellyfin.Plugin.Streamyfin.Injection;
+
+/// <summary>
+/// Puts the plugin's own logo on its row in the dashboard drawer.
+/// </summary>
+/// <remarks>
+/// The drawer renders the icon as <c>&lt;Icon&gt;{MenuIcon}&lt;/Icon&gt;</c>, MUI's icon
+/// font component, so <c>MenuIcon</c> can only ever be a Material ligature. The only way
+/// to show an image is to reach the page from outside, which is what File Transformation
+/// exists for.
+///
+/// <para>
+/// This is deliberately CSS and not script. The drawer is a React tree that re-renders,
+/// and a script that rewrote the DOM would have its work thrown away on the next render
+/// unless it kept a MutationObserver alive. A stylesheet survives every render.
+/// </para>
+/// </remarks>
+public static class DrawerLogoPatch
+{
+    /// <summary>
+    /// Where the drawer row for the landing page points. See <c>getPluginUrl</c> in
+    /// <c>src/utils/dashboard.js</c>, which builds <c>configurationpage?name=</c> plus the
+    /// page name.
+    /// </summary>
+    private const string LandingPageName = "Application";
+
+    /// <summary>
+    /// Injects the stylesheet into the web client's entry point.
+    /// </summary>
+    /// <param name="payload">The file as it stands.</param>
+    /// <returns>The file with the stylesheet before its closing head tag.</returns>
+    public static string IndexHtml(FileTransformationPayload payload)
+    {
+        var contents = payload?.Contents ?? string.Empty;
+
+        if (contents.Length == 0 || contents.Contains(Marker, StringComparison.Ordinal))
+        {
+            // Already patched. The transformation runs per request, and appending a
+            // second copy on every page load would grow the document without bound.
+            return contents;
+        }
+
+        return Regex.Replace(contents, "(</head>)", Style() + "$1", RegexOptions.IgnoreCase);
+    }
+
+    private const string Marker = "streamyfin-drawer-logo";
+
+    private static string Style()
+    {
+        var version = typeof(StreamyfinPlugin).Assembly.GetName().Version?.ToString() ?? "0.0.0.0";
+        var id = StreamyfinPlugin.PluginId.ToString("N", CultureInfo.InvariantCulture);
+
+        // Jellyfin already serves the logo, from imagePath in the plugin's meta.json.
+        // The version is part of the route: the id alone answers 405.
+        var image = string.Create(
+            CultureInfo.InvariantCulture,
+            $"/Plugins/{id}/{version}/Image");
+
+        // Matched on the link rather than on anything identifying the plugin, because the
+        // drawer renders nothing else to go on. A page called Application belonging to
+        // another plugin, and also asking for a drawer row, would pick this up. The cost
+        // of that collision is a wrong icon.
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $$"""
+            <style id="{{Marker}}">
+            a[href*="configurationpage?name={{LandingPageName}}"] .MuiIcon-root {
+                font-size: 0;
+                width: 1.5rem;
+                height: 1.5rem;
+                background: center / contain no-repeat url("{{image}}");
+            }
+            </style>
+
+            """);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoRegistration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoRegistration.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace Jellyfin.Plugin.Streamyfin.Injection;
+
+/// <summary>
+/// Tells the File Transformation plugin, if it is installed, to run
+/// <see cref="DrawerLogoPatch"/> over the web client's entry point.
+/// </summary>
+/// <remarks>
+/// A scheduled task on a startup trigger rather than plugin construction, because the
+/// other plugin has to be loaded before it can be found, and plugin load order is not
+/// something either plugin controls. Jellyfin discovers this by the interface, so
+/// nothing registers it.
+///
+/// <para>
+/// File Transformation is not in the official catalogue and most servers will not have
+/// it. Its absence is the normal case and costs nothing: the plugin keeps its Material
+/// glyph and this logs once at debug.
+/// </para>
+/// </remarks>
+public class DrawerLogoRegistration : IScheduledTask
+{
+    // Fixed, so a restart replaces the registration rather than adding another.
+    private const string TransformationId = "2f6c1a94-8e33-4d7b-9c05-a1b7e2d4f680";
+    private const string FileTransformationAssemblyMarker = ".FileTransformation";
+    private const string PluginInterfaceType = "Jellyfin.Plugin.FileTransformation.PluginInterface";
+    private const string RegisterMethod = "RegisterTransformation";
+
+    private readonly ILogger<DrawerLogoRegistration> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DrawerLogoRegistration"/> class.
+    /// </summary>
+    /// <param name="loggerFactory">Logger factory.</param>
+    public DrawerLogoRegistration(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        _logger = loggerFactory.CreateLogger<DrawerLogoRegistration>();
+    }
+
+    /// <inheritdoc />
+    public string Name => "Streamyfin drawer logo";
+
+    /// <inheritdoc />
+    public string Key => "Jellyfin.Plugin.Streamyfin.DrawerLogo";
+
+    /// <inheritdoc />
+    public string Description => "Registers the dashboard drawer logo with the File Transformation plugin, when it is installed.";
+
+    /// <inheritdoc />
+    public string Category => "Startup Services";
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+        [new TaskTriggerInfo { Type = TaskTriggerInfoType.StartupTrigger }];
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var pluginInterface = FindPluginInterface();
+
+        if (pluginInterface is null)
+        {
+            _logger.LogDebug(
+                "File Transformation is not installed, so the drawer keeps the Material icon");
+            return Task.CompletedTask;
+        }
+
+        var payload = new JObject
+        {
+            ["id"] = TransformationId,
+            ["fileNamePattern"] = "index.html",
+            ["callbackAssembly"] = GetType().Assembly.FullName,
+            ["callbackClass"] = typeof(DrawerLogoPatch).FullName,
+            ["callbackMethod"] = nameof(DrawerLogoPatch.IndexHtml)
+        };
+
+        pluginInterface.GetMethod(RegisterMethod)?.Invoke(null, [payload]);
+        _logger.LogInformation("Registered the drawer logo with File Transformation");
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Finds the other plugin's entry point across every load context.
+    /// </summary>
+    /// <returns>The type, or <c>null</c> when the plugin is not installed.</returns>
+    /// <remarks>
+    /// By reflection because Jellyfin loads each plugin into its own load context, so a
+    /// direct reference would resolve to a type the other plugin does not recognise as
+    /// its own. This is the idiom its README documents.
+    ///
+    /// <para>
+    /// The interface is the same on both lines. Version 3.0 rewrote the plugin around an
+    /// <c>IStartupFilter</c> middleware for Jellyfin 12 and dropped Harmony, but
+    /// <c>RegisterTransformation</c> took no part in that: it only gained a
+    /// <c>RemoveTransformation</c> sibling. So this needs no <c>Compat</c> entry.
+    /// </para>
+    /// </remarks>
+    private static Type? FindPluginInterface()
+    {
+        foreach (var context in AssemblyLoadContext.All)
+        {
+            foreach (var assembly in context.Assemblies)
+            {
+                if (assembly.FullName?.Contains(FileTransformationAssemblyMarker, StringComparison.Ordinal) != true)
+                {
+                    continue;
+                }
+
+                var type = assembly.GetType(PluginInterfaceType);
+                if (type is not null)
+                {
+                    return type;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoRegistration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Injection/DrawerLogoRegistration.cs
@@ -83,7 +83,20 @@ public class DrawerLogoRegistration : IScheduledTask
             ["callbackMethod"] = nameof(DrawerLogoPatch.IndexHtml)
         };
 
-        pluginInterface.GetMethod(RegisterMethod)?.Invoke(null, [payload]);
+        var register = pluginInterface.GetMethod(RegisterMethod);
+
+        if (register is null)
+        {
+            // The plugin is installed but does not expose what its README documents,
+            // which means it changed under us. Worth a warning rather than the silence
+            // of a null conditional, since the outcome looks exactly like success.
+            _logger.LogWarning(
+                "File Transformation is installed but has no {Method}, so the drawer keeps the Material icon",
+                RegisterMethod);
+            return Task.CompletedTask;
+        }
+
+        register.Invoke(null, [payload]);
         _logger.LogInformation("Registered the drawer logo with File Transformation");
 
         return Task.CompletedTask;

--- a/Jellyfin.Plugin.Streamyfin/Injection/FileTransformationPayload.cs
+++ b/Jellyfin.Plugin.Streamyfin/Injection/FileTransformationPayload.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Streamyfin.Injection;
+
+/// <summary>
+/// What the File Transformation plugin hands a callback.
+/// </summary>
+/// <remarks>
+/// Declared here rather than referenced, because that plugin cannot be referenced as
+/// a library: Jellyfin loads each plugin into its own load context, so the same type
+/// coming from two assemblies is two different types. The shape is documented in its
+/// README and is one property.
+/// </remarks>
+public class FileTransformationPayload
+{
+    /// <summary>
+    /// Gets or sets the file as it stands before this callback runs.
+    /// </summary>
+    [JsonPropertyName("contents")]
+    public string? Contents { get; set; }
+}

--- a/Jellyfin.Plugin.Streamyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Streamyfin/Plugin.cs
@@ -102,37 +102,82 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         }
     ];
 
+    /// <summary>
+    /// The label the dashboard shows for the plugin's entry.
+    /// </summary>
+    internal const string MenuDisplayName = "Streamyfin";
+
+    /// <summary>
+    /// The dashboard's icon for that entry.
+    /// </summary>
+    /// <remarks>
+    /// It has to be a Material ligature and cannot be the plugin's own logo.
+    /// <c>PluginDrawerSection.tsx</c> in the web client renders it as
+    /// <c>&lt;Icon&gt;{pageInfo.MenuIcon}&lt;/Icon&gt;</c>, which is the MUI icon font
+    /// component, so anything that is not a glyph name comes out as literal text.
+    /// The logo still shows where an image is allowed, on the plugin catalogue entry,
+    /// through <c>imageUrl</c> in the manifest.
+    ///
+    /// <para>
+    /// <c>smart_display</c> is the closest the font gets: a rounded rectangle with a
+    /// play triangle inside it, which is the logo's silhouette.
+    /// </para>
+    /// </remarks>
+    internal const string MenuIcon = "smart_display";
+
+    /// <summary>
+    /// The plugin's pages, the admin's landing page first.
+    /// </summary>
+    /// <returns>The pages, ordered.</returns>
+    /// <remarks>
+    /// The <c>Other.HomePage</c> setting names the page an administrator wants to land
+    /// on. It has to come first because the dashboard opens the plugin on the first
+    /// page it is given.
+    /// </remarks>
+    internal static List<PluginPageInfo> OrderedPages(List<PluginPageInfo> pages, string? homePageName)
+    {
+        ArgumentNullException.ThrowIfNull(pages);
+
+        if (string.IsNullOrWhiteSpace(homePageName))
+        {
+            return pages;
+        }
+
+        var homePage = pages.Find(page => string.Equals(page.Name, homePageName, StringComparison.Ordinal));
+
+        if (homePage is null)
+        {
+            // A page name that no longer exists, from a renamed page or a typo in the
+            // YAML. Serving the pages in their declared order beats serving none.
+            return pages;
+        }
+
+        List<PluginPageInfo> ordered = [homePage];
+        ordered.AddRange(pages.Where(page => page.Name != homePage.Name));
+
+        return ordered;
+    }
+
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {
-        if (Instance?.Configuration?.Config?.Other?.HomePage != null)
-        {
-            var homePage = _pages().FirstOrDefault(page => string.Equals(page.Name, Instance.Configuration.Config.Other.HomePage, StringComparison.Ordinal));
+        var pages = OrderedPages(_pages(), Instance?.Configuration?.Config?.Other?.HomePage);
 
-            if (homePage != null)
-            {
-                List<PluginPageInfo> pages = [homePage];
-                pages.AddRange(_pages().Where(p => p.Name != homePage.Name));
+        // The dashboard renders one entry per page that asks for one, so only the
+        // landing page asks. Marking every page would put four Streamyfin entries in
+        // the drawer, and marking a fixed one would ignore the home page setting.
+        var landing = pages.Count > 0 ? pages[0] : null;
 
-                foreach (var pluginPageInfo in pages)
-                {
-                    yield return pluginPageInfo;
-                }
-            }
-            else
-            {
-                foreach (var pluginPageInfo in _pages())
-                {
-                    yield return pluginPageInfo;
-                }
-            }
-        }
-        else
+        foreach (var pluginPageInfo in pages)
         {
-            foreach (var pluginPageInfo in _pages())
+            if (ReferenceEquals(pluginPageInfo, landing))
             {
-                yield return pluginPageInfo;
+                pluginPageInfo.DisplayName = MenuDisplayName;
+                pluginPageInfo.EnableInMainMenu = true;
+                pluginPageInfo.MenuIcon = MenuIcon;
             }
+
+            yield return pluginPageInfo;
         }
 
         // region pages

--- a/Jellyfin.Plugin.Streamyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Streamyfin/Plugin.cs
@@ -119,11 +119,13 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// through <c>imageUrl</c> in the manifest.
     ///
     /// <para>
-    /// <c>smart_display</c> is the closest the font gets: a rounded rectangle with a
-    /// play triangle inside it, which is the logo's silhouette.
+    /// <c>devices</c> rather than something closer to the logo's play triangle: every
+    /// glyph of that family reads as the YouTube mark, which this plugin is not. It
+    /// also says what the plugin is for, configuring the Streamyfin app on a user's
+    /// devices, which is more use in a drawer than a decorative shape.
     /// </para>
     /// </remarks>
-    internal const string MenuIcon = "smart_display";
+    internal const string MenuIcon = "devices";
 
     /// <summary>
     /// The plugin's pages, the admin's landing page first.

--- a/Jellyfin.Plugin.Streamyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Streamyfin/Plugin.cs
@@ -167,6 +167,30 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         return ordered;
     }
 
+    /// <summary>
+    /// The page the drawer row points at, which is the page the dashboard opens.
+    /// </summary>
+    /// <remarks>
+    /// Read by <see cref="GetPages"/> to decide which page asks for a menu row, and by
+    /// <c>DrawerLogoPatch</c> to build a selector for that row. Two answers to the same
+    /// question would mean a stylesheet aimed at a row that is not there, which is a
+    /// silent failure: the logo simply never appears.
+    /// </remarks>
+    internal static string? LandingPageName
+    {
+        get
+        {
+            if (Instance is null)
+            {
+                return null;
+            }
+
+            var pages = OrderedPages(Instance._pages(), Instance.Configuration?.Config?.Other?.HomePage);
+
+            return pages.Count > 0 ? pages[0].Name : null;
+        }
+    }
+
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {

--- a/Jellyfin.Plugin.Streamyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Streamyfin/Plugin.cs
@@ -44,7 +44,14 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     private static string? _prefix;
 
     /// <inheritdoc />
-    public override Guid Id => Guid.Parse("1e9e5d38-6e67-4615-8719-e98a5c34f004");
+    public override Guid Id => PluginId;
+
+    /// <summary>
+    /// The plugin's id, as a constant. Jellyfin serves the logo at
+    /// <c>/Plugins/{id}/{version}/Image</c>, and the drawer stylesheet needs it before
+    /// there is an instance to ask.
+    /// </summary>
+    internal static readonly Guid PluginId = Guid.Parse("1e9e5d38-6e67-4615-8719-e98a5c34f004");
 
     /// <summary>
     /// Gets the current plugin instance.


### PR DESCRIPTION
Part of #114.

Streamyfin was reachable from the plugin list and from a direct URL, and nowhere else. Plugins that show up in the dashboard drawer ask for it, through three fields on `PluginPageInfo` this plugin never set:

```csharp
EnableInMainMenu = true,
DisplayName = "Streamyfin",
MenuIcon = "smart_display",
```

## One row, on the page the admin lands on

The drawer renders **one row per page that asks**, so marking all four pages would put four Streamyfin rows in it. Marking a fixed one would ignore the `Other.HomePage` setting, which exists precisely so an administrator can choose where the plugin opens.

So the row sits on whichever page that setting names, which is the page the dashboard opens anyway. One setting, one meaning.

## The ordering moved somewhere it can be tested

The `Other.HomePage` logic lived inside `GetPages`, as three branches doing the same thing. It is now `OrderedPages`, and the case nobody had handled has an answer: a home page naming a page that no longer exists, from a rename or a typo in the YAML, falls back to the declared order rather than serving nothing.

## The icon, and then the real logo

`PluginDrawerSection.tsx` renders it as:

```tsx
<ListItemIcon>
    <Icon>{pageInfo.MenuIcon ?? 'folder'}</Icon>
</ListItemIcon>
```

`<Icon>` is MUI's icon **font** component, so `MenuIcon` can only ever be a Material ligature. `devices` rather than something closer to the logo's play triangle: every glyph of that family reads as the YouTube mark, which this plugin is not. It also says what the plugin is for.

An image has to come from **outside** the plugin's own pages, and File Transformation is what exists for that. It is how Media Bar, Custom Tabs and the rest reach the web client. So the row now also carries the real logo when that plugin is installed:

- **A stylesheet, not a script.** The drawer is a React tree that re-renders. A script rewriting the DOM would have its work thrown away on the next render unless it kept a `MutationObserver` alive. A stylesheet survives every render.
- **Nothing new is embedded.** The image is the one Jellyfin already serves from the plugin's own `meta.json`, at `/Plugins/{id}/{version}/Image`. The version is part of the route, the id alone answers 405. The zip is byte for byte the same set of files.
- **Registration is a startup scheduled task**, not plugin construction, because the other plugin has to be loaded before it can be found and neither controls load order. It looks the entry point up by reflection across every load context, which is the idiom its README documents and is necessary because Jellyfin gives each plugin its own load context.
- **Idempotent.** The transformation runs per request, so the patch checks for its own marker. Appending on every page load would grow the document for as long as the server is up.

### No `Compat` entry, which is worth stating

Media Bar carries three version specific copies of this. Its copies serve 10.10.7, below this plugin's floor. Two things had to be checked rather than assumed, and both came back clean:

- `TaskTriggerInfo` is **identical** on `release-10.11.z` and on `master`.
- File Transformation 3.0 rewrote itself around an `IStartupFilter` middleware for Jellyfin 12 and dropped Harmony, but [`main...v12`](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation/compare/main...v12) leaves `RegisterTransformation(JObject)` untouched. It only gained a `RemoveTransformation` sibling.

So one code path covers both lines.

### What it costs when the plugin is absent

Nothing. File Transformation is not in the official catalogue, it needs `https://www.iamparadox.dev/jellyfin/plugins/manifest.json` added as a repository, and most servers will not have it. Its absence is the normal case: the drawer keeps the Material glyph and the task logs one line at debug.

### The one thing to know

The rule matches on the drawer link, `configurationpage?name=Application`, because the drawer renders nothing else to go on. A page called `Application` belonging to another plugin, and also asking for a drawer row, would pick this up. The cost of that collision is a wrong icon.

## Testing

`dotnet test` on both targets: **89 passed, 0 failed** on `jf11` and on `jf12`, 0 warnings and 0 errors on both. Thirteen new tests, on the page ordering, on there being exactly one menu row, and on the patch: it lands inside the head, patching twice equals patching once, it points at the plugin's own image route, a document with no head is left alone, and nothing to patch is not a failure. That last one matters more than it looks, since a callback that threw would take the web client's entry point down with it.

Deployed to a real Jellyfin 12.0.0, which does **not** have File Transformation installed, so this exercised the absent path:

- The entry comes back from `GET /web/ConfigurationPages?enableInMainMenu=true` alongside the other plugins that have one, `{"MenuIcon": "devices", "DisplayName": "Streamyfin"}`.
- The task appears under Startup Services, runs at startup and completes.
- `/web/index.html` is served untouched.
- No error in the log.

The injected path still needs a server with File Transformation installed to be seen end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Streamyfin dashboard menu metadata, including a display name and device icon.
  * The configured home page now appears first when valid.
  * Invalid or unspecified home-page settings retain the default page order.
  * Only the landing page is shown in the main menu.
  * Added Streamyfin branding to the Jellyfin dashboard drawer with the plugin logo.
  * Logo registration works automatically when the required dashboard transformation support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->