### PR TITLE
fix(notifications): send through a configured client, and stop reading a refusal as a delivery

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/NotificationTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/NotificationTests.cs
@@ -19,11 +19,13 @@ public class NotificationTests(ITestOutputHelper output)
     /// <summary>
     /// These two reach the real Expo endpoint, so they need a client that really connects.
     /// The plugin itself is handed a configured one by the server; this keeps these tests
-    /// doing exactly what they did before the client was injected.
+    /// doing what they did before the client was injected, with the same thirty second
+    /// timeout, so a network stall fails the run rather than holding CI for a hundred.
     /// </summary>
     private sealed class PlainHttpClientFactory : System.Net.Http.IHttpClientFactory
     {
-        public System.Net.Http.HttpClient CreateClient(string name) => new();
+        public System.Net.Http.HttpClient CreateClient(string name) =>
+            new() { Timeout = System.TimeSpan.FromSeconds(30) };
     }
 
     // Replace with your own android emulator / ios simulator token

--- a/Jellyfin.Plugin.Streamyfin.Tests/NotificationTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/NotificationTests.cs
@@ -12,7 +12,19 @@ namespace Jellyfin.Plugin.Streamyfin.Tests;
 public class NotificationTests(ITestOutputHelper output)
 {
     private static readonly SerializationHelper _serializationHelper = new();
-    private readonly NotificationHelper _notificationHelper = new(null, null, _serializationHelper);
+
+    private readonly NotificationHelper _notificationHelper =
+        new(null, null, _serializationHelper, new PlainHttpClientFactory());
+
+    /// <summary>
+    /// These two reach the real Expo endpoint, so they need a client that really connects.
+    /// The plugin itself is handed a configured one by the server; this keeps these tests
+    /// doing exactly what they did before the client was injected.
+    /// </summary>
+    private sealed class PlainHttpClientFactory : System.Net.Http.IHttpClientFactory
+    {
+        public System.Net.Http.HttpClient CreateClient(string name) => new();
+    }
 
     // Replace with your own android emulator / ios simulator token
     // Do not use a real devices token. If you do, you can invalidate the token by re-installing streamyfin on your device.

--- a/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading;

--- a/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Streamyfin.PushNotifications;
+using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// How the plugin talks to Expo.
+///
+/// It used to build a <c>new HttpClient()</c> for every notification, which opens a
+/// connection pool per send and never reuses one, and it read the body as a ticket list
+/// without looking at the status code, so a rejection came back looking like a delivery
+/// with no tickets. Both are what these tests hold in place.
+/// </summary>
+public class PushNotificationClientTests
+{
+    private const string ExpoSendUrl = "https://exp.host/--/api/v2/push/send";
+
+    private static NotificationHelper HelperFor(StubHandler handler) =>
+        new(null, null, new SerializationHelper(), new StubHttpClientFactory(handler));
+
+    private static ExpoNotificationRequest ANotification() =>
+        new() { Title = "A title", Body = "A body", To = ["ExponentPushToken[xxx]"] };
+
+    /// <summary>
+    /// The send goes through the client the factory hands out. A client built inline gets
+    /// its own connection pool every time, which is the socket exhaustion this avoids, and
+    /// it also carries the default hundred second timeout inside an event handler.
+    /// </summary>
+    [Fact]
+    public async Task TheSendGoesThroughTheInjectedClient()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, """{"data":[{"status":"ok","id":"1"}]}""");
+
+        var response = await HelperFor(handler).Send(ANotification());
+
+        Assert.Equal(1, handler.Calls);
+        Assert.Equal(new Uri(ExpoSendUrl), handler.LastRequest?.RequestUri);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest?.Method);
+        Assert.NotNull(response);
+        Assert.Single(response!.Data);
+    }
+
+    /// <summary>
+    /// A rejected send is not read as a delivery. Expo answers 429 when it is being asked
+    /// too often, and the body is not a ticket list; parsing it anyway produced a response
+    /// with an empty ticket list, which every caller here treats as "sent".
+    /// </summary>
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.BadRequest)]
+    public async Task ARejectedSendIsNotReadAsSuccess(HttpStatusCode status)
+    {
+        var handler = new StubHandler(status, "<html>rate limited</html>");
+
+        var response = await HelperFor(handler).Send(ANotification());
+
+        Assert.Null(response);
+    }
+
+    /// <summary>
+    /// The client is asked for by name, so its timeout and headers are configured once at
+    /// registration rather than per call site.
+    /// </summary>
+    [Fact]
+    public async Task TheClientIsAskedOfTheFactoryByName()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, """{"data":[]}""");
+        var factory = new StubHttpClientFactory(handler);
+
+        await new NotificationHelper(null, null, new SerializationHelper(), factory).Send(ANotification());
+
+        Assert.Equal(NotificationHelper.ExpoClientName, factory.RequestedName);
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastRequest = request;
+
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public string? RequestedName { get; private set; }
+
+        public HttpClient CreateClient(string name)
+        {
+            RequestedName = name;
+            return new HttpClient(handler, disposeHandler: false);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Streamyfin/PluginServiceRegistrator.cs
@@ -1,3 +1,4 @@
+using System;
 using Jellyfin.Data.Events.Users;
 using Jellyfin.Plugin.Streamyfin.PushNotifications;
 using Jellyfin.Plugin.Streamyfin.PushNotifications.Events;
@@ -22,6 +23,12 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<LocalizationHelper>();
         serviceCollection.AddSingleton<SerializationHelper>();
         serviceCollection.AddSingleton<NotificationHelper>();
+
+        // The client that talks to Expo. Thirty seconds rather than the hundred an
+        // HttpClient defaults to: a push send happens inside an event handler the server is
+        // waiting on, so a hung request should give up long before that.
+        serviceCollection
+            .AddHttpClient(NotificationHelper.ExpoClientName, client => client.Timeout = TimeSpan.FromSeconds(30));
 
         // Event listeners
         serviceCollection.AddScoped<IEventConsumer<SessionStartedEventArgs>, SessionStartEvent>();

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
@@ -14,18 +14,27 @@ namespace Jellyfin.Plugin.Streamyfin.PushNotifications;
 
 public class NotificationHelper
 {
+    /// <summary>
+    /// The name of the configured client that talks to Expo. Its timeout lives with the
+    /// registration in <c>PluginServiceRegistrator</c> rather than at this call site.
+    /// </summary>
+    public const string ExpoClientName = "streamyfin-expo";
+
     private readonly ILogger<NotificationHelper>? _logger;
     private readonly SerializationHelper _serializationHelper;
     private readonly IUserManager? _userManager;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     public NotificationHelper(
         ILoggerFactory? loggerFactory,
         IUserManager? userManager,
-        SerializationHelper serializationHelper)
+        SerializationHelper serializationHelper,
+        IHttpClientFactory httpClientFactory)
     {
         _logger = loggerFactory?.CreateLogger<NotificationHelper>();
         _userManager = userManager;
         _serializationHelper = serializationHelper;
+        _httpClientFactory = httpClientFactory;
     }
 
     /// <summary>
@@ -35,8 +44,16 @@ public class NotificationHelper
     /// <returns>Expo's response, or null when there is nobody to send to.</returns>
     public async Task<ExpoNotificationResponse?> SendToAdmins(params Notification[] notifications)
     {
+        // Declared nullable and dereferenced all the same. A null here threw inside an event
+        // handler the server was waiting on, rather than skipping a notification.
+        if (_userManager is null)
+        {
+            _logger?.LogWarning("No user manager available, cannot work out which admins to notify");
+            return null;
+        }
+
         var adminTokens = _userManager.GetAdminTokens();
-        
+
         _logger?.LogInformation("Attempting to send {0} notifications to admins", notifications.Length);
 
         // No admin tokens found.
@@ -99,7 +116,13 @@ public class NotificationHelper
     {
         _logger?.LogInformation("Attempting to send {0} notifications to admins", notifications.Length);
 
-        var excludedIds = excludedUserIds ?? Array.Empty<Guid>().ToList(); 
+        if (_userManager is null)
+        {
+            _logger?.LogWarning("No user manager available, cannot work out which admins to notify");
+            return null;
+        }
+
+        var excludedIds = excludedUserIds ?? Array.Empty<Guid>().ToList();
         var adminTokens = _userManager.GetAdminDeviceTokens()
             .FindAll(deviceToken => !excludedIds.Contains(deviceToken.UserId))
             .Select(deviceToken => deviceToken.Token)
@@ -129,11 +152,30 @@ public class NotificationHelper
     private async Task<ExpoNotificationResponse?> SendNotificationToExpo(string serializedRequest)
     {
         _logger?.LogDebug("Preparing to send notification");
-        using HttpClient client = new();
-        var httpRequest = GetHttpRequestMessage(serializedRequest);
-        var rawResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
+
+        // From the factory, never a new HttpClient per send: one built inline gets its own
+        // connection pool every time and carries the default hundred second timeout, inside
+        // an event handler that Jellyfin is waiting on.
+        var client = _httpClientFactory.CreateClient(ExpoClientName);
+        using var httpRequest = GetHttpRequestMessage(serializedRequest);
+        using var rawResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
+
+        // Expo answers 429 when it is being asked too often, and the body is then not a
+        // ticket list. Read as one anyway it yields a response with no tickets, which every
+        // caller reads as a delivery that simply had nothing to report.
+        if (!rawResponse.IsSuccessStatusCode)
+        {
+            var body = await rawResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            _logger?.LogError(
+                "Expo refused the notification with {Status}: {Body}",
+                (int)rawResponse.StatusCode,
+                body.Length > 500 ? body[..500] : body);
+
+            return null;
+        }
+
         _logger?.LogDebug("Received response");
-        httpRequest.Dispose();
 
         return await rawResponse.Content.ReadFromJsonAsync<ExpoNotificationResponse>().ConfigureAwait(false);
     }


### PR DESCRIPTION
Part of #114. Covers **P4.1**.

Three defects on the path every push notification takes.

## A new HttpClient per send

`SendNotificationToExpo` did `using HttpClient client = new()` on every notification. That opens a connection pool per send and reuses none of them, and it carries HttpClient's default **hundred second** timeout, inside an event handler the server is waiting on.

The client now comes from `IHttpClientFactory` under a name, so its timeout, thirty seconds, is set once at registration rather than at the call site.

## A refusal read as a delivery

The response body was parsed as a ticket list without looking at the status code. Expo answers **429** when it is being asked too often, and the body is then not a ticket list. Read as one anyway it produced a response with an empty ticket list, which every caller here treats as a delivery that simply had nothing to report. A rejection is now logged with its status and a truncated body, and returns null.

## A nullable dereferenced

`IUserManager` is declared `IUserManager?` and was dereferenced regardless, so a null threw inside an event handler rather than skipping the notification.

## Tests

Five new ones, against a stubbed handler passed through the factory: the send goes through the injected client and reaches the Expo URL, a 429, a 502 and a 400 each come back as null rather than a success, and the client is asked for by name.

166 tests green, 0 warnings on both targets.

The two existing notification tests reach the real Expo endpoint over the network, so they keep a client that really connects and what they exercise is unchanged. Worth saying out loud though: they make the suite depend on an external service, which is its own problem for another day.

## Found while reading, not fixed here

`SendToAll` puts every device token on the server into the `to` field of a single message. Expo caps a message at 100 recipients, so past that the send fails for the remainder. That belongs with P4.3, along with batching, honouring `Retry-After` and backoff. P4.2, reading receipts and pruning `DeviceNotRegistered` tokens, builds on this client and comes next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push-notification reliability with a configured HTTP client and timeout.
  * Failed notification requests now return a safe failure result instead of being treated as successful deliveries.
  * Added clearer logging for rejected notification requests.
  * Admin notifications now safely handle unavailable user-management services.

* **Tests**
  * Added coverage for successful and rejected push-notification requests, client configuration, and missing service scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->