### PR TITLE
feat(settings): group the admin form into the sections the app uses

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/GeneratedFormSchemaTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/GeneratedFormSchemaTests.cs
@@ -15,6 +15,46 @@ namespace Jellyfin.Plugin.Streamyfin.Tests;
 /// </summary>
 public class GeneratedFormSchemaTests
 {
+    /// <summary>
+    /// Every setting names the section of the form it belongs to. The form renders one
+    /// collapsible section per category rather than ninety two settings in a single
+    /// column, so a setting without one would have nowhere to go. Failing here is the
+    /// point: adding a setting is also deciding where an administrator will look for it.
+    /// </summary>
+    [Fact]
+    public void EverySettingNamesItsSection()
+    {
+        var uncategorised = Configuration.Settings.SettingsSchema.Descriptors
+            .Where(descriptor => string.IsNullOrWhiteSpace(descriptor.Category))
+            .Select(descriptor => descriptor.Key)
+            .ToArray();
+
+        Assert.True(
+            uncategorised.Length == 0,
+            $"no category, so the form has nowhere to put them: {string.Join(", ", uncategorised)}");
+    }
+
+    /// <summary>
+    /// The section reaches the served schema, which is where the page reads it from. The
+    /// page groups on this rather than keeping a list of its own that would drift.
+    /// </summary>
+    [Fact]
+    public void TheSchemaCarriesTheSection()
+    {
+        using var document = JsonDocument.Parse(SerializationHelper.GetJsonSchema<Config>());
+        var settings = SettingsProperties(document);
+
+        foreach (var descriptor in Configuration.Settings.SettingsSchema.Descriptors)
+        {
+            var property = settings.GetProperty(descriptor.Key);
+
+            Assert.True(
+                property.TryGetProperty("x-category", out var category),
+                $"{descriptor.Key} reaches the form without a category");
+            Assert.Equal(descriptor.Category, category.GetString());
+        }
+    }
+
     private static JsonElement SettingsProperties(JsonDocument document) =>
         document.RootElement
             .GetProperty("definitions")

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingScopeAttribute.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingScopeAttribute.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// Where a setting belongs in the generated admin form.
+/// </summary>
+/// <remarks>
+/// The categories are the app's own, read from the settings pages a user navigates
+/// rather than invented here, so an administrator deciding what to lock sees the same
+/// arrangement as the person who will live with it. A form that groups settings its own
+/// way makes the administrator translate between two vocabularies for no gain.
+///
+/// <para>
+/// <see cref="Group"/> subdivides the larger categories. The app puts twenty six
+/// settings on its playback page, which reads as a wall in a form that shows every
+/// platform at once rather than only the device in your hand.
+/// </para>
+///
+/// <para>
+/// One deliberate departure from the app's arrangement: it shows <c>videoPlayer</c> on
+/// the playback page and the two native player toggles on the TV screen, because a user
+/// only ever sees their own device. An administrator configures every platform in one
+/// sitting, so the three settings that decide which player runs are kept together.
+/// </para>
+///
+/// <para>
+/// Which platforms each setting actually reaches is a separate question, and a real one:
+/// locking a phone-only setting on a TV-only fleet changes nothing, and the form cannot
+/// say so yet. It is not recorded here because the derivation is only sound for the
+/// settings the app exposes on a settings screen, and guessing the rest would put a
+/// wrong claim in front of an administrator. It gets its own pass.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class SettingScopeAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SettingScopeAttribute"/> class.
+    /// </summary>
+    /// <param name="category">The section of the form, matching the app's own.</param>
+    public SettingScopeAttribute(string category)
+    {
+        Category = category;
+    }
+
+    /// <summary>
+    /// Gets the section of the form this setting belongs to.
+    /// </summary>
+    public string Category { get; }
+
+    /// <summary>
+    /// Gets or sets the subdivision within the category, for the categories large enough
+    /// to need one. Null leaves the setting directly under its category.
+    /// </summary>
+    public string? Group { get; set; }
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -180,18 +180,22 @@ public class Settings
 {
     [NotNull]
     [Display(Name = "Home view", Description = "Customize the appearance of the apps home page")]
+    [SettingScope("Home and appearance")]
     public Lockable<Home>? home { get; set; }
 
     [NotNull]
     [Display(Name = "Show titles on the home screen", Description = "Show the title under each card on the home screen")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? showHomeTitles { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Show the home backdrop", Description = "Show a backdrop image behind the home screen")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? showHomeBackdrop { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Show the hero carousel", Description = "Show the large rotating carousel at the top of the home screen")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? showHeroCarousel { get; set; } // = true;
 
     // string[] rather than an array of a declared enum, following hiddenLibraries. An
@@ -199,287 +203,355 @@ public class Settings
     // fail to load the day the app adds a section name the plugin does not know yet.
     [NotNull]
     [Display(Name = "Hidden hero sections", Description = "Content groups to keep out of the hero carousel: continueWatching, nextUp, recentlyAdded")]
+    [SettingScope("Home and appearance")]
     public Lockable<string[]>? hiddenHomeHeroSections { get; set; } // = [];
 
     [NotNull]
     [Display(Name = "Hidden hero media types", Description = "Media kinds to keep out of the hero carousel: movie, tv")]
+    [SettingScope("Home and appearance")]
     public Lockable<string[]>? hiddenHomeHeroMediaTypes { get; set; } // = [];
 
     [NotNull]
     [Display(Name = "Merge Next Up and Continue Watching", Description = "Show both in a single row instead of two")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? mergeNextUpAndContinueWatching { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Use episode images in Next Up", Description = "Show the episode's own image rather than the series poster")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? useEpisodeImagesForNextUp { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Show the series poster on an episode", Description = "Use the series poster rather than the episode image on an episode page")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? showSeriesPosterOnEpisode { get; set; } // = false;
 
     // Media Controls
     [NotNull]
     [Display(Name = "Forward skip time", Description = "The amount of time in seconds you want to be able to skip forward during playback")]
+    [SettingScope("Playback controls", Group = "Skip and seek")]
     public Lockable<int>? forwardSkipTime { get; set; } // = 30;
     
     [NotNull]
     [Display(Name = "Rewind skip time", Description = "The amount of time in seconds you want to be able to rewind during playback")]
+    [SettingScope("Playback controls", Group = "Skip and seek")]
     public Lockable<int>? rewindSkipTime { get; set; } // = 10;
 
     // Media segment skip preferences
     [NotNull]
     [Display(Name = "Skip intro", Description = "Automatically skip intros during playback: none, ask, or auto")]
+    [SettingScope("Media segment skip")]
     public Lockable<SegmentSkipMode>? skipIntro { get; set; } // = ask
 
     [NotNull]
     [Display(Name = "Skip outro", Description = "Automatically skip outros/credits during playback: none, ask, or auto")]
+    [SettingScope("Media segment skip")]
     public Lockable<SegmentSkipMode>? skipOutro { get; set; } // = ask
 
     [NotNull]
     [Display(Name = "Skip recap", Description = "Automatically skip recaps during playback: none, ask, or auto")]
+    [SettingScope("Media segment skip")]
     public Lockable<SegmentSkipMode>? skipRecap { get; set; } // = ask
 
     [NotNull]
     [Display(Name = "Skip commercial", Description = "Automatically skip commercials during playback: none, ask, or auto")]
+    [SettingScope("Media segment skip")]
     public Lockable<SegmentSkipMode>? skipCommercial { get; set; } // = ask
 
     [NotNull]
     [Display(Name = "Skip preview", Description = "Automatically skip previews during playback: none, ask, or auto")]
+    [SettingScope("Media segment skip")]
     public Lockable<SegmentSkipMode>? skipPreview { get; set; } // = ask
     
     // Audio
     [NotNull]
     [Display(Name = "Remember audio selection", Description = "Allows you to set the audio language from the previous played item")]
+    [SettingScope("Audio and subtitles", Group = "Audio")]
     public Lockable<bool>? rememberAudioSelections { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Prefer local audio", Description = "Prefer downloaded audio over streaming when it is available")]
+    [SettingScope("Music")]
     public Lockable<bool>? preferLocalAudio { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Audio look-ahead caching", Description = "Pre-cache upcoming tracks for gapless music playback")]
+    [SettingScope("Music")]
     public Lockable<bool>? audioLookaheadEnabled { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Audio look-ahead count", Description = "How many upcoming tracks to pre-cache")]
+    [SettingScope("Music")]
     public Lockable<int>? audioLookaheadCount { get; set; } // = 1;
 
     [NotNull]
     [Display(Name = "Audio max cache size (MB)", Description = "Maximum disk space used for audio look-ahead caching")]
+    [SettingScope("Music")]
     public Lockable<int>? audioMaxCacheSizeMB { get; set; } // = 500;
     // No default for either. The app leaves both null and follows what the server or the
     // media offers until the user picks one, so a value here would choose for everyone.
     [NotNull]
     [Display(Name = "Default audio language", Description = "Language to pick automatically when a title offers it")]
+    [SettingScope("Audio and subtitles", Group = "Audio")]
     public Lockable<LanguagePreference>? defaultAudioLanguage { get; set; }
 
     // Subtitles
     [NotNull]
     [Display(Name = "Default subtitle language", Description = "Subtitle language to pick automatically when a title offers it")]
+    [SettingScope("Audio and subtitles", Group = "Subtitles")]
     public Lockable<LanguagePreference>? defaultSubtitleLanguage { get; set; }
     [NotNull]
     [Display(Name = "Subtitle playback mode", Description = "Setting to determine when subtitles will automatically play during video playback")]
+    [SettingScope("Audio and subtitles", Group = "Subtitles")]
     public Lockable<SubtitlePlaybackMode>? subtitleMode { get; set; }
 
     [NotNull]
     [Display(Name = "Remember subtitle selection", Description = "Allows you to set the subtitle language from the previous played item")]
+    [SettingScope("Audio and subtitles", Group = "Subtitles")]
     public Lockable<bool>? rememberSubtitleSelections { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Subtitles when muted", Description = "Turn subtitles on automatically while the sound is off, and turn them back off when it returns")]
+    [SettingScope("Audio and subtitles", Group = "Subtitles")]
     public Lockable<bool>? subtitlesOnMute { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Allow restarting playback for subtitles when muted", Description = "Some subtitle formats cannot be turned on without the server re-processing the stream, which briefly interrupts playback")]
+    [SettingScope("Audio and subtitles", Group = "Subtitles")]
     public Lockable<bool>? subtitlesOnMuteAllowRestart { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Subtitle scale size", Description = "Adjust the subtitle size during video playback")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<int>? subtitleSize { get; set; } // = 80;
 
     [NotNull]
     [Display(Name = "Subtitle font", Description = "Font family used to render subtitles")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<string>? subtitleFont { get; set; } // = "System";
 
     [NotNull]
     [Display(Name = "Subtitle colour", Description = "Subtitle text colour, as a hex value such as #FFFFFF")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<string>? subtitleColor { get; set; } // = "#FFFFFF";
 
     [NotNull]
     [Display(Name = "Subtitle background", Description = "Draw a box behind the subtitles")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<bool>? subtitleBackground { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Subtitle background opacity", Description = "How opaque the subtitle background is, from 0 to 100")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<int>? subtitleBackgroundOpacity { get; set; } // = 60;
 
     [NotNull]
     [Display(Name = "Subtitle background padding", Description = "Space between the subtitle text and the edge of its background")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<int>? subtitleBackgroundPadding { get; set; } // = 8;
 
     [NotNull]
     [Display(Name = "Subtitle vertical margin", Description = "Distance between the subtitles and the edge of the video")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<int>? subtitleMarginY { get; set; } // = 25;
 
     [NotNull]
     [Display(Name = "Subtitle horizontal alignment", Description = "left, center or right")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<SubtitleAlignX>? subtitleAlignX { get; set; } // = center;
 
     [NotNull]
     [Display(Name = "Subtitle vertical alignment", Description = "top, center or bottom")]
+    [SettingScope("Audio and subtitles", Group = "Subtitle appearance")]
     public Lockable<SubtitleAlignY>? subtitleAlignY { get; set; } // = bottom;
 
     // Other
     [NotNull]
     [Display(Name = "Default video orientation", Description = "Lock orientation during video playback")]
+    [SettingScope("Playback controls", Group = "Quality")]
     public Lockable<OrientationLock>? defaultVideoOrientation { get; set; }
     
     [NotNull]
     [Display(Name = "Safe Area in video controls", Description = "Enable or disable the safe area for video controls")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? safeAreaInControlsEnabled { get; set; } // = true;
     
     [NotNull]
     [Display(Name = "Show custom menu links", Description = "Show custom menu links in Jellyfin's web configuration")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? showCustomMenuLinks { get; set; } // = false;
     
     [NotNull]
     [Display(Name = "Hidden libraries", Description = "Enter all library Ids you want hidden from users")]
+    [SettingScope("Home and appearance")]
     public Lockable<string[]>? hiddenLibraries { get; set; } // = [];
 
     [NotNull]
     [Display(Name = "Disable haptic feedback")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? disableHapticFeedback { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Default playback quality")]
+    [SettingScope("Playback controls", Group = "Quality")]
     public Lockable<Bitrate?>? defaultBitrate { get; set; } // = null/MAX;
 
     [NotNull]
     [Display(Name = "Max auto play episode count")]
+    [SettingScope("Playback controls", Group = "Autoplay and resume")]
     public Lockable<int>? maxAutoPlayEpisodeCount { get; set; } // = 3
 
     [NotNull]
     [Display(Name = "Auto play next episode", Description = "Automatically start the next episode when one finishes")]
+    [SettingScope("Playback controls", Group = "Autoplay and resume")]
     public Lockable<bool>? autoPlayNextEpisode { get; set; } // = true
 
     [NotNull]
     [Display(Name = "Default playback speed", Description = "The default video playback speed multiplier")]
+    [SettingScope("Playback controls", Group = "Quality")]
     public Lockable<double>? defaultPlaybackSpeed { get; set; } // = 1.0
 
     // Swipe controls
 
     [NotNull]
     [Display(Name = "Horizontal swipe to skip")]
+    [SettingScope("Playback controls", Group = "Skip and seek")]
     public Lockable<bool>? enableHorizontalSwipeSkip { get; set; } // = true 
     
      [NotNull]
     [Display(Name = "Left side brightness control")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? enableLeftSideBrightnessSwipe { get; set; } // = true
 
     [NotNull]
     [Display(Name = "Right side volume control")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? enableRightSideVolumeSwipe { get; set; } // = true
 
     [NotNull]
     [Display(Name = "Hide volume slider", Description = "Hide the volume slider in the video controls")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? hideVolumeSlider { get; set; } // = false
 
     [NotNull]
     [Display(Name = "Hide brightness slider", Description = "Hide the brightness slider in the video controls")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? hideBrightnessSlider { get; set; } // = false
 
     [NotNull]
     [Display(Name = "Double tap to seek")]
+    [SettingScope("Playback controls", Group = "Skip and seek")]
     public Lockable<bool>? enableDoubleTapToSeek { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Hold to speed up")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? enableHoldToSpeed { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Hold to speed rate", Description = "Playback speed multiplier while the screen is held")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<double>? holdToSpeedRate { get; set; } // = 2.0;
 
     [NotNull]
     [Display(Name = "Pinch to zoom")]
+    [SettingScope("Playback controls", Group = "Gestures")]
     public Lockable<bool>? enablePinchToZoom { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Ask before resuming", Description = "Ask whether to resume or start over instead of resuming straight away")]
+    [SettingScope("Playback controls", Group = "Autoplay and resume")]
     public Lockable<bool>? showResumeDialog { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Auto play episode count", Description = "How many episodes have played automatically so far. 0 starts the count over")]
+    [SettingScope("Advanced")]
     public Lockable<int>? autoPlayEpisodeCount { get; set; } // = 0;
 
     [NotNull]
     [Display(Name = "Play the default audio track", Description = "Play the track the server marks as default rather than the last one chosen")]
+    [SettingScope("Audio and subtitles", Group = "Audio")]
     public Lockable<bool>? playDefaultAudioTrack { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Audio transcoding mode", Description = "How surround audio is handled: auto, stereo, 5.1 or passthrough")]
+    [SettingScope("Audio and subtitles", Group = "Audio")]
     public Lockable<AudioTranscodeMode>? audioTranscodeMode { get; set; } // = auto;
 
     // region Plugins
     // Jellyseerr
     [NotNull]
     [Display(Name = "Jellyseerr Server URL", Description = "Enter the url for your jellyseerr server. **Jellyfin authentication is required**")]
+    [SettingScope("Plugins", Group = "Jellyseerr")]
     public Lockable<string>? jellyseerrServerUrl { get; set; }
 
     [NotNull]
     [Display(Name = "Jellyseerr API Key", Description = "Seerr admin API key (Seerr Settings > General). Lets Streamyfin sign each user in to Seerr without a password. **Warning: every authenticated Jellyfin user on this server can read this key and it grants full admin access to the Seerr API — only set it if you trust all of your users.** Requires a Seerr version with the /user/jellyfin/{id} route.")]
     [Secret]
+    [SettingScope("Plugins", Group = "Jellyseerr")]
     public Lockable<string>? jellyseerrApiKey { get; set; }
 
     // Marlin Search
     [NotNull]
     [Display(Name = "Default search engine", Description = "Enter the search engine you want to use in streamyfin")]
+    [SettingScope("Plugins", Group = "Marlin search")]
     public Lockable<SearchEngine>? searchEngine { get; set; } // = SearchEngine.Jellyfin;
     
     [NotNull]
     [Display(Name = "Marlin server URL", Description = "Enter the URL for your Marlin server")]
+    [SettingScope("Plugins", Group = "Marlin search")]
     public Lockable<string>? marlinServerUrl { get; set; }
 
     // Streamystats
     [NotNull]
     [Display(Name = "Streamystats Server URL", Description = "Enter the URL for your Streamystats server")]
+    [SettingScope("Plugins", Group = "Streamystats")]
     public Lockable<string>? streamyStatsServerUrl { get; set; }
     
     [NotNull]
     [Display(Name = "Streamystats Movie Recommendations", Description = "Allow Streamystats to provide movie recommendations using your watch history")]
+    [SettingScope("Plugins", Group = "Streamystats")]
     public Lockable<bool>? streamyStatsMovieRecommendations { get; set; }
     
     [NotNull]
     [Display(Name = "Streamystats Series Recommendations", Description = "Allow Streamystats to provide series recommendations using your watch history")]
+    [SettingScope("Plugins", Group = "Streamystats")]
     public Lockable<bool>? streamyStatsSeriesRecommendations { get; set; }
     
     [NotNull]
     [Display(Name = "Streamystats Promoted Watchlists", Description = "Allow Streamystats to promote watchlists using your watch history")]
+    [SettingScope("Plugins", Group = "Streamystats")]
     public Lockable<bool>? streamyStatsPromotedWatchlists { get; set; }
 
     [NotNull]
     [Display(Name = "Hide watchlists tab", Description = "Hide the Streamystats watchlists tab in the app")]
+    [SettingScope("Plugins", Group = "Streamystats")]
     public Lockable<bool>? hideWatchlistsTab { get; set; }
 
     // KefinTweaks
     [NotNull]
     [Display(Name = "KefinTweaks watchlist integration", Description = "Enable the KefinTweaks watchlist integration")]
+    [SettingScope("Plugins", Group = "KefinTweaks")]
     public Lockable<bool>? useKefinTweaks { get; set; }
 
     [NotNull]
     [Display(Name = "Popular lists", Description = "Show popular lists from the Popular Lists plugin")]
+    [SettingScope("Plugins", Group = "KefinTweaks")]
     public Lockable<bool>? usePopularPlugin { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Awards from Wikidata", Description = "Show awards fetched from Wikidata on a title's page")]
+    [SettingScope("Plugins", Group = "KefinTweaks")]
     public Lockable<bool>? wikidataAwardsEnabled { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "OpenSubtitles", Description = "Allow searching OpenSubtitles for subtitles during playback")]
+    [SettingScope("Plugins", Group = "OpenSubtitles")]
     public Lockable<bool>? openSubtitlesEnabled { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Sign in to Jellyseerr automatically", Description = "Sign the user in to Jellyseerr without asking, when the server allows it")]
+    [SettingScope("Plugins", Group = "Jellyseerr")]
     public Lockable<bool>? autoLoginJellyseerr { get; set; } // = true;
 
     // No default. The app leaves this undefined and follows the device language until
@@ -487,18 +559,22 @@ public class Settings
     // never chose.
     [NotNull]
     [Display(Name = "App language", Description = "Language code the app uses, such as fr or en")]
+    [SettingScope("Home and appearance")]
     public Lockable<string>? preferedLanguage { get; set; }
 
     [NotNull]
     [Display(Name = "Media list collections", Description = "Collection ids to offer as media lists in the app")]
+    [SettingScope("Plugins", Group = "KefinTweaks")]
     public Lockable<string[]>? mediaListCollectionIds { get; set; } // = [];
 
     [NotNull]
     [Display(Name = "Download live activity", Description = "Show download progress on the lock screen")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? showDownloadLiveActivity { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "HEVC for Chromecast", Description = "Offer HEVC to a Chromecast, which only some models decode")]
+    [SettingScope("Playback controls", Group = "Quality")]
     public Lockable<bool>? enableH265ForChromecast { get; set; } // = false;
 
     // The five mpv settings and deviceProfile describe what a device can do rather than
@@ -507,10 +583,12 @@ public class Settings
     // TV box with less memory to spare.
     [NotNull]
     [Display(Name = "mpv cache", Description = "Whether mpv caches ahead: auto, yes or no")]
+    [SettingScope("Playback controls", Group = "mpv")]
     public Lockable<MpvCacheMode>? mpvCacheEnabled { get; set; } // = auto;
 
     [NotNull]
     [Display(Name = "mpv cache seconds", Description = "How many seconds mpv caches ahead")]
+    [SettingScope("Playback controls", Group = "mpv")]
     public Lockable<int>? mpvCacheSeconds { get; set; } // = 10;
 
     // No default on purpose: the app's own default is not one number. It is 150 MB on a
@@ -518,51 +596,62 @@ public class Settings
     // number would push it to both and flatten a distinction the app makes deliberately.
     [NotNull]
     [Display(Name = "mpv demuxer buffer (MB)", Description = "Read-ahead buffer size. The app defaults to 150 MB on a phone and 75 MB on Android TV, so one number here applies to both")]
+    [SettingScope("Playback controls", Group = "mpv")]
     public Lockable<int>? mpvDemuxerMaxBytes { get; set; }
 
     // No default, same reason: 50 MB on a phone, 30 MB on Android TV.
     [NotNull]
     [Display(Name = "mpv back buffer (MB)", Description = "How much already-played data mpv keeps. The app defaults to 50 MB on a phone and 30 MB on Android TV")]
+    [SettingScope("Playback controls", Group = "mpv")]
     public Lockable<int>? mpvDemuxerMaxBackBytes { get; set; }
 
     [NotNull]
     [Display(Name = "mpv video output driver", Description = "gpu-next or gpu. gpu is the fallback for devices where gpu-next misbehaves")]
+    [SettingScope("Playback controls", Group = "mpv")]
     public Lockable<MpvVoDriver>? mpvVoDriver { get; set; } // = gpu-next;
 
     [NotNull]
     [Display(Name = "Device profile", Description = "Which playback profile the app reports: Expo, Native or Old")]
+    [SettingScope("Advanced")]
     public Lockable<DeviceProfile>? deviceProfile { get; set; } // = Expo;
 
     [NotNull]
     [Display(Name = "Crash reporting", Description = "Whether the app sends crash reports. Turning it off for everyone is a reasonable policy; turning it on takes a consent decision away from the user")]
+    [SettingScope("Plugins", Group = "Diagnostics")]
     public Lockable<bool>? sentryEnabled { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "OpenSubtitles API key", Description = "An OpenSubtitles key for every user on this server. Setting it overwrites the key a user entered themselves, which may be one they pay for")]
     [Secret]
+    [SettingScope("Plugins", Group = "OpenSubtitles")]
     public Lockable<string>? openSubtitlesApiKey { get; set; }
     // endregion Plugins
     
     // Misc.
     [NotNull]
     [Display(Name = "Library options", Description = "Customize how you want Streamyfin's library tab to look")]
+    [SettingScope("Advanced")]
     public Lockable<LibraryOptions>? libraryOptions { get; set; }
 
     // TV
     [NotNull]
     [Display(Name = "TV typography scale", Description = "Text size on the TV app: small, default, large or extraLarge")]
+    [SettingScope("Home and appearance")]
     public Lockable<TVTypographyScale>? tvTypographyScale { get; set; } // = default;
 
     [NotNull]
     [Display(Name = "TV theme music", Description = "Play a series theme music while browsing it on TV")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? tvThemeMusicEnabled { get; set; } // = true;
 
     [NotNull]
     [Display(Name = "Hide the remote session button")]
+    [SettingScope("Home and appearance")]
     public Lockable<bool>? hideRemoteSessionButton { get; set; } // = false;
 
     [NotNull]
     [Display(Name = "Inactivity timeout", Description = "Sign out of the TV app after this long with no activity, in milliseconds. 0 never signs out")]
+    [SettingScope("Security")]
     public Lockable<InactivityTimeout>? inactivityTimeout { get; set; } // = Disabled;
 
     // Which player runs is decided by getActiveVideoPlayer() in the app, from this
@@ -575,6 +664,7 @@ public class Settings
         Description = "Apple TV only, and only on tvOS 26 or newer. On by default, so this is the opt out: "
                       + "while it is on, Apple TV uses the native player whatever Video player says. Turn it "
                       + "off to hand Apple TV back to Video player.")]
+    [SettingScope("Playback controls", Group = "Video player")]
     public Lockable<bool>? nativeVideoPlayerTV { get; set; } // = true;
 
     [NotNull]
@@ -582,6 +672,7 @@ public class Settings
         Name = "Native player on Android TV",
         Description = "Android TV only. Off by default, so this is the opt in. Video player set to ExoPlayer "
                       + "still wins over it.")]
+    [SettingScope("Playback controls", Group = "Video player")]
     public Lockable<bool>? nativeVideoPlayerAndroidTV { get; set; } // = false;
 
     // No default on purpose. The app resolves this at runtime through
@@ -594,6 +685,7 @@ public class Settings
                       + "everywhere. ExoPlayer is Android TV only, and wins there. Native applies to phones "
                       + "and tablets only: on a TV it is not chosen here but by the two Native player "
                       + "settings above.")]
+    [SettingScope("Playback controls", Group = "Video player")]
     public Lockable<VideoPlayer>? videoPlayer { get; set; }
 
 }

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -189,7 +189,7 @@ public class Settings
     public Lockable<bool>? showHomeTitles { get; set; } // = true;
 
     [NotNull]
-    [Display(Name = "Show the home backdrop", Description = "Show a backdrop image behind the home screen")]
+    [Display(Name = "Show the home backdrop", Description = "Apple TV and Android TV only. Show a backdrop image behind the home screen")]
     [SettingScope("Home and appearance")]
     public Lockable<bool>? showHomeBackdrop { get; set; } // = true;
 
@@ -222,7 +222,7 @@ public class Settings
     public Lockable<bool>? useEpisodeImagesForNextUp { get; set; } // = false;
 
     [NotNull]
-    [Display(Name = "Show the series poster on an episode", Description = "Use the series poster rather than the episode image on an episode page")]
+    [Display(Name = "Show the series poster on an episode", Description = "Apple TV and Android TV only. Use the series poster rather than the episode image on an episode page")]
     [SettingScope("Home and appearance")]
     public Lockable<bool>? showSeriesPosterOnEpisode { get; set; } // = false;
 
@@ -640,7 +640,7 @@ public class Settings
     public Lockable<TVTypographyScale>? tvTypographyScale { get; set; } // = default;
 
     [NotNull]
-    [Display(Name = "TV theme music", Description = "Play a series theme music while browsing it on TV")]
+    [Display(Name = "TV theme music", Description = "Apple TV and Android TV only. Play a series theme music while browsing it")]
     [SettingScope("Home and appearance")]
     public Lockable<bool>? tvThemeMusicEnabled { get; set; } // = true;
 

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsSchema.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsSchema.cs
@@ -17,6 +17,8 @@ namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
 /// <param name="IsSecret">Whether the value is a credential. See <see cref="SecretAttribute"/>.</param>
 /// <param name="DisplayName">Label for a form, when the property carries one.</param>
 /// <param name="Description">Help text for a form, when the property carries one.</param>
+/// <param name="Category">The section of the form it belongs to. See <see cref="SettingScopeAttribute"/>.</param>
+/// <param name="Group">The subdivision within that category, when it has one.</param>
 public sealed record SettingDescriptor(
     string Key,
     PropertyInfo Property,
@@ -24,7 +26,9 @@ public sealed record SettingDescriptor(
     bool IsLockable,
     bool IsSecret,
     string? DisplayName,
-    string? Description);
+    string? Description,
+    string? Category,
+    string? Group);
 
 /// <summary>
 /// The settings, as data.
@@ -95,6 +99,7 @@ public static class SettingsSchema
 
         var valueType = lockable ? underlying.GetGenericArguments()[0] : underlying;
         var display = property.GetCustomAttribute<DisplayAttribute>();
+        var scope = property.GetCustomAttribute<SettingScopeAttribute>();
 
         return new SettingDescriptor(
             Key: property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name,
@@ -103,6 +108,8 @@ public static class SettingsSchema
             IsLockable: lockable,
             IsSecret: property.GetCustomAttribute<SecretAttribute>() is not null,
             DisplayName: display?.Name,
-            Description: display?.Description);
+            Description: display?.Description,
+            Category: scope?.Category,
+            Group: scope?.Group);
     }
 }

--- a/Jellyfin.Plugin.Streamyfin/Pages/Application/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Application/index.html
@@ -2,22 +2,61 @@
      data-require="emby-button,emby-select,emby-checkbox"
      data-controller="__plugin/Application.js">
     <style>
-        /* json-editor wraps the settings in a root object of its own, whose header reads
-           "root" and whose controls edit the raw JSON. Both are noise on a settings page.
-           The child combinator keeps this to the root: every setting keeps its own header. */
-        #settings-editor > .je-object__container > .je-header,
-        #settings-editor > .je-object__container > .je-object__controls { display: none; }
-        #settings-editor > .je-object__container > .je-indented-panel {
+        /* One collapsible section per category, closed to start with. Ninety two settings
+           in one column ran to eighteen thousand pixels, which is not a page anyone reads. */
+        #settings-editor .sf-section {
+            border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+        }
+        #settings-editor .sf-section > summary {
+            cursor: pointer;
+            padding: 0.75em 0.25em;
+            font-size: 1.15em;
+            font-weight: 600;
+            list-style-position: inside;
+        }
+        #settings-editor .sf-section > summary:hover {
+            background: rgba(255, 255, 255, 0.04);
+        }
+        #settings-editor .sf-group {
+            margin: 1em 0 0.35em;
+            padding-left: 0.25em;
+            font-size: 0.95em;
+            font-weight: 600;
+            opacity: 0.75;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        /* json-editor wraps each section's settings in a root object of its own, whose
+           header reads "root" and whose controls edit the raw JSON. Both are noise here.
+           The child combinator keeps this to those roots: every setting keeps its header. */
+        #settings-editor .je-object__container > .je-header,
+        #settings-editor .je-object__container > .je-object__controls { display: none; }
+        #settings-editor .je-indented-panel {
             margin: 0;
             padding: 0;
             border: none;
         }
+        /* A setting is itself an object, so put its own header back. */
+        #settings-editor .je-indented-panel .je-object__container > .je-header { display: block; }
 
-        /* Each setting renders as a collapsible object; tighten its spacing to the
-           dashboard's and let the emby input classes the schema carries do the rest. */
-        #settings-editor .je-object__container { margin-bottom: 0.6em; }
+        /* Density. A setting was taking about two hundred pixels: a bordered box, a header,
+           a collapse button and generous padding, for what is usually one input and a lock. */
+        #settings-editor .je-object__container {
+            margin: 0 0 0.35em;
+            padding: 0.35em 0.5em;
+        }
         #settings-editor .je-header > label { font-weight: 600; }
-        #settings-editor .je-desc { opacity: 0.75; margin: 0.2em 0 0.6em; }
+        #settings-editor .je-desc {
+            opacity: 0.7;
+            margin: 0.1em 0 0.4em;
+            font-size: 0.9em;
+        }
+        #settings-editor .je-indented-panel .je-indented-panel {
+            border-left: 2px solid rgba(255, 255, 255, 0.08);
+            padding-left: 0.6em;
+        }
+        #settings-editor .json-editor-btntype-toggle { padding: 0 0.4em; }
     </style>
 
     <div class="content-primary" style="max-width: 53em; height: 100%">

--- a/Jellyfin.Plugin.Streamyfin/Pages/Application/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Application/index.js
@@ -1,7 +1,7 @@
 // The Application page is json-editor reading the schema the plugin serves, rather than a
 // form written by hand a control at a time. Everything specific to a setting travels in the
-// schema (see SerializationHelper.ShapeForGeneratedForm); this file only mounts the editor,
-// seeds it with the stored config and writes the admin's edits back.
+// schema (see SerializationHelper.ShapeForGeneratedForm); this file only mounts the editors,
+// seeds them with the stored config and writes the admin's edits back.
 
 // json-editor labels the "Max" playback-quality option as the empty string, and the hand
 // written page always turned a blank field into null, so the value round-trips blank <-> null:
@@ -26,8 +26,8 @@ const toConfig = (settings) => mapSettingValues(settings, (value) => (value === 
 // unset setting into a set one. So a save keeps the settings that were already in the config and
 // adds only the ones the admin actually changed.
 //
-// The comparison is against the editor's own first value, not against what it was seeded with.
-// The editor adds a default for every key the config was missing, so a key absent from the
+// The comparison is against the editors' own first value, not against what they were seeded
+// with. An editor adds a default for every key the config was missing, so a key absent from the
 // config compares against undefined and would count as changed, which is how a save came to
 // carry all 92 settings and then be rejected by the server.
 const settingsToPersist = (loaded, initial, edited) => {
@@ -44,15 +44,59 @@ const settingsToPersist = (loaded, initial, edited) => {
     return result;
 };
 
-// The Settings subtree of the served Config schema, made a schema in its own right so the
-// editor renders the settings and nothing else. Its definitions stay at the root so the
-// references inside the settings still resolve.
-const buildFormSchema = (schema) => ({
+// The settings, arranged the way the app arranges them: one section per category, subdivided
+// where a category is large enough to need it. Both come from the schema, so the page holds no
+// list of its own to drift. Object key order is the order the settings are declared in, which
+// is the order the sections come out in.
+const sectionsFrom = (schema) => {
+    const properties = schema?.definitions?.Settings?.properties ?? {};
+    const sections = new Map();
+
+    for (const [key, spec] of Object.entries(properties)) {
+        const category = spec["x-category"] ?? "Other";
+        const group = spec["x-group"] ?? "";
+
+        if (!sections.has(category)) {
+            sections.set(category, new Map());
+        }
+
+        const groups = sections.get(category);
+        if (!groups.has(group)) {
+            groups.set(group, []);
+        }
+
+        groups.get(group).push(key);
+    }
+
+    return sections;
+};
+
+// A schema of its own for one section, so its editor renders those settings and nothing else.
+// The definitions stay at the root, or the references inside the settings stop resolving.
+const schemaFor = (schema, keys) => ({
     type: "object",
     title: "",
-    properties: schema?.definitions?.Settings?.properties ?? {},
-    definitions: schema?.definitions ?? {},
+    properties: Object.fromEntries(keys.map((key) => [key, schema.definitions.Settings.properties[key]])),
+    definitions: schema.definitions,
 });
+
+const pick = (values, keys) => Object.fromEntries(
+    keys.filter((key) => key in (values ?? {})).map((key) => [key, values[key]]));
+
+const EDITOR_OPTIONS = {
+    theme: "html",
+    iconlib: null,
+    disable_edit_json: true,
+    disable_properties: true,
+    no_additional_properties: true,
+    // Every declared setting has to render, whether or not the config already carries it:
+    // reaching a setting the admin never set is the whole point. Left optional, json-editor
+    // draws only the keys present in the stored config, which on one server was 20 of 92, and
+    // disable_properties removes the button that would add the rest. Writing them all back is
+    // prevented by settingsToPersist, not here.
+    required_by_default: true,
+    show_errors: "never",
+};
 
 export default function (view) {
     view.addEventListener("viewshow", () => {
@@ -64,42 +108,60 @@ export default function (view) {
             }
 
             const mount = document.getElementById("settings-editor");
-            let editor = null;
-            let initial = null;
+            const editors = [];
 
             const render = () => {
                 const schema = shared.getJsonSchema();
-                if (!schema || editor) return;
+                if (!schema || editors.length) return;
 
-                editor = new window.JSONEditor(mount, {
-                    schema: buildFormSchema(schema),
-                    startval: toForm(shared.getConfig()?.settings),
-                    theme: "html",
-                    iconlib: null,
-                    disable_edit_json: true,
-                    disable_properties: true,
-                    no_additional_properties: true,
-                    // Every declared setting has to render, whether or not the config
-                    // already carries it: reaching a setting the admin never set is the
-                    // whole point. Left optional, json-editor draws only the keys present
-                    // in the stored config, which on this server was 20 of 92, and
-                    // disable_properties removes the button that would add the rest.
-                    // Writing them all back is prevented by settingsToPersist, not here.
-                    required_by_default: true,
-                    show_errors: "never",
-                });
+                const seed = toForm(shared.getConfig()?.settings);
+                mount.textContent = "";
 
-                // What the editor holds once it has filled in every setting the config was
-                // missing. A save compares against this, so an untouched default is not a change.
-                editor.on("ready", () => {
-                    initial = editor.getValue();
-                });
+                for (const [category, groups] of sectionsFrom(schema)) {
+                    const section = document.createElement("details");
+                    section.className = "sf-section";
+
+                    const heading = document.createElement("summary");
+                    const count = [...groups.values()].reduce((total, keys) => total + keys.length, 0);
+                    heading.textContent = `${category} (${count})`;
+                    section.appendChild(heading);
+
+                    for (const [group, keys] of groups) {
+                        if (group) {
+                            const label = document.createElement("h3");
+                            label.className = "sf-group";
+                            label.textContent = group;
+                            section.appendChild(label);
+                        }
+
+                        const host = document.createElement("div");
+                        section.appendChild(host);
+
+                        const editor = new window.JSONEditor(host, {
+                            ...EDITOR_OPTIONS,
+                            schema: schemaFor(schema, keys),
+                            startval: pick(seed, keys),
+                        });
+
+                        // What the editor holds once it has filled in every setting the config
+                        // was missing. A save compares against this, so an untouched default is
+                        // not counted as a change.
+                        const entry = { editor, initial: null };
+                        editor.on("ready", () => {
+                            entry.initial = editor.getValue();
+                        });
+                        editors.push(entry);
+                    }
+
+                    mount.appendChild(section);
+                }
             };
 
             const dispose = () => {
-                editor?.destroy();
-                editor = null;
-                initial = null;
+                for (const { editor } of editors) {
+                    editor.destroy();
+                }
+                editors.length = 0;
             };
 
             // Schema and config are loaded once, before this import resolves, so the first
@@ -107,16 +169,23 @@ export default function (view) {
             render();
             shared.setOnSchemaUpdatedListener("application", render);
             shared.setOnConfigUpdatedListener("application", () => {
-                if (!editor) render();
+                if (!editors.length) render();
             });
 
             shared.keyedEventListener(document.getElementById("save-settings-btn"), "click", (e) => {
                 e.preventDefault();
-                if (!editor) return;
+                if (!editors.length) return;
+
+                const edited = {};
+                const initial = {};
+                for (const entry of editors) {
+                    const value = entry.editor.getValue();
+                    Object.assign(edited, value);
+                    Object.assign(initial, entry.initial ?? value);
+                }
 
                 const config = shared.getConfig() ?? {};
-                const settings = toConfig(
-                    settingsToPersist(config.settings, initial ?? editor.getValue(), editor.getValue()));
+                const settings = toConfig(settingsToPersist(config.settings, initial, edited));
 
                 shared.setConfig({ ...config, settings });
                 shared.saveConfig();

--- a/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/SerializationHelper.cs
@@ -99,7 +99,40 @@ public class SerializationHelper
 
         var schema = JsonSchemaGenerator.FromType<T>(settings);
         MarkSecrets(schema);
+        MarkCategories(schema);
         return ShapeForGeneratedForm(schema.ToJson());
+    }
+
+    /// <summary>
+    /// Carries each setting's section of the form, as <c>x-category</c> and
+    /// <c>x-group</c>.
+    /// </summary>
+    /// <remarks>
+    /// The form renders one collapsible section per category rather than ninety two
+    /// settings in a single column. The values come from <see cref="SettingsSchema"/>,
+    /// so a new setting picks its section with one attribute and nothing here changes.
+    /// </remarks>
+    private static void MarkCategories(JsonSchema schema)
+    {
+        foreach (var candidate in SchemasCarryingSettings(schema))
+        {
+            foreach (var descriptor in SettingsSchema.Descriptors)
+            {
+                if (descriptor.Category is null
+                    || !candidate.Properties.TryGetValue(descriptor.Key, out var property))
+                {
+                    continue;
+                }
+
+                property.ExtensionData ??= new Dictionary<string, object?>();
+                property.ExtensionData["x-category"] = descriptor.Category;
+
+                if (descriptor.Group is not null)
+                {
+                    property.ExtensionData["x-group"] = descriptor.Group;
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/docs/rewrite/admin-ui-generated.md
+++ b/docs/rewrite/admin-ui-generated.md
@@ -192,6 +192,51 @@ wants its own change and its own test rather than being folded in here.
 - **A json-editor theme beyond the emby classes already injected.** No new theme
   work.
 
+## Why there is no "platforms" field on a setting
+
+Not every setting applies everywhere, and the obvious next step after grouping was
+to record which platforms each one reaches and show it in the form. It was
+investigated and **deliberately dropped**. The reason is written here so nobody
+spends another afternoon rediscovering it.
+
+There are two different questions, and they give different answers:
+
+1. **Where can a user change it?** Derivable, by following which of the app's
+   settings pages exposes the key. It gives a clean answer for 84 of the 95 keys.
+2. **Where does it take effect?** What an administrator actually needs, since they
+   are deciding what to impose on a fleet.
+
+They do not agree, and the first one is the misleading one:
+
+| Setting | Offered on | Read by |
+|---|---|---|
+| `hiddenLibraries` | mobile pages only | `Home.tv.tsx`, `TVLibraries.tsx` |
+| `defaultBitrate` | mobile pages only | `ItemContent.tv.tsx` |
+| `streamyStatsMovieRecommendations` | mobile pages only | `Home.tv.tsx` |
+
+A badge reading "mobile only" on any of those would be a lie an administrator has
+no way to check, which is worse than saying nothing at all.
+
+The second question is not derivable either. Most settings are read by shared
+player and provider files, `buildNativePlayerConfig.ts`, `useVideoNavigation.ts`,
+`InactivityProvider.tsx`, whose platform is a runtime property rather than
+something the source states. And the derivation that looked cleanest still
+produced a wrong answer: it called `preferedLanguage` TV only, when it is the
+app's language setting and `_layout.tsx` and `AppLanguageSelector.tsx` read it.
+
+**What is done instead**: the settings that are verifiably platform specific say
+so in their own description, in prose, one at a time. Only a handful qualify, and
+each was checked rather than derived:
+
+- `showHomeBackdrop`, `showSeriesPosterOnEpisode` and `tvThemeMusicEnabled`, where
+  nothing outside a `.tv.*` file or `useTVThemeMusic.ts` reads them.
+- `videoPlayer` and the two native player toggles, which #138 already describes,
+  including that `Native` is a phone and tablet value and that a TV chooses
+  through the two toggles instead.
+
+If a future setting is genuinely platform specific, the answer is a sentence in
+its `[Display]` description, not a field that claims to know for all 95.
+
 ## Delivery
 
 Branch `refonte/p3-1-schema-form`, one pull request onto `develop`, squash, body


### PR DESCRIPTION
Part of #114. Follows #136 on readability.

The generated form put all ninety two settings in one column, about eighteen thousand pixels of it, with no way to find anything. It now renders **one collapsible section per category, closed to start with**, and subdivides the larger ones.

## The categories are the app's, not mine

They were derived by following which of the app's own settings pages exposes each key, through the component graph, rather than assigned by hand. An administrator deciding what to lock then sees the same arrangement as the person who will live with it, instead of translating between two vocabularies.

| Section | Settings |
| --- | --- |
| Playback controls | 28, subdivided into Video player, Skip and seek, Gestures, Autoplay and resume, Quality, mpv |
| Audio and subtitles | 18, subdivided into Audio, Subtitles, Subtitle appearance |
| Plugins | 17, subdivided into Jellyseerr, Streamystats, Marlin search, KefinTweaks, OpenSubtitles, Diagnostics |
| Home and appearance | 16 |
| Media segment skip | 5 |
| Music | 4 |
| Advanced | 3 |
| Security | 1 |

## How it holds

- `SettingScopeAttribute` carries the category and its optional group.
- `SettingsSchema` reads it, so the schema carries `x-category` and `x-group` and the page keeps no list of its own to drift from the class.
- A test fails the build when a setting has no category. Adding a setting is therefore also deciding where an administrator will look for it, the same device as the parity test's `NotDeclared`.

Density too: a setting was taking about two hundred pixels for what is usually one input and a lock.

## One deliberate departure

The app shows `videoPlayer` on its playback page and the two native player toggles on its TV screen, because a user only ever sees their own device. An administrator configures every platform in one sitting, so the three settings that decide which player runs are kept together. #138 gave them descriptions that explain the platform nuance.

## Platform scope: investigated, and deliberately not shipped

The obvious next step was to record which platforms each setting reaches and show it. It was tried and dropped, because it cannot be done honestly. Two questions look like one:

- **Where can a user change it?** Derivable, 84 of 95 keys. Also misleading: `hiddenLibraries`, `defaultBitrate` and the Streamystats toggles are offered on the mobile pages only, and `Home.tv.tsx` and `ItemContent.tv.tsx` read them all the same. A "mobile only" badge on those would be a lie an administrator cannot check.
- **Where does it take effect?** What an administrator actually needs, and not derivable: most settings are read by shared player and provider files whose platform is a runtime property, not something the source states.

The cleanest derivation also produced a wrong answer, calling `preferedLanguage` TV only when it is the app's language setting.

So the settings that are verifiably platform specific say so in their own description instead, one at a time, each checked rather than derived: `showHomeBackdrop`, `showSeriesPosterOnEpisode` and `tvThemeMusicEnabled` are TV only, and #138 already covers the three that decide the video player. The reasoning is in the dossier so nobody repeats the investigation.

## Draft until it has been seen

161 tests green, 0 warnings on both targets. But the grouping is JS, and the last round taught me that only a real dashboard proves this half: three defects in #136 were invisible to the unit tests. Marked draft until it has been loaded on a real Jellyfin 12, which is waiting on my connectivity to the test server rather than on the code.
