### PR TITLE
docs(settings): say which platform each video player setting decides

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -565,19 +565,35 @@ public class Settings
     [Display(Name = "Inactivity timeout", Description = "Sign out of the TV app after this long with no activity, in milliseconds. 0 never signs out")]
     public Lockable<InactivityTimeout>? inactivityTimeout { get; set; } // = Disabled;
 
+    // Which player runs is decided by getActiveVideoPlayer() in the app, from this
+    // setting and the two below, in an order that depends on the platform. The three
+    // descriptions say which of them actually decides where, because an administrator
+    // setting the wrong one of the three sees nothing happen and has no way to tell.
     [NotNull]
-    [Display(Name = "Native player on Apple TV")]
+    [Display(
+        Name = "Native player on Apple TV",
+        Description = "Apple TV only, and only on tvOS 26 or newer. On by default, so this is the opt out: "
+                      + "while it is on, Apple TV uses the native player whatever Video player says. Turn it "
+                      + "off to hand Apple TV back to Video player.")]
     public Lockable<bool>? nativeVideoPlayerTV { get; set; } // = true;
 
     [NotNull]
-    [Display(Name = "Native player on Android TV")]
+    [Display(
+        Name = "Native player on Android TV",
+        Description = "Android TV only. Off by default, so this is the opt in. Video player set to ExoPlayer "
+                      + "still wins over it.")]
     public Lockable<bool>? nativeVideoPlayerAndroidTV { get; set; } // = false;
 
     // No default on purpose. The app resolves this at runtime through
     // getActiveVideoPlayer() so an existing install keeps the player it has been
     // using. A default here would choose for every device that never has.
     [NotNull]
-    [Display(Name = "Video player", Description = "0 for mpv, 1 for ExoPlayer, which is Android TV only, 2 for the native player")]
+    [Display(
+        Name = "Video player",
+        Description = "Which player the app uses, on the platforms where this setting decides. MPV runs "
+                      + "everywhere. ExoPlayer is Android TV only, and wins there. Native applies to phones "
+                      + "and tablets only: on a TV it is not chosen here but by the two Native player "
+                      + "settings above.")]
     public Lockable<VideoPlayer>? videoPlayer { get; set; }
 
 }


### PR DESCRIPTION
Part of #114.

Three settings decide which video player runs, and `getActiveVideoPlayer` picks between them in an order that depends on the platform. Nothing said so, and the generated form now puts all three in front of an administrator who has no way to tell which one applies to the devices they care about.

| Setting | Where it actually decides |
| --- | --- |
| `videoPlayer` | MPV everywhere. ExoPlayer on Android TV only, and it wins there. **Native only on phones and tablets**, never on a TV. |
| `nativeVideoPlayerTV` | Apple TV only, tvOS 26 or newer. **On by default**, and while on it takes precedence over `videoPlayer` entirely. |
| `nativeVideoPlayerAndroidTV` | Android TV only. Off by default. `videoPlayer: ExoPlayer` still wins over it. |

The two toggles had no description at all. `videoPlayer`'s said "0 for mpv, 1 for ExoPlayer, which is Android TV only, 2 for the native player", which also no longer matches what the form shows, since it renders the enum names rather than the numbers.

Text only, taken from what the app does rather than from the old description. No key, default or enum value moves, so the parity tests are untouched.

This is the visible half of a wider gap: 12 settings are reachable only from the TV settings screen and 27 only from the mobile one, and the plugin presents all of them as if they were universal. Encoding that per setting, and holding it to the app with the parity mechanism, wants its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified video-player settings descriptions for TV, Android TV, and other supported platforms.
  * Added more detailed guidance to help users identify which platform each setting controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->