### PR TITLE
feat(settings): serve each caller only what they are allowed to see

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/OutputFilteringTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/OutputFilteringTests.cs
@@ -1,0 +1,168 @@
+using Jellyfin.Plugin.Streamyfin.Configuration;
+using Jellyfin.Plugin.Streamyfin.Configuration.Notifications;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// What each caller is allowed to receive from the configuration endpoints.
+///
+/// This is the fix for the finding at the top of
+/// <c>docs/rewrite/state-of-the-plugin.md</c>: <c>GET config</c> handed the whole
+/// configuration, Seerr admin key included, to every account on the server.
+/// </summary>
+public class OutputFilteringTests
+{
+    private readonly SerializationHelper _serialization = new();
+    private readonly SettingsResolutionService _resolution;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OutputFilteringTests"/> class.
+    /// </summary>
+    public OutputFilteringTests()
+    {
+        _resolution = new SettingsResolutionService(_serialization);
+    }
+
+    private static Config ServerConfig() => new()
+    {
+        settings = new Settings
+        {
+            subtitleSize = new Lockable<int> { locked = true, value = 80 },
+            jellyseerrApiKey = new Lockable<string> { locked = true, value = "a-real-key" },
+            jellyseerrServerUrl = new Lockable<string> { locked = true, value = "https://seerr.example" }
+        },
+        notifications = new Notifications
+        {
+            ItemAdded = new ItemAddedNotificationConfiguration
+            {
+                Enabled = true,
+                EnabledLibraries = ["a-library-id"]
+            }
+        },
+        Other = new Other { HomePage = "Yaml" }
+    };
+
+    /// <summary>
+    /// An administrator receives the configuration untouched. They have to see and edit
+    /// every part of it, credentials included, or they cannot administer anything.
+    /// </summary>
+    [Fact]
+    public void AnAdministratorSeesEverything()
+    {
+        var config = ServerConfig();
+
+        var served = _resolution.ForCaller(config, null, null, isElevated: true);
+
+        Assert.Same(config, served);
+        Assert.Equal("a-real-key", served.settings?.jellyseerrApiKey?.value);
+        Assert.NotNull(served.notifications);
+        Assert.Equal("Yaml", served.Other?.HomePage);
+    }
+
+    /// <summary>
+    /// Everyone else loses the credentials. This is the whole point of the part.
+    /// </summary>
+    [Fact]
+    public void EveryoneElseLosesTheCredentials()
+    {
+        var served = _resolution.ForCaller(ServerConfig(), null, null, isElevated: false);
+
+        Assert.Null(served.settings?.jellyseerrApiKey);
+        Assert.Equal("https://seerr.example", served.settings?.jellyseerrServerUrl?.value);
+    }
+
+    /// <summary>
+    /// And the server side blocks, which are not per user and which the app does not
+    /// read. It takes <c>data.settings</c> and nothing else. Serving a user the list of
+    /// accounts that receive notifications is the same kind of leak as the key, quieter.
+    /// </summary>
+    [Fact]
+    public void EveryoneElseLosesTheServerSideBlocks()
+    {
+        var served = _resolution.ForCaller(ServerConfig(), null, null, isElevated: false);
+
+        Assert.Null(served.notifications);
+        Assert.Null(served.Other);
+        Assert.NotNull(served.settings);
+    }
+
+    /// <summary>
+    /// A caller's own levels are applied on the way out, so what they receive is what
+    /// applies to them rather than what applies to everyone.
+    /// </summary>
+    [Fact]
+    public void ACallersLevelsAreResolvedOnTheWayOut()
+    {
+        var group = new SettingsGroup
+        {
+            Name = "Staff",
+            SettingsJson = _serialization.SerializeToJson(new Settings
+            {
+                subtitleSize = new Lockable<int> { locked = false, value = 60 }
+            })
+        };
+
+        var served = _resolution.ForCaller(ServerConfig(), [group], null, isElevated: false);
+
+        Assert.Equal(60, served.settings?.subtitleSize?.value);
+        Assert.False(served.settings?.subtitleSize?.locked);
+    }
+
+    /// <summary>
+    /// A credential a group tried to hand out is still removed. Redaction is the last
+    /// thing that happens, so no level can put a key back.
+    /// </summary>
+    [Fact]
+    public void AGroupCannotHandOutACredential()
+    {
+        var group = new SettingsGroup
+        {
+            Name = "Trusted",
+            SettingsJson = _serialization.SerializeToJson(new Settings
+            {
+                jellyseerrApiKey = new Lockable<string> { locked = false, value = "handed-out" }
+            })
+        };
+
+        var served = _resolution.ForCaller(ServerConfig(), [group], null, isElevated: false);
+
+        Assert.Null(served.settings?.jellyseerrApiKey);
+    }
+
+    /// <summary>
+    /// An administrator gets the raw configuration rather than their own resolved view,
+    /// because the admin pages edit what the server declares. Serving them a resolved set
+    /// would mean saving it back and writing their group's overrides into the global
+    /// configuration.
+    /// </summary>
+    [Fact]
+    public void AnAdministratorIsNotServedTheirOwnResolvedView()
+    {
+        var group = new SettingsGroup
+        {
+            Name = "Staff",
+            SettingsJson = _serialization.SerializeToJson(new Settings
+            {
+                subtitleSize = new Lockable<int> { locked = false, value = 60 }
+            })
+        };
+
+        var served = _resolution.ForCaller(ServerConfig(), [group], null, isElevated: true);
+
+        Assert.Equal(80, served.settings?.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// A server with no configuration at all serves an empty one rather than throwing.
+    /// </summary>
+    [Fact]
+    public void NoConfigurationIsNotAFailure()
+    {
+        Assert.NotNull(_resolution.ForCaller(null, null, null, isElevated: true));
+        Assert.NotNull(_resolution.ForCaller(null, null, null, isElevated: false));
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -106,13 +106,22 @@ public class StreamyfinController : ControllerBase
     return new ConfigSaveResponse { Error = false };
   }
 
+  /// <summary>
+  /// The configuration, as the calling user should receive it.
+  /// </summary>
+  /// <returns>The configuration.</returns>
+  /// <remarks>
+  /// An administrator gets it untouched. Anyone else gets their settings resolved
+  /// across the three targeting levels, with credentials removed and the server side
+  /// blocks left out. Until P1.4 this served the whole configuration, Seerr admin key
+  /// included, to every account on the server.
+  /// </remarks>
   [HttpGet("config")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
   public ActionResult getConfig()
   {
-    var config = StreamyfinPlugin.Instance!.Configuration.Config;
-    return new JsonStringResult(_serializationHelperService.SerializeToJson(config));
+    return new JsonStringResult(_serializationHelperService.SerializeToJson(ConfigForCaller()));
   }
 
   [HttpGet("config/schema")]
@@ -123,6 +132,10 @@ public class StreamyfinController : ControllerBase
     return new JsonStringResult(SerializationHelper.GetJsonSchema<Config>());
   }
 
+  /// <summary>
+  /// The configuration as YAML, filtered the same way as the JSON.
+  /// </summary>
+  /// <returns>The configuration.</returns>
   [HttpGet("config/yaml")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -130,7 +143,7 @@ public class StreamyfinController : ControllerBase
   {
     return new ConfigYamlRes
     {
-      Value = _serializationHelperService.SerializeToYaml(StreamyfinPlugin.Instance!.Configuration.Config)
+      Value = _serializationHelperService.SerializeToYaml(ConfigForCaller())
     };
   }
   
@@ -512,6 +525,22 @@ public class StreamyfinController : ControllerBase
   // Through the same tolerant read the resolution uses. Nothing validates the JSON
   // on the way in, and a group whose settings cannot be read has to still appear in
   // the list, or an administrator cannot see it to repair it.
+  /// <summary>
+  /// The configuration the caller is allowed to see, with their levels resolved.
+  /// </summary>
+  /// <returns>The configuration.</returns>
+  private Configuration.Config ConfigForCaller()
+  {
+    var callerId = CallerId;
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    return Resolution.ForCaller(
+      StreamyfinPlugin.Instance!.Configuration.Config,
+      database.GetGroupsForUser(callerId),
+      database.GetUserSettingsOverride(callerId),
+      CallerIsApiKey || _userManager.IsAdministrator(callerId));
+  }
+
   private SettingsGroupDto ToDto(SettingsGroup group, List<Guid> members) => new()
   {
     Id = group.Id,

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
@@ -55,6 +55,48 @@ public sealed class SettingsResolutionService(
     }
 
     /// <summary>
+    /// The configuration as one caller should receive it.
+    /// </summary>
+    /// <param name="config">The server's configuration.</param>
+    /// <param name="groups">The caller's groups, least specific first.</param>
+    /// <param name="userOverride">Anything targeted at the caller alone.</param>
+    /// <param name="isElevated">Whether the caller administers this server.</param>
+    /// <returns>
+    /// For an administrator, the configuration untouched: they have to see and edit
+    /// every part of it. For anyone else, the settings resolved for them with the
+    /// credentials removed, and nothing else.
+    /// </returns>
+    /// <remarks>
+    /// This is the fix for the finding at the top of
+    /// <c>docs/rewrite/state-of-the-plugin.md</c>: <c>GET config</c> handed the whole
+    /// configuration, Seerr admin key included, to every account on the server.
+    ///
+    /// <para>
+    /// The notification configuration and the admin's landing page go with it. They are
+    /// server side settings, they cannot be resolved for a caller because they are not
+    /// per user, and the app reads neither: it takes <c>data.settings</c> and nothing
+    /// else. Serving a user the list of accounts that receive notifications is the same
+    /// kind of leak as serving them the key, just quieter.
+    /// </para>
+    /// </remarks>
+    public Config ForCaller(
+        Config? config,
+        IEnumerable<SettingsGroup>? groups,
+        UserSettingsOverride? userOverride,
+        bool isElevated)
+    {
+        if (isElevated)
+        {
+            return config ?? new Config();
+        }
+
+        return new Config
+        {
+            settings = SettingsResolver.Redact(Resolve(config?.settings, groups, userOverride))
+        };
+    }
+
+    /// <summary>
     /// Reads one stored level, tolerating a level that cannot be read.
     /// </summary>
     /// <param name="json">The stored JSON.</param>


### PR DESCRIPTION
Part of #114. Covers **P1.4**. Closes the finding at the top of [`state-of-the-plugin.md`](https://github.com/streamyfin/jellyfin-plugin-streamyfin/blob/develop/docs/rewrite/state-of-the-plugin.md).

`GET config` was guarded by `[Authorize]` alone, so **every account on the server received the entire configuration**. `examples/full.yml` has warned in capitals for months that the Seerr admin key is readable by anyone with an account. It is not a warning any more.

## Who gets what

**An administrator receives it untouched.** They have to see and edit every part of it, credentials included. They also get the **raw** set rather than their own resolved view, which is easy to get wrong: the admin pages save what they load, so serving a resolved set would write their own group's overrides into the global configuration on the next save. There is a test named after that.

**Everyone else** receives their settings, resolved across the three levels from #129, with the credentials removed. Redaction is the **last** step, so no group or user level can hand a key back out. That has a test too, because a targeting system whose overrides can defeat the filter is worse than no filter.

## The notification block goes with the key

Not obvious, so it was checked rather than assumed. `refreshStreamyfinPluginSettings` in `utils/atoms/settings.ts` takes `data.settings` and nothing else: the app never reads `notifications` or `other`.

Both are server side settings, neither can be resolved for a caller because neither is per user, and `notifications` carries enabled library ids, user ids and usernames. Serving a user the list of accounts that receive notifications is the same kind of leak as serving them the key, just quieter. Non administrators now get `settings` and nothing else.

`config/yaml` is filtered the same way. It is the same configuration in another format, and filtering one and not the other would be a hole with a different content type.

## What this costs, deliberately

A non administrator no longer receives `jellyseerrApiKey`, so **the app's passwordless Seerr sign-in stops working for them** and falls back to the password login it already has at `components/settings/Jellyseerr.tsx:91-113`.

That was the decision recorded in `docs/rewrite/log.md`, taken after reading how the app actually uses that key. `loginWithApiKey` does not sign a user in: it resolves the Seerr account with `GET /user/jellyfin/{id}` and every call after that goes out **as the key's owner**, with the user id as a parameter the client chooses. The app's own comment says so at `hooks/useJellyseerr.ts:159`. So any user who could read the key could request as anyone and approve it.

The passwordless path returns properly with [seerr#2244](https://github.com/seerr-team/seerr/pull/2244), using the user's own Jellyfin token rather than an admin key. That pull request is still open.

⚠️ **The Seerr key has to be rotated.** `Jellyseerr.tsx:118` persists it into each device's own settings storage, so filtering it server side does not remove it from the devices that already connected. Without a rotation this is cosmetic for existing installations.

## Testing

`dotnet test` on both targets: **100 passed, 0 failed** on `jf11` and on `jf12`, 0 warnings and 0 errors on both. Seven new tests covering each side of the rule.

Verified on a real Jellyfin with two real accounts rather than only in tests:

| | admin | normal user |
|---|---|---|
| `jellyseerrApiKey` | `SUPER-SECRET-ADMIN-KEY` | **absent** |
| `jellyseerrServerUrl` | present | present |
| `subtitleSize` | `80` locked, the raw global | `60` unlocked, **their group's** |
| `notifications`, `other` | present | **absent** |

`config/yaml` for that user carries neither the key nor the notification block.
