### PR TITLE
feat(api): put every route under a version prefix, keep the old paths

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Streamyfin.Api;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// The routes the plugin serves.
+///
+/// P1.6 put every route under a <c>v1/</c> prefix and kept the path it has always had
+/// as a shim, so that the next change to this surface is a choice rather than a
+/// breaking one. That promise is only worth something if something checks it: a route
+/// dropped from a shim is not a failure anything else notices until an app in the
+/// field hits a 404, months later, on a version nobody is testing.
+/// </summary>
+public class ApiSurfaceTests
+{
+    /// <summary>
+    /// Every path that has ever been served, and still must be.
+    /// </summary>
+    /// <remarks>
+    /// Removing an entry from this list is how a route stops being supported. It should
+    /// take a deliberate edit and a note about which app versions are being cut off,
+    /// rather than falling out of a refactor.
+    /// </remarks>
+    private static readonly string[] _legacyRoutes =
+    [
+        "config",
+        "config/default",
+        "config/resolved",
+        "config/schema",
+        "config/yaml",
+        "device",
+        "device/{deviceId}",
+        "groups",
+        "groups/{id}",
+        "groups/{id}/members",
+        "notification",
+        "users/{userId}/settings"
+    ];
+
+    private static IEnumerable<(MethodInfo Method, string Template)> Routes() =>
+        typeof(StreamyfinController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .SelectMany(
+                method => method.GetCustomAttributes<HttpMethodAttribute>(),
+                (method, attribute) => (method, attribute.Template))
+            .Where(pair => pair.Template is not null)
+            .Select(pair => (pair.method, pair.Template!));
+
+    /// <summary>
+    /// Every route the plugin serves is reachable under the version prefix, so a client
+    /// written today never has to use an unversioned path.
+    /// </summary>
+    [Fact]
+    public void EveryActionIsReachableUnderTheVersionPrefix()
+    {
+        var withoutVersioned = Routes()
+            .GroupBy(r => r.Method)
+            .Where(group => !group.Any(r => r.Template.StartsWith("v1/", StringComparison.Ordinal)))
+            .Select(group => group.Key.Name)
+            .ToArray();
+
+        Assert.Empty(withoutVersioned);
+    }
+
+    /// <summary>
+    /// Every path that was ever served still is. This is the shim promise, and it is the
+    /// whole reason the prefix could be introduced without a flag day.
+    /// </summary>
+    [Fact]
+    public void EveryPathThatWasEverServedStillIs()
+    {
+        var served = Routes().Select(r => r.Template).ToHashSet(StringComparer.Ordinal);
+
+        var missing = _legacyRoutes.Where(route => !served.Contains(route)).ToArray();
+
+        Assert.Empty(missing);
+    }
+
+    /// <summary>
+    /// A shim goes on the same action as the route it stands in for, never on a second
+    /// method that delegates. Two methods drift: one gets a fix, the other does not, and
+    /// the shim quietly stops behaving like the thing it shims.
+    /// </summary>
+    [Fact]
+    public void AShimSharesTheActionItStandsInFor()
+    {
+        foreach (var legacy in _legacyRoutes)
+        {
+            var methods = Routes()
+                .Where(r => r.Template == legacy)
+                .Select(r => r.Method)
+                .Distinct()
+                .ToArray();
+
+            Assert.All(
+                methods,
+                method => Assert.Contains(
+                    Routes().Where(r => r.Method == method),
+                    r => r.Template.StartsWith("v1/", StringComparison.Ordinal)));
+        }
+    }
+
+    /// <summary>
+    /// The names that were singular and should not have been keep working, under both the
+    /// old path and the version prefix, next to the plural they should have had.
+    /// </summary>
+    [Theory]
+    [InlineData("device", "devices")]
+    [InlineData("device/{deviceId}", "devices/{deviceId}")]
+    [InlineData("notification", "notifications")]
+    public void ARenamedRouteKeepsItsOldNameToo(string singular, string plural)
+    {
+        var served = Routes().Select(r => r.Template).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Contains($"v1/{plural}", served);
+        Assert.Contains($"v1/{singular}", served);
+        Assert.Contains(singular, served);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
@@ -83,26 +83,39 @@ public class ApiSurfaceTests
     }
 
     /// <summary>
-    /// A shim goes on the same action as the route it stands in for, never on a second
-    /// method that delegates. Two methods drift: one gets a fix, the other does not, and
-    /// the shim quietly stops behaving like the thing it shims.
+    /// A shim goes on the same action as the route it stands in for, and that action
+    /// answers the same path under the prefix. Asserting only that the action has some
+    /// versioned route would pass for an action carrying an unrelated one.
     /// </summary>
+    /// <remarks>
+    /// Same action rather than a second method that delegates. Two methods drift: one
+    /// gets a fix, the other does not, and the shim quietly stops behaving like the
+    /// thing it shims.
+    /// </remarks>
     [Fact]
-    public void AShimSharesTheActionItStandsInFor()
+    public void AShimAnswersTheSamePathUnderThePrefix()
     {
+        var routes = Routes().ToList();
+
         foreach (var legacy in _legacyRoutes)
         {
-            var methods = Routes()
+            var actions = routes
                 .Where(r => r.Template == legacy)
                 .Select(r => r.Method)
                 .Distinct()
                 .ToArray();
 
-            Assert.All(
-                methods,
-                method => Assert.Contains(
-                    Routes().Where(r => r.Method == method),
-                    r => r.Template.StartsWith("v1/", StringComparison.Ordinal)));
+            Assert.NotEmpty(actions);
+
+            foreach (var action in actions)
+            {
+                var templates = routes
+                    .Where(r => r.Method == action)
+                    .Select(r => r.Template)
+                    .ToArray();
+
+                Assert.Contains($"v1/{legacy}", templates);
+            }
         }
     }
 

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -44,8 +44,32 @@ public class ConfigSaveResponse
 //}
 
 /// <summary>
-/// CollectionImportController.
+/// The plugin's HTTP surface.
 /// </summary>
+/// <remarks>
+/// Every route exists twice: once under <c>v1/</c>, which is canonical, and once at
+/// the path it has always had. The unversioned ones are shims and nothing new should
+/// use them.
+///
+/// <para>
+/// They are extra attributes on the same action rather than separate methods that
+/// delegate. Two methods drift: one gets a fix, the other does not, and the shim
+/// quietly stops behaving like the route it stands in for.
+/// </para>
+///
+/// <para>
+/// The prefix is what makes the next change to this surface a choice rather than a
+/// breaking one. Every app in the field calls the unversioned paths, and until now
+/// renaming any of them would have broken every installed copy at once. That is also
+/// why <c>device</c> and <c>notification</c> keep working alongside the plural names
+/// they should have had.
+/// </para>
+///
+/// <para>
+/// <c>ApiSurfaceTests</c> is what keeps this true, since a route dropped from a shim
+/// is not a failure anything else would notice until an old client hits a 404.
+/// </para>
+/// </remarks>
 [ApiController]
 [Route("streamyfin")]
 public class StreamyfinController : ControllerBase
@@ -81,6 +105,8 @@ public class StreamyfinController : ControllerBase
     _logger.LogInformation("StreamyfinController Loaded");
   }
 
+  [HttpPost("v1/config/yaml")]
+
   [HttpPost("config/yaml")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -114,6 +140,7 @@ public class StreamyfinController : ControllerBase
   /// blocks left out. Until P1.4 this served the whole configuration, Seerr admin key
   /// included, to every account on the server.
   /// </remarks>
+  [HttpGet("v1/config")]
   [HttpGet("config")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -121,6 +148,8 @@ public class StreamyfinController : ControllerBase
   {
     return new JsonStringResult(_serializationHelperService.SerializeToJson(ConfigForCaller()));
   }
+
+  [HttpGet("v1/config/schema")]
 
   [HttpGet("config/schema")]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -134,6 +163,7 @@ public class StreamyfinController : ControllerBase
   /// The configuration as YAML, filtered the same way as the JSON.
   /// </summary>
   /// <returns>The configuration.</returns>
+  [HttpGet("v1/config/yaml")]
   [HttpGet("config/yaml")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -144,6 +174,8 @@ public class StreamyfinController : ControllerBase
       Value = _serializationHelperService.SerializeToYaml(ConfigForCaller())
     };
   }
+  
+  [HttpGet("v1/config/default")]
   
   [HttpGet("config/default")]
   [Authorize]
@@ -160,6 +192,8 @@ public class StreamyfinController : ControllerBase
   /// Post expo push tokens for a specific user and device
   /// </summary>
   /// <param name="deviceToken"></param>
+  [HttpPost("v1/devices")]
+  [HttpPost("v1/device")]
   [HttpPost("device")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -175,6 +209,8 @@ public class StreamyfinController : ControllerBase
   /// Delete expo push tokens for a specific device 
   /// </summary>
   /// <param name="deviceId"></param>
+  [HttpDelete("v1/devices/{deviceId}")]
+  [HttpDelete("v1/device/{deviceId}")]
   [HttpDelete("device/{deviceId}")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -193,6 +229,8 @@ public class StreamyfinController : ControllerBase
   /// </summary>
   /// <param name="notifications"></param>
   /// <returns></returns>
+  [HttpPost("v1/notifications")]
+  [HttpPost("v1/notification")]
   [HttpPost("notification")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -314,6 +352,7 @@ public class StreamyfinController : ControllerBase
   /// Lists the settings groups.
   /// </summary>
   /// <returns>The groups, least specific first, each with its members.</returns>
+  [HttpGet("v1/groups")]
   [HttpGet("groups")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -331,6 +370,7 @@ public class StreamyfinController : ControllerBase
   /// </summary>
   /// <param name="request">The group to create. Its id is ignored.</param>
   /// <returns>The created group.</returns>
+  [HttpPost("v1/groups")]
   [HttpPost("groups")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -365,6 +405,7 @@ public class StreamyfinController : ControllerBase
   /// <param name="id">The group id.</param>
   /// <param name="request">What it should become. Members are left alone.</param>
   /// <returns>The updated group.</returns>
+  [HttpPut("v1/groups/{id}")]
   [HttpPut("groups/{id}")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -404,6 +445,7 @@ public class StreamyfinController : ControllerBase
   /// </summary>
   /// <param name="id">The group id.</param>
   /// <returns>No content.</returns>
+  [HttpDelete("v1/groups/{id}")]
   [HttpDelete("groups/{id}")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -419,6 +461,7 @@ public class StreamyfinController : ControllerBase
   /// <param name="id">The group id.</param>
   /// <param name="request">Who should be in it afterwards.</param>
   /// <returns>The group, with its new members.</returns>
+  [HttpPut("v1/groups/{id}/members")]
   [HttpPut("groups/{id}/members")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status200OK)]
@@ -447,6 +490,7 @@ public class StreamyfinController : ControllerBase
   /// <param name="userId">The Jellyfin user id.</param>
   /// <param name="request">The settings. Send an empty body to clear them.</param>
   /// <returns>No content.</returns>
+  [HttpPut("v1/users/{userId}/settings")]
   [HttpPut("users/{userId}/settings")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -473,6 +517,7 @@ public class StreamyfinController : ControllerBase
   /// </summary>
   /// <param name="userId">The Jellyfin user id.</param>
   /// <returns>No content.</returns>
+  [HttpDelete("v1/users/{userId}/settings")]
   [HttpDelete("users/{userId}/settings")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -499,6 +544,7 @@ public class StreamyfinController : ControllerBase
   /// as elevated here too rather than as an anonymous caller.
   /// </para>
   /// </remarks>
+  [HttpGet("v1/config/resolved")]
   [HttpGet("config/resolved")]
   [Authorize]
   [ProducesResponseType(StatusCodes.Status200OK)]


### PR DESCRIPTION
Part of #114. Covers **P1.6**, and completes **P1**.

The surface grew a route at a time and had **no version at all**, so renaming any of them would have broken every app in the field at once. Every route now answers under `v1/` as well as at the path it has always had.

## The shims are attributes, not methods

```csharp
[HttpGet("v1/config")]
[HttpGet("config")]
public ActionResult getConfig() { ... }
```

Not a second method that delegates. Two methods drift: one gets a fix, the other does not, and the shim quietly stops behaving like the route it stands in for. One action, two paths, no way for them to disagree.

That also makes the names that were wrong fixable at last:

| was | is | old still answers |
|---|---|---|
| `device` | `v1/devices` | yes, and `v1/device` too |
| `device/{deviceId}` | `v1/devices/{deviceId}` | yes |
| `notification` | `v1/notifications` | yes, and it took a list all along |

## A test, because a promise is not a mechanism

`ApiSurfaceTests` enumerates the routes by reflection and asserts three things: every action is reachable under the prefix, every path that was ever served still is, and every shim sits on the same action as its canonical route.

A route dropped from a shim is not a failure anything else notices, until an app in the field hits a 404 months later on a version nobody is testing. Removing an entry from the list in that test is now **how a route stops being supported**: a deliberate edit with a note about which app versions are being cut off, rather than something that falls out of a refactor.

## Noted, not changed

`GET config/schema` has **no authorization attribute** and answers 200 to anyone, found while listing the surface. It is worth stating precisely rather than alarming:

- It carries **no server data**. It is generated from the C# types, so it is identical on every installation.
- The same content sits in `examples/full.yml` in a public repository.
- Closing it would break the admin page, which fetches it with a bare `fetch` at `Pages/shared.js:190` and then hands the URL to Monaco at `Pages/YamlEditor/index.js:182` to fetch again. The fix is to pass the already loaded schema inline instead of a URI.

That JavaScript cannot be exercised from here without a browser signed in to the dashboard, and shipping it unverified would trade a low severity exposure for a broken settings editor. Worth a separate change, with a browser to verify it in.

## Testing

`dotnet test` on both targets: **115 passed, 0 failed** on `jf11` and on `jf12`, 0 warnings and 0 errors on both. Six new tests.

Verified on a real Jellyfin 12.0.0, every path actually called:

```
v1/config 200   v1/config/yaml 200   v1/config/schema 200
v1/config/default 200   v1/config/resolved 200   v1/groups 200
config 200      config/yaml 200      config/schema 200
config/default 200      config/resolved 200      groups 200
v1/devices POST 200     device POST 200
v1/notifications POST 202   notification POST 202
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned `v1` API routes across Streamyfin endpoints.
  * Added plural route aliases for device and notification endpoints.

* **Bug Fixes**
  * Preserved existing unversioned routes for compatibility with integrations using legacy paths.

* **Documentation**
  * Updated API endpoint documentation to cover both versioned and legacy routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->