### PR TITLE
test(settings): retire a not-declared excuse the day its setting is declared

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsParityTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsParityTests.cs
@@ -248,21 +248,99 @@ public class SettingsParityTests
     [Fact]
     public void EveryExcusedDisagreementNamesASettingThatExists()
     {
-        var known = Manifest().Select(entry => entry.Key).ToHashSet(StringComparer.Ordinal);
-
-        var declared = DeclaredKeys();
-
-        var stale = NotDeclared.Keys
-            .Concat(KnownDisagreements.Keys)
-            .Where(key => !known.Contains(key))
-            // Both directions for an ahead-of-the-app key: the plugin dropped it, or the
-            // app caught up and it is no longer ahead of anything.
-            .Concat(DeclaredAheadOfTheApp.Keys.Where(key => !declared.Contains(key) || known.Contains(key)))
-            .ToArray();
+        var stale = StaleExcuses(
+            Manifest().Select(entry => entry.Key).ToHashSet(StringComparer.Ordinal),
+            DeclaredKeys(),
+            NotDeclared.Keys,
+            KnownDisagreements.Keys,
+            DeclaredAheadOfTheApp.Keys);
 
         Assert.True(
             stale.Length == 0,
             "Excused, but no such setting exists:\n  " + string.Join("\n  ", stale));
+    }
+
+    /// <summary>
+    /// The excuses that no longer name a setting in the state they were written for.
+    /// </summary>
+    /// <remarks>
+    /// Taken apart from the lists it reads so the cases it exists to catch can be shown
+    /// on made-up sets. On the real ones every case is, by construction, absent.
+    /// </remarks>
+    private static string[] StaleExcuses(
+        IReadOnlySet<string> known,
+        IReadOnlySet<string> declared,
+        IEnumerable<string> notDeclared,
+        IEnumerable<string> knownDisagreements,
+        IEnumerable<string> declaredAheadOfTheApp) =>
+        // Both directions for a not-declared key: the app dropped it, or the plugin
+        // declared it after all and the reason for leaving it out has been acted on.
+        notDeclared.Where(key => !known.Contains(key) || declared.Contains(key))
+            .Concat(knownDisagreements.Where(key => !known.Contains(key)))
+            // Both directions for an ahead-of-the-app key: the plugin dropped it, or the
+            // app caught up and it is no longer ahead of anything.
+            .Concat(declaredAheadOfTheApp.Where(key => !declared.Contains(key) || known.Contains(key)))
+            .ToArray();
+
+    /// <summary>
+    /// A setting that gets declared retires the entry saying it would not be.
+    /// </summary>
+    /// <remarks>
+    /// Checking only that the key still exists misses this: <c>downloadQuality</c> is
+    /// excused today because the app cannot read it back. The day the app moves and the
+    /// property is written, the reason is spent, and an entry left behind covers the key
+    /// again the moment the declaration is removed.
+    /// </remarks>
+    [Fact]
+    public void ANotDeclaredEntryDiesWhenItsSettingGetsDeclared()
+    {
+        var known = new HashSet<string>(StringComparer.Ordinal) { "downloadQuality" };
+        var notDeclared = new[] { "downloadQuality" };
+
+        Assert.Empty(StaleExcuses(known, new HashSet<string>(), notDeclared, [], []));
+
+        var declared = new HashSet<string>(StringComparer.Ordinal) { "downloadQuality" };
+
+        Assert.Equal(
+            new[] { "downloadQuality" },
+            StaleExcuses(known, declared, notDeclared, [], []));
+    }
+
+    /// <summary>
+    /// An excuse for a key the app stopped reading is stale whichever list it sits in.
+    /// </summary>
+    [Fact]
+    public void AnExcuseForAKeyTheAppDroppedIsStale()
+    {
+        var gone = new[] { "settingTheAppRemoved" };
+        var nothing = new HashSet<string>(StringComparer.Ordinal);
+
+        Assert.Equal(gone, StaleExcuses(nothing, nothing, gone, [], []));
+        Assert.Equal(gone, StaleExcuses(nothing, nothing, [], gone, []));
+    }
+
+    /// <summary>
+    /// A key declared ahead of the app is stale from both sides.
+    /// </summary>
+    /// <remarks>
+    /// This is what retired <c>subtitlesOnMuteAllowRestart</c>: the plugin still declared
+    /// it, and the app caught up, so it was no longer ahead of anything.
+    /// </remarks>
+    [Fact]
+    public void AKeyDeclaredAheadOfTheAppDiesFromEitherSide()
+    {
+        var ahead = new[] { "subtitlesOnMuteAllowRestart" };
+        var declared = new HashSet<string>(StringComparer.Ordinal) { "subtitlesOnMuteAllowRestart" };
+        var nothing = new HashSet<string>(StringComparer.Ordinal);
+
+        // Still ahead: declared here, unknown to the app.
+        Assert.Empty(StaleExcuses(nothing, declared, [], [], ahead));
+
+        // The app caught up.
+        Assert.Equal(ahead, StaleExcuses(declared, declared, [], [], ahead));
+
+        // The plugin dropped the property.
+        Assert.Equal(ahead, StaleExcuses(nothing, nothing, [], [], ahead));
     }
 
     /// <summary>

--- a/docs/rewrite/settings-parity.md
+++ b/docs/rewrite/settings-parity.md
@@ -158,8 +158,10 @@ invoked from. It is the same device as `ApiSurfaceTests._legacyRoutes`, where a
 checked-in list turns a promise into something a build can fail on, and editing
 the list is the deliberate act.
 
-Three rules read it, and two further tests refuse an excuse that has outlived
-either the setting it names or the reason it was written for.
+Three rules read it. The rest of the tests in the file refuse an excuse that has
+outlived either the setting it names or the reason it was written for, from
+whichever side moved: the app dropping a key, the app catching up, or the plugin
+declaring the setting an entry said it would not.
 
 1. **Every key in the manifest is either declared in `Settings.cs` or named in an
    explicit `NotDeclared` set with its reason.** Silence is not an option: a key


### PR DESCRIPTION
Part of #114. Follow up to #134, on a finding CodeRabbit raised outside the diff two minutes before it merged.

`EveryExcusedDisagreementNamesASettingThatExists` asked one question of a `NotDeclared` entry: does the app still read this key. So an entry survived the plugin declaring the very setting it says will not be declared.

`downloadQuality` is the live case. It is excused today because the app types it `{ label, value }` while `normalizePluginValue` only rebuilds `{ key, value }`, so the app side has to move first. The day it moves and the property is written, the reason is spent and nothing says so. Worse, the entry sits there covering the key again the moment the declaration is removed, which is exactly the silence the parity tests exist to break.

## The shape of the fix

An excuse is stale from either side, and each list has two sides:

| List | Stale when |
|---|---|
| `NotDeclared` | the app dropped the key, **or the plugin declared it after all** |
| `KnownDisagreements` | the app dropped the key |
| `DeclaredAheadOfTheApp` | the plugin dropped the property, or the app caught up |

Only the bolded half was missing. `DeclaredAheadOfTheApp` already had both, which is what retired `subtitlesOnMuteAllowRestart` this morning.

## Why it moved into a static

Every case here is, by construction, impossible on the real lists: a test that could demonstrate the bug would be a repository in the state the test forbids. So the computation takes its lists as arguments and three tests drive it with made-up sets, one per direction that can go stale. Reverting the one condition turns `ANotDeclaredEntryDiesWhenItsSettingGetsDeclared` red, which is the only proof that matters for a check of this kind.

## Testing

`make test` on both targets: **151 passing, 0 failed, 0 warnings and 0 errors** on `jf11` and on `jf12`. Three new tests, no production code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings parity checks to detect all mismatches between app and plugin settings, including newly declared plugin settings.

* **Tests**
  * Added coverage for settings removed by the app, added by the plugin, and cases where the app catches up.

* **Documentation**
  * Clarified the documented scenarios covered by settings parity tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->