### PR TITLE
fix(settings): let an admin save a default audio or subtitle language

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/LanguagePreferenceRoundTripTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/LanguagePreferenceRoundTripTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.Streamyfin.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// A name the schema describes has to be a name the config reader accepts.
+///
+/// The two are written by different libraries: the schema comes from NJsonSchema over
+/// the CLR property names, the config is read by YamlDotNet under the camel case
+/// convention. Every settings type happens to agree because its properties are already
+/// lower case, except <c>LanguagePreference</c>, whose members are PascalCase so that
+/// the app can match them against the SDK's <c>CultureDto</c>. The schema therefore
+/// described a name its own reader rejected, and an administrator could not save a
+/// default audio or subtitle language at all:
+///
+/// <code>
+/// Property 'ThreeLetterISOLanguageName' not found on type '...LanguagePreference'
+/// </code>
+///
+/// Nothing surfaced it while the settings page was written by hand, because that page
+/// never offered the two settings. A generated form offers them.
+/// </summary>
+public class LanguagePreferenceRoundTripTests
+{
+    private static string[] SchemaPropertyNames(string definition)
+    {
+        using var document = JsonDocument.Parse(SerializationHelper.GetJsonSchema<Config>());
+
+        return document.RootElement
+            .GetProperty("definitions")
+            .GetProperty(definition)
+            .GetProperty("properties")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Reads a config written with the names the schema describes. This is the whole
+    /// point: a form fills in what the schema tells it to, so a name the reader does not
+    /// know is a setting that cannot be saved.
+    /// </summary>
+    [Fact]
+    public void AConfigWrittenWithTheSchemasNamesIsRead()
+    {
+        var names = SchemaPropertyNames("LanguagePreference");
+
+        var isoCode = Assert.Single(names.Where(name =>
+            name.Contains("ThreeLetter", StringComparison.OrdinalIgnoreCase)));
+        var display = Assert.Single(names.Where(name =>
+            name.Contains("DisplayName", StringComparison.OrdinalIgnoreCase)));
+
+        var config = new SerializationHelper().Deserialize<Config>(
+            $"""
+             settings:
+               defaultAudioLanguage:
+                 locked: false
+                 value:
+                   {isoCode}: fre
+                   {display}: French
+             """);
+
+        var language = config.settings?.defaultAudioLanguage?.value;
+
+        Assert.NotNull(language);
+        Assert.Equal("fre", language!.ThreeLetterISOLanguageName);
+        Assert.Equal("French", language.DisplayName);
+    }
+
+    /// <summary>
+    /// The app matches on the SDK's <c>CultureDto</c>, whose member is
+    /// <c>ThreeLetterISOLanguageName</c>. Whatever the config is written with, what the
+    /// app is served keeps that name, so this is the half that must not move.
+    /// </summary>
+    [Fact]
+    public void TheAppIsStillServedTheCultureDtoNames()
+    {
+        var json = new SerializationHelper().SerializeToJson(new Config
+        {
+            settings = new Configuration.Settings.Settings
+            {
+                defaultAudioLanguage = new Configuration.Settings.Lockable<Configuration.Settings.LanguagePreference>
+                {
+                    value = new Configuration.Settings.LanguagePreference
+                    {
+                        ThreeLetterISOLanguageName = "fre",
+                        DisplayName = "French",
+                    },
+                },
+            },
+        });
+
+        Assert.Contains("\"ThreeLetterISOLanguageName\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"DisplayName\"", json, StringComparison.Ordinal);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
@@ -75,6 +75,16 @@ public class SerializationHelper
     /// <summary>
     /// Generate schema to json
     /// </summary>
+    /// <remarks>
+    /// The names are camel cased to match the config, which YamlDotNet reads under the
+    /// camel case convention. Every settings type agreed already, its properties being
+    /// lower case to begin with, except <c>LanguagePreference</c>: its members are
+    /// PascalCase so the app can match them against the SDK's <c>CultureDto</c>, and the
+    /// schema described a name its own reader rejected. A form fills in what the schema
+    /// tells it to, so that made the two language settings impossible to save. This only
+    /// touches how the schema spells a name; what the app is served is written by
+    /// <see cref="SerializeToJson{T}"/> and keeps the CLR names.
+    /// </remarks>
     public static string GetJsonSchema<T>()
     {
         var settings = new SystemTextJsonSchemaGeneratorSettings
@@ -84,6 +94,7 @@ public class SerializationHelper
 #if DEBUG
         settings.SerializerOptions.WriteIndented = true;
 #endif
+        settings.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         settings.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 
         var schema = JsonSchemaGenerator.FromType<T>(settings);


### PR DESCRIPTION
Part of #114.

An administrator cannot save a default audio or subtitle language. The save fails
with:

```
Property 'ThreeLetterISOLanguageName' not found on type
'...Configuration.Settings.LanguagePreference'
```

## Why

Two libraries name the same thing differently and nothing reconciled them. The
schema comes from NJsonSchema over the CLR property names; the config is read by
YamlDotNet under the camel case convention. Every settings type agrees already,
because its properties are lower case to begin with. `LanguagePreference` is the
one exception: its members are PascalCase so the app can match them against the
SDK's `CultureDto`.

So the schema described `ThreeLetterISOLanguageName` while its own reader only
accepts `threeLetterISOLanguageName`. Anything that fills in what the schema
describes writes a config the server then refuses.

Nothing surfaced it because the settings page was written by hand and never
offered the two settings. It came out of loading a generated form, which offers
every declared setting, against a real server.

## The change

The schema generator camel cases its names, which is the spelling the config
already uses. Measured on the generated document, exactly two names move:

| Before | After |
| --- | --- |
| `ThreeLetterISOLanguageName` | `threeLetterISOLanguageName` |
| `DisplayName` | `displayName` |

The other 131 property names in the document are untouched, which is the point:
every other type was already spelled the way the reader expects.

## What must not move

What the app receives is written by a different serializer and keeps the CLR
names, so it still reads `ThreeLetterISOLanguageName` as `CultureDto` requires.
Renaming the C# members, or putting a `JsonPropertyName` on them, would have
changed that too and broken the app. A test pins it, so this fix cannot drift into
fixing the config by breaking the client.

## Tests

Two, both new:

- a config written with the names the schema describes is read back. This is the
  invariant that was violated, expressed directly rather than as a spelling check,
  so it keeps holding whichever library changes.
- the app is still served the `CultureDto` names.

153 tests green on jf11 and on jf12, 0 warnings on both.

## Note for whoever merges

#136 also edits `GetJsonSchema`. Whichever of the two lands second wants a rebase;
the changes are independent, one adds a naming policy and the other post-processes
the generated document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated configuration schemas so property names use the expected camelCase format.
  * Improved compatibility when saving and loading language preferences.
  * Preserved the correct culture property names in application responses.

* **Tests**
  * Added coverage to verify language preference configuration round-trips correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->