### PR TITLE
feat(settings): move the server level into the plugin's own database

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/GlobalConfigurationStoreTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/GlobalConfigurationStoreTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Xml.Linq;
+using Jellyfin.Plugin.Streamyfin.Configuration;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// The configuration the server declares for everyone, which P1.5 moved out of
+/// Jellyfin's plugin XML and into the plugin's own database, so that all three
+/// targeting levels live in one store.
+/// </summary>
+public class GlobalConfigurationStoreTests : IDisposable
+{
+    private readonly string _directory;
+    private readonly PluginDatabase _db;
+    private readonly SerializationHelper _serialization = new();
+    private readonly GlobalConfigurationStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GlobalConfigurationStoreTests"/> class.
+    /// </summary>
+    public GlobalConfigurationStoreTests()
+    {
+        _directory = TestDirectory.Create();
+        _db = new PluginDatabase(_directory);
+        _store = new GlobalConfigurationStore(_db, _serialization);
+    }
+
+    private static Config Sample(int subtitleSize) => new()
+    {
+        settings = new Settings
+        {
+            subtitleSize = new Lockable<int> { locked = true, value = subtitleSize }
+        }
+    };
+
+    /// <summary>
+    /// A server that has never been configured reads as an empty configuration rather
+    /// than as null, so every caller sees "the server has no opinion".
+    /// </summary>
+    [Fact]
+    public void AnEmptyStoreReadsAsAnEmptyConfiguration()
+    {
+        Assert.NotNull(_store.Current);
+        Assert.Null(_store.Current.settings);
+    }
+
+    /// <summary>
+    /// What is written comes back, through a second store so the answer cannot come from
+    /// the first one's cache.
+    /// </summary>
+    [Fact]
+    public void WhatIsWrittenComesBack()
+    {
+        _store.Save(Sample(120));
+
+        var fresh = new GlobalConfigurationStore(_db, _serialization);
+
+        Assert.Equal(120, fresh.Current.settings?.subtitleSize?.value);
+        Assert.True(fresh.Current.settings?.subtitleSize?.locked);
+    }
+
+    /// <summary>
+    /// A write is visible immediately on the store that made it. The value is held in
+    /// memory between writes, and a stale read after a save would be worse than no cache.
+    /// </summary>
+    [Fact]
+    public void AWriteIsVisibleImmediately()
+    {
+        _store.Save(Sample(80));
+        Assert.Equal(80, _store.Current.settings?.subtitleSize?.value);
+
+        _store.Save(Sample(60));
+        Assert.Equal(60, _store.Current.settings?.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// The import carries the old configuration over.
+    /// </summary>
+    [Fact]
+    public void TheImportCarriesTheOldConfigurationOver()
+    {
+        _store.Import(Sample(42), null);
+
+        Assert.Equal(42, _store.Current.settings?.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// It runs once. Running again would undo every change made since, which on a server
+    /// that has been running for months is the whole configuration.
+    /// </summary>
+    [Fact]
+    public void TheImportRunsOnce()
+    {
+        _store.Import(Sample(42), null);
+        _store.Save(Sample(99));
+
+        var restarted = new GlobalConfigurationStore(_db, _serialization);
+        restarted.Import(Sample(42), null);
+
+        Assert.Equal(99, restarted.Current.settings?.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// A server with nothing in its old file imports an empty configuration rather than
+    /// skipping the import, so the marker is written and it is not retried every start.
+    /// </summary>
+    [Fact]
+    public void ImportingNothingStillMarksItDone()
+    {
+        _store.Import(null, null);
+        _store.Save(Sample(77));
+
+        var restarted = new GlobalConfigurationStore(_db, _serialization);
+        restarted.Import(null, null);
+
+        Assert.Equal(77, restarted.Current.settings?.subtitleSize?.value);
+    }
+
+    /// <summary>
+    /// Settings the old file carries that this version no longer declares are found, so
+    /// they can be reported. The XML deserializer drops them silently and before anything
+    /// here sees them, so an administrator has been running with values that do nothing.
+    /// </summary>
+    /// <remarks>
+    /// The three names are not invented. They are what a real server's configuration file
+    /// still carried while this was written.
+    /// </remarks>
+    [Fact]
+    public void SettingsThisVersionNoLongerDeclaresAreFound()
+    {
+        var document = XDocument.Parse(
+            """
+            <PluginConfiguration>
+              <Config>
+                <settings>
+                  <subtitleSize><locked>false</locked><value>60</value></subtitleSize>
+                  <autoDownload><locked>false</locked><value>true</value></autoDownload>
+                  <downloadMethod><locked>false</locked><value>remux</value></downloadMethod>
+                  <remuxConcurrentLimit><locked>false</locked><value>2</value></remuxConcurrentLimit>
+                </settings>
+              </Config>
+            </PluginConfiguration>
+            """);
+
+        Assert.Equal(
+            new[] { "autoDownload", "downloadMethod", "remuxConcurrentLimit" },
+            GlobalConfigurationStore.UnknownSettingKeys(document));
+    }
+
+    /// <summary>
+    /// A file whose settings this version all declares reports nothing.
+    /// </summary>
+    [Fact]
+    public void AFileThisVersionUnderstandsReportsNothing()
+    {
+        var document = XDocument.Parse(
+            """
+            <PluginConfiguration>
+              <Config>
+                <settings>
+                  <subtitleSize><locked>false</locked><value>60</value></subtitleSize>
+                  <forwardSkipTime><locked>false</locked><value>15</value></forwardSkipTime>
+                </settings>
+              </Config>
+            </PluginConfiguration>
+            """);
+
+        Assert.Empty(GlobalConfigurationStore.UnknownSettingKeys(document));
+    }
+
+    /// <summary>
+    /// A file with no settings block at all is not a failure.
+    /// </summary>
+    [Fact]
+    public void AFileWithNoSettingsIsNotAFailure()
+    {
+        Assert.Empty(GlobalConfigurationStore.UnknownSettingKeys(
+            XDocument.Parse("<PluginConfiguration><Config /></PluginConfiguration>")));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        TestDirectory.Delete(_directory);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -99,9 +99,7 @@ public class StreamyfinController : ControllerBase
       return new ConfigSaveResponse { Error = true, Message = e.ToString() };
     }
 
-    var c = StreamyfinPlugin.Instance!.Configuration;
-    c.Config = p;
-    StreamyfinPlugin.Instance!.UpdateConfiguration(c);
+    StreamyfinPlugin.Instance!.Settings.Save(p);
 
     return new ConfigSaveResponse { Error = false };
   }
@@ -510,7 +508,7 @@ public class StreamyfinController : ControllerBase
     var database = StreamyfinPlugin.Instance!.Database;
 
     var resolved = Resolution.Resolve(
-      StreamyfinPlugin.Instance!.Configuration.Config?.settings,
+      StreamyfinPlugin.Instance!.Settings.Current.settings,
       database.GetGroupsForUser(callerId),
       database.GetUserSettingsOverride(callerId));
 
@@ -535,7 +533,7 @@ public class StreamyfinController : ControllerBase
     var database = StreamyfinPlugin.Instance!.Database;
 
     return Resolution.ForCaller(
-      StreamyfinPlugin.Instance!.Configuration.Config,
+      StreamyfinPlugin.Instance!.Settings.Current,
       database.GetGroupsForUser(callerId),
       database.GetUserSettingsOverride(callerId),
       CallerIsApiKey || _userManager.IsAdministrator(callerId));

--- a/Jellyfin.Plugin.Streamyfin/Configuration/GlobalConfigurationStore.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/GlobalConfigurationStore.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration;
+
+/// <summary>
+/// The configuration the server declares for everyone, and the only way to read or
+/// write it.
+/// </summary>
+/// <remarks>
+/// Named for the level it holds rather than simply <c>ConfigurationStore</c>, which
+/// Jellyfin already has in <c>MediaBrowser.Common.Configuration</c> and which means
+/// something else entirely.
+/// </remarks>
+/// <remarks>
+/// It lived in Jellyfin's plugin configuration XML until P1.5, which left the three
+/// targeting levels in two stores: the global one in a file the server owned, groups
+/// and per user overrides in the plugin's own database. Anything reasoning about all
+/// three had to know about both, and only one of them could be read inside a
+/// transaction.
+///
+/// <para>
+/// The XML is read once and then left alone. It is never written to and never
+/// deleted, so a downgrade to a build that still reads it finds it exactly as it was
+/// left, which is the same rollback path the device token import took in P0.4.
+/// </para>
+/// </remarks>
+public sealed class GlobalConfigurationStore
+{
+    /// <summary>
+    /// The file Jellyfin writes a plugin's configuration to, named after the assembly.
+    /// </summary>
+    internal const string LegacyFileName = "Jellyfin.Plugin.Streamyfin.xml";
+
+    private readonly PluginDatabase _database;
+    private readonly SerializationHelper _serialization;
+    private readonly ILogger<GlobalConfigurationStore>? _logger;
+    private readonly object _gate = new();
+
+    private Config? _cached;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GlobalConfigurationStore"/> class.
+    /// </summary>
+    /// <param name="database">The plugin's database.</param>
+    /// <param name="serialization">The plugin's serializer.</param>
+    /// <param name="logger">Optional logger.</param>
+    public GlobalConfigurationStore(
+        PluginDatabase database,
+        SerializationHelper serialization,
+        ILogger<GlobalConfigurationStore>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        ArgumentNullException.ThrowIfNull(serialization);
+
+        _database = database;
+        _serialization = serialization;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the current configuration.
+    /// </summary>
+    /// <remarks>
+    /// Held in memory between writes. A playback event reads this, and going to SQLite
+    /// on every notification to deserialise a document that changes a few times a year
+    /// would be a poor trade.
+    /// </remarks>
+    public Config Current
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _cached ??= Read();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces the configuration.
+    /// </summary>
+    /// <param name="config">The new configuration.</param>
+    public void Save(Config config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        lock (_gate)
+        {
+            _database.SaveGlobalConfigJson(_serialization.SerializeToJson(config));
+            _cached = config;
+        }
+    }
+
+    /// <summary>
+    /// Carries the configuration over from Jellyfin's plugin XML, once.
+    /// </summary>
+    /// <param name="legacy">The configuration as Jellyfin deserialized it.</param>
+    /// <param name="pluginConfigurationsPath">
+    /// Where Jellyfin keeps plugin configuration files, used only to report the keys it
+    /// dropped. Pass <c>null</c> to skip that.
+    /// </param>
+    public void Import(Config? legacy, string? pluginConfigurationsPath)
+    {
+        var json = _serialization.SerializeToJson(legacy ?? new Config());
+
+        if (!_database.ImportGlobalConfiguration(json))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            _cached = null;
+        }
+
+        _logger?.LogInformation(
+            "Imported the configuration from {File}. The old file is left in place and is not read again",
+            LegacyFileName);
+
+        ReportKeysJellyfinDropped(pluginConfigurationsPath);
+    }
+
+    /// <summary>
+    /// Finds settings in the old file that this plugin no longer declares.
+    /// </summary>
+    /// <param name="pluginConfigurationsPath">Where Jellyfin keeps plugin configuration files.</param>
+    /// <remarks>
+    /// The XML deserializer drops an element it has no property for, silently and before
+    /// anything here sees it. So an administrator who set a key that was later removed or
+    /// renamed has been running with a value that does nothing, and no way to find out.
+    /// Reading the file directly is the only way to say so.
+    ///
+    /// <para>
+    /// It reports rather than guesses. A removed setting has no new home to move a value
+    /// into, and inventing one would be worse than saying the value is not used.
+    /// </para>
+    /// </remarks>
+    private void ReportKeysJellyfinDropped(string? pluginConfigurationsPath)
+    {
+        if (string.IsNullOrWhiteSpace(pluginConfigurationsPath))
+        {
+            return;
+        }
+
+        var path = Path.Combine(pluginConfigurationsPath, LegacyFileName);
+
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        List<string> unknown;
+
+        try
+        {
+            unknown = UnknownSettingKeys(XDocument.Load(path));
+        }
+        catch (Exception ex) when (ex is IOException or System.Xml.XmlException or UnauthorizedAccessException)
+        {
+            _logger?.LogDebug(ex, "Could not read {Path} to check for settings that are no longer used", path);
+            return;
+        }
+
+        if (unknown.Count == 0)
+        {
+            return;
+        }
+
+        _logger?.LogWarning(
+            "{Count} setting(s) in {File} are not used by this version and were not carried over: {Keys}. "
+            + "They were removed or renamed in an earlier release, and the values have not been doing anything",
+            unknown.Count,
+            LegacyFileName,
+            string.Join(", ", unknown));
+    }
+
+    /// <summary>
+    /// The settings in an old configuration file that this version does not declare.
+    /// </summary>
+    /// <param name="document">The parsed file.</param>
+    /// <returns>The key names, in the order the file lists them.</returns>
+    internal static List<string> UnknownSettingKeys(XDocument document)
+    {
+        var settings = document?.Root?.Element("Config")?.Element("settings");
+
+        if (settings is null)
+        {
+            return [];
+        }
+
+        return settings.Elements()
+            .Select(element => element.Name.LocalName)
+            .Where(name => SettingsSchema.Find(name) is null)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private Config Read()
+    {
+        var json = _database.GetGlobalConfigJson();
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Config();
+        }
+
+        try
+        {
+            return _serialization.DeserializeJson<Config>(json) ?? new Config();
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            // Serving an empty configuration beats refusing to start. Every setting then
+            // reads as "the server has no opinion", which is the same as a fresh install.
+            _logger?.LogError(ex, "The stored configuration could not be read. Serving an empty one");
+            return new Config();
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/GlobalConfiguration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/GlobalConfiguration.cs
@@ -1,0 +1,37 @@
+namespace Jellyfin.Plugin.Streamyfin.Db;
+
+/// <summary>
+/// The configuration the server declares for everyone, which is the first of the
+/// three targeting levels.
+/// </summary>
+/// <remarks>
+/// One row. It lived in Jellyfin's own plugin configuration XML until P1.5, which
+/// left the three levels in two different stores: the global one in a file the
+/// server owned, the other two in this database. Anything that had to reason about
+/// all three had to know about both.
+///
+/// <para>
+/// Stored as JSON for the same reason a group's overrides are: the configuration
+/// gains a setting far more often than it gains a shape, and forty five columns
+/// would turn every new setting into a migration.
+/// </para>
+/// </remarks>
+public class GlobalConfiguration
+{
+    /// <summary>
+    /// The only row's key. A fixed value rather than an identity column, so a bug
+    /// that writes twice overwrites rather than quietly giving the server a second
+    /// configuration it will never read.
+    /// </summary>
+    public const string Current = "current";
+
+    /// <summary>
+    /// Gets or sets the row key.
+    /// </summary>
+    public string Id { get; set; } = Current;
+
+    /// <summary>
+    /// Gets or sets the configuration, as JSON.
+    /// </summary>
+    public string ConfigJson { get; set; } = "{}";
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/ImportMarker.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/ImportMarker.cs
@@ -17,6 +17,11 @@ public class ImportMarker
     public const string LegacyDeviceTokens = "legacy-device-tokens";
 
     /// <summary>
+    /// The import of the configuration from Jellyfin's plugin XML.
+    /// </summary>
+    public const string LegacyGlobalConfig = "legacy-global-config";
+
+    /// <summary>
     /// Gets or sets the name of the import.
     /// </summary>
     public string Name { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -175,6 +175,81 @@ public class PluginDatabase
     }
 
     /// <summary>
+    /// Reads the configuration the server declares for everyone.
+    /// </summary>
+    /// <returns>The stored JSON, or <c>null</c> before anything has been written.</returns>
+    public string? GetGlobalConfigJson()
+    {
+        using var context = CreateContext();
+        return context.GlobalConfigurations.AsNoTracking()
+            .FirstOrDefault(c => c.Id == GlobalConfiguration.Current)?.ConfigJson;
+    }
+
+    /// <summary>
+    /// Writes the configuration the server declares for everyone.
+    /// </summary>
+    /// <param name="configJson">The configuration, as JSON.</param>
+    public void SaveGlobalConfigJson(string configJson)
+    {
+        using var context = CreateContext();
+
+        var existing = context.GlobalConfigurations
+            .FirstOrDefault(c => c.Id == GlobalConfiguration.Current);
+
+        if (existing is null)
+        {
+            context.GlobalConfigurations.Add(new GlobalConfiguration
+            {
+                Id = GlobalConfiguration.Current,
+                ConfigJson = configJson
+            });
+        }
+        else
+        {
+            existing.ConfigJson = configJson;
+        }
+
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Carries the configuration over from Jellyfin's plugin XML, once.
+    /// </summary>
+    /// <param name="configJson">The configuration as it stands in the XML, as JSON.</param>
+    /// <returns>True when this call performed the import.</returns>
+    /// <remarks>
+    /// Same shape as the device token import: a marker written in the same transaction
+    /// as the row, so a failure leaves neither and the next start retries. The XML file
+    /// is never written to and never deleted, so downgrading to a build that reads it
+    /// finds it exactly as it was left.
+    /// </remarks>
+    public bool ImportGlobalConfiguration(string configJson)
+    {
+        using var context = CreateContext();
+
+        if (context.ImportMarkers.Any(m => m.Name == ImportMarker.LegacyGlobalConfig))
+        {
+            return false;
+        }
+
+        context.GlobalConfigurations.Add(new GlobalConfiguration
+        {
+            Id = GlobalConfiguration.Current,
+            ConfigJson = configJson
+        });
+
+        context.ImportMarkers.Add(new ImportMarker
+        {
+            Name = ImportMarker.LegacyGlobalConfig,
+            ImportedAt = DateTimeOffset.UtcNow,
+            RowsImported = 1
+        });
+
+        context.SaveChanges();
+        return true;
+    }
+
+    /// <summary>
     /// Gets every settings group.
     /// </summary>
     /// <returns>The groups, in layer order.</returns>

--- a/Jellyfin.Plugin.Streamyfin/Db/StreamyfinDbContext.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/StreamyfinDbContext.cs
@@ -28,6 +28,7 @@ public class StreamyfinDbContext : DbContext
         SettingsGroups = Set<SettingsGroup>();
         SettingsGroupMembers = Set<SettingsGroupMember>();
         UserSettingsOverrides = Set<UserSettingsOverride>();
+        GlobalConfigurations = Set<GlobalConfiguration>();
     }
 
     /// <summary>
@@ -43,6 +44,7 @@ public class StreamyfinDbContext : DbContext
         SettingsGroups = Set<SettingsGroup>();
         SettingsGroupMembers = Set<SettingsGroupMember>();
         UserSettingsOverrides = Set<UserSettingsOverride>();
+        GlobalConfigurations = Set<GlobalConfiguration>();
     }
 
     /// <summary>
@@ -69,6 +71,11 @@ public class StreamyfinDbContext : DbContext
     /// Gets or sets the settings targeted at a single user.
     /// </summary>
     public DbSet<UserSettingsOverride> UserSettingsOverrides { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration the server declares for everyone. One row.
+    /// </summary>
+    public DbSet<GlobalConfiguration> GlobalConfigurations { get; set; }
 
     /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -119,6 +126,13 @@ public class StreamyfinDbContext : DbContext
             entity.ToTable("UserSettingsOverrides");
             entity.HasKey(o => o.UserId);
             entity.Property(o => o.SettingsJson).IsRequired();
+        });
+
+        modelBuilder.Entity<GlobalConfiguration>(entity =>
+        {
+            entity.ToTable("GlobalConfigurations");
+            entity.HasKey(c => c.Id);
+            entity.Property(c => c.ConfigJson).IsRequired();
         });
 
         base.OnModelCreating(modelBuilder);

--- a/Jellyfin.Plugin.Streamyfin/Migrations/20260825202423_AddGlobalConfiguration.Designer.cs
+++ b/Jellyfin.Plugin.Streamyfin/Migrations/20260825202423_AddGlobalConfiguration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Jellyfin.Plugin.Streamyfin.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jellyfin.Plugin.Streamyfin.Migrations
 {
     [DbContext(typeof(StreamyfinDbContext))]
-    partial class StreamyfinDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825202423_AddGlobalConfiguration")]
+    partial class AddGlobalConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.11");

--- a/Jellyfin.Plugin.Streamyfin/Migrations/20260825202423_AddGlobalConfiguration.cs
+++ b/Jellyfin.Plugin.Streamyfin/Migrations/20260825202423_AddGlobalConfiguration.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jellyfin.Plugin.Streamyfin.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGlobalConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GlobalConfigurations",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    ConfigJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GlobalConfigurations", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GlobalConfigurations");
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Streamyfin/Plugin.cs
@@ -30,6 +30,16 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         Instance = this;
         Database = new PluginDatabase(applicationPaths.DataPath, loggerFactory.CreateLogger<PluginDatabase>());
+
+        Settings = new GlobalConfigurationStore(
+            Database,
+            new SerializationHelper(),
+            loggerFactory.CreateLogger<GlobalConfigurationStore>());
+
+        // Reading base.Configuration here is what makes Jellyfin parse the old XML, so
+        // this is the last point at which its contents are available to carry over.
+        Settings.Import(Configuration?.Config, applicationPaths.PluginConfigurationsPath);
+
         _prefix = GetType().Namespace;
     }
 
@@ -37,6 +47,16 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// Gets the plugin's database.
     /// </summary>
     public PluginDatabase Database { get; }
+
+    /// <summary>
+    /// Gets the configuration the server declares for everyone.
+    /// </summary>
+    /// <remarks>
+    /// Reads and writes go here rather than to <c>Configuration</c>, which is Jellyfin's
+    /// XML backed property and stopped being the source of truth in P1.5. The file is
+    /// still on disk, untouched, as the way back.
+    /// </remarks>
+    public GlobalConfigurationStore Settings { get; }
 
     /// <inheritdoc />
     public override string Name => "Streamyfin";
@@ -185,7 +205,7 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 return null;
             }
 
-            var pages = OrderedPages(Instance._pages(), Instance.Configuration?.Config?.Other?.HomePage);
+            var pages = OrderedPages(Instance._pages(), Instance.Settings.Current.Other?.HomePage);
 
             return pages.Count > 0 ? pages[0].Name : null;
         }
@@ -194,7 +214,7 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {
-        var pages = OrderedPages(_pages(), Instance?.Configuration?.Config?.Other?.HomePage);
+        var pages = OrderedPages(_pages(), Instance?.Settings.Current.Other?.HomePage);
 
         // The dashboard renders one entry per page that asks for one, so only the
         // landing page asks. Marking every page would put four Streamyfin entries in

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/Events/BaseEvent.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/Events/BaseEvent.cs
@@ -15,7 +15,7 @@ public abstract class BaseEvent
     private static readonly TimeSpan RecentEventThreshold = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
 
-    protected static Config? Config => StreamyfinPlugin.Instance?.Configuration.Config;
+    protected static Config? Config => StreamyfinPlugin.Instance?.Settings.Current;
     
     protected readonly ILogger _logger;
     protected readonly LocalizationHelper _localization;


### PR DESCRIPTION
Part of #114. Covers **P1.5**.

The three targeting levels lived in **two stores**: the server level in Jellyfin's plugin configuration XML, groups and per user overrides in the plugin's own database. Anything reasoning about all three had to know about both, and only one of them could be read inside a transaction. They are now in one place.

## The migration

The XML is read once, at plugin construction, which is the last point its contents are available. It is then **never written to and never deleted**, so a downgrade to a build that still reads it finds it exactly as it was left.

Same rollback path, same marker mechanism and same failure behaviour as the device token import in P0.4: a failure leaves neither the row nor the marker, so the next start retries.

Stored as JSON for the same reason a group's overrides are. The configuration gains a setting far more often than it gains a shape, and forty five columns would turn every new setting into a migration.

The value is held in memory between writes. A playback event reads it, and going to SQLite on every notification to deserialise a document that changes a few times a year would be a poor trade.

## What the plan assumed, and what was actually true

The plan wrote this part as "one time migration of the old XML config", assuming the earlier parts had replaced the config model. They had not: `Settings` stayed as it was and P1.1 to P1.4 built around it. So the question was whether there was anything to migrate at all.

There was, and it was not the part anyone had written down.

**Jellyfin has been dropping settings silently.** The XML deserializer discards an element it has no property for, before anything in this plugin sees it. An administrator who set a key that was later removed or renamed has been running with a value that does nothing, and no way to find out. A real server's configuration file, checked while writing this, still carries three:

```
downloadMethod    remuxConcurrentLimit    autoDownload
```

The import now reads the file directly and names them in the log. It **reports rather than guesses**: a removed setting has no new home to move a value into, and inventing one would be worse than saying the value is unused.

This also matters going forward. #109 renamed two keys, and any administrator who had set the old ones would have lost them the same way, quietly.

## What changed at the call sites

Five, and they are the whole surface: the page ordering that reads `Other.HomePage`, `BaseEvent` for the notification handlers, and three in the controller. `Configuration`, Jellyfin's XML backed property, is no longer read anywhere.

## Testing

`dotnet test` on both targets: **109 passed, 0 failed** on `jf11` and on `jf12`, 0 warnings and 0 errors on both. Nine new tests, including that the import runs once (running it again on a server that has been up for months would undo the entire configuration) and that importing nothing still writes the marker so it is not retried on every start.

Verified against a **real server's configuration file** rather than a fixture:

| | before | after |
|---|---|---|
| settings set | 18 | **18** |
| `forwardSkipTime` | `15` | `15` |
| `subtitleSize` | `60` | `60` |
| `defaultVideoOrientation` | `7` | `7` |
| `jellyseerrServerUrl` | `https://***.***.******` locked | same |
| `other.homePage` | `Application` | `Application` |

The XML is byte for byte unchanged, `md5` identical before and after. The third migration applied on a database that already had the first two without touching the 34 device tokens in it. And the warning fired, naming exactly the three keys that file carries which this version no longer declares.
