### PR TITLE
feat(targeting): give groups and per user overrides a screen

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/PluginPagesTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PluginPagesTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MediaBrowser.Common.Plugins;
@@ -19,6 +20,58 @@ public class PluginPagesTests
         new() { Name = "Notifications" },
         new() { Name = "Yaml" }
     ];
+
+    /// <summary>
+    /// Every page the plugin serves is embedded in the assembly under the path it claims.
+    /// </summary>
+    /// <remarks>
+    /// A page is registered by an <c>EmbeddedResourcePath</c> string, so a wrong one is
+    /// not a build error: the dashboard serves an empty tab and nothing says why. The
+    /// list is the plugin's own rather than one repeated here, so a page added without
+    /// its resource fails, and so does a resource renamed without its page.
+    ///
+    /// <para>
+    /// This exists because of the targeting screen: P1.2 to P1.4 built groups and per
+    /// user overrides with an API, tests and no screen at all, which left an
+    /// administrator hand crafting HTTP requests to use any of it.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EveryPageResourceIsEmbedded()
+    {
+        var assembly = typeof(StreamyfinPlugin).Assembly;
+        var embedded = assembly.GetManifestResourceNames().ToHashSet(StringComparer.Ordinal);
+
+        var plugin = (IHasWebPages)FormatterServices_CreateUninitialized();
+
+        var missing = plugin.GetPages()
+            .Select(page => page.EmbeddedResourcePath)
+            .Where(path => !embedded.Contains(path!))
+            .ToArray();
+
+        Assert.Empty(missing);
+    }
+
+    /// <summary>
+    /// The pages that carry the admin interface are all served. Enumerating the plugin's
+    /// own list proves each path exists; it cannot prove a page was never dropped from
+    /// it, and a tab that quietly stops being registered is exactly as invisible as one
+    /// pointing at a missing resource.
+    /// </summary>
+    [Theory]
+    [InlineData("Application")]
+    [InlineData("Targeting")]
+    [InlineData("Notifications")]
+    [InlineData("Other")]
+    [InlineData("Yaml")]
+    public void ThePageIsServed(string name)
+    {
+        var plugin = (IHasWebPages)FormatterServices_CreateUninitialized();
+        var served = plugin.GetPages().Select(page => page.Name).ToArray();
+
+        Assert.Contains(name, served);
+        Assert.Contains(name + ".js", served);
+    }
 
     /// <summary>
     /// With no preference the declared order stands.

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -485,6 +485,32 @@ public class StreamyfinController : ControllerBase
   }
 
   /// <summary>
+  /// The settings targeted at one user.
+  /// </summary>
+  /// <param name="userId">The Jellyfin user id.</param>
+  /// <returns>The settings, or an empty body when the user has none.</returns>
+  /// <remarks>
+  /// The only one of the targeting routes with no unversioned shim, because it is the
+  /// only one that was never served: P1.2 gave this level a write and a delete and no
+  /// read, which left the targeting screen nothing to open an existing override with.
+  /// Read through the same tolerant path the resolution uses, so an override whose JSON
+  /// cannot be read still answers rather than failing, and an administrator can see it
+  /// to repair it.
+  /// </remarks>
+  [HttpGet("v1/users/{userId}/settings")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  public ActionResult<UserSettingsOverrideDto> GetUserSettingsOverride([FromRoute, Required] Guid userId)
+  {
+    var stored = StreamyfinPlugin.Instance!.Database.GetUserSettingsOverride(userId);
+
+    return new UserSettingsOverrideDto
+    {
+      Settings = stored is null ? null : Resolution.ReadLevel(stored.SettingsJson, $"user {userId}")
+    };
+  }
+
+  /// <summary>
   /// Sets the settings targeted at one user.
   /// </summary>
   /// <param name="userId">The Jellyfin user id.</param>

--- a/Jellyfin.Plugin.Streamyfin/Pages/Application/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Application/index.js
@@ -1,25 +1,8 @@
 // The Application page is json-editor reading the schema the plugin serves, rather than a
 // form written by hand a control at a time. Everything specific to a setting travels in the
 // schema (see SerializationHelper.ShapeForGeneratedForm); this file only mounts the editors,
-// seeds them with the stored config and writes the admin's edits back.
-
-// json-editor labels the "Max" playback-quality option as the empty string, and the hand
-// written page always turned a blank field into null, so the value round-trips blank <-> null:
-// a stored null shows as blank in the form, and a blank is saved as null.
-const NO_VALUE = "";
-
-const mapSettingValues = (settings, map) => {
-    const out = {};
-    for (const [key, entry] of Object.entries(settings ?? {})) {
-        out[key] = entry && typeof entry === "object" && !Array.isArray(entry) && "value" in entry
-            ? { ...entry, value: map(entry.value) }
-            : entry;
-    }
-    return out;
-};
-
-const toForm = (settings) => mapSettingValues(settings, (value) => (value === null ? NO_VALUE : value));
-const toConfig = (settings) => mapSettingValues(settings, (value) => (value === NO_VALUE ? null : value));
+// seeds them with the stored config and writes the admin's edits back. The mounting itself
+// is in settings-form.js, shared with the Targeting page.
 
 // The form renders every declared setting, filling the ones the config does not carry with a
 // schema default. Writing all of them would push defaults the admin never chose and turn every
@@ -44,58 +27,14 @@ const settingsToPersist = (loaded, initial, edited) => {
     return result;
 };
 
-// The settings, arranged the way the app arranges them: one section per category, subdivided
-// where a category is large enough to need it. Both come from the schema, so the page holds no
-// list of its own to drift. Object key order is the order the settings are declared in, which
-// is the order the sections come out in.
-const sectionsFrom = (schema) => {
-    const properties = schema?.definitions?.Settings?.properties ?? {};
-    const sections = new Map();
-
-    for (const [key, spec] of Object.entries(properties)) {
-        const category = spec["x-category"] ?? "Other";
-        const group = spec["x-group"] ?? "";
-
-        if (!sections.has(category)) {
-            sections.set(category, new Map());
-        }
-
-        const groups = sections.get(category);
-        if (!groups.has(group)) {
-            groups.set(group, []);
-        }
-
-        groups.get(group).push(key);
-    }
-
-    return sections;
-};
-
-// A schema of its own for one section, so its editor renders those settings and nothing else.
-// The definitions stay at the root, or the references inside the settings stop resolving.
-const schemaFor = (schema, keys) => ({
-    type: "object",
-    title: "",
-    properties: Object.fromEntries(keys.map((key) => [key, schema.definitions.Settings.properties[key]])),
-    definitions: schema.definitions,
-});
-
-const pick = (values, keys) => Object.fromEntries(
-    keys.filter((key) => key in (values ?? {})).map((key) => [key, values[key]]));
-
 const EDITOR_OPTIONS = {
-    theme: "html",
-    iconlib: null,
-    disable_edit_json: true,
     disable_properties: true,
-    no_additional_properties: true,
     // Every declared setting has to render, whether or not the config already carries it:
     // reaching a setting the admin never set is the whole point. Left optional, json-editor
     // draws only the keys present in the stored config, which on one server was 20 of 92, and
     // disable_properties removes the button that would add the rest. Writing them all back is
     // prevented by settingsToPersist, not here.
     required_by_default: true,
-    show_errors: "never",
 };
 
 export default function (view) {
@@ -103,65 +42,21 @@ export default function (view) {
         import(window.ApiClient.getUrl("web/configurationpage?name=shared.js")).then(async (shared) => {
             shared.setPage("Application");
 
-            if (!window.JSONEditor) {
-                await import(window.ApiClient.getUrl("web/configurationpage?name=json-editor.js"));
-            }
+            const form = await import(window.ApiClient.getUrl("web/configurationpage?name=settings-form.js"));
+            await form.loadJsonEditor();
 
             const mount = document.getElementById("settings-editor");
-            const editors = [];
+            let editors = [];
 
             const render = () => {
                 const schema = shared.getJsonSchema();
                 if (!schema || editors.length) return;
 
-                const seed = toForm(shared.getConfig()?.settings);
-                mount.textContent = "";
-
-                for (const [category, groups] of sectionsFrom(schema)) {
-                    const section = document.createElement("details");
-                    section.className = "sf-section";
-
-                    const heading = document.createElement("summary");
-                    const count = [...groups.values()].reduce((total, keys) => total + keys.length, 0);
-                    heading.textContent = `${category} (${count})`;
-                    section.appendChild(heading);
-
-                    for (const [group, keys] of groups) {
-                        if (group) {
-                            const label = document.createElement("h3");
-                            label.className = "sf-group";
-                            label.textContent = group;
-                            section.appendChild(label);
-                        }
-
-                        const host = document.createElement("div");
-                        section.appendChild(host);
-
-                        const editor = new window.JSONEditor(host, {
-                            ...EDITOR_OPTIONS,
-                            schema: schemaFor(schema, keys),
-                            startval: pick(seed, keys),
-                        });
-
-                        // What the editor holds once it has filled in every setting the config
-                        // was missing. A save compares against this, so an untouched default is
-                        // not counted as a change.
-                        const entry = { editor, initial: null };
-                        editor.on("ready", () => {
-                            entry.initial = editor.getValue();
-                        });
-                        editors.push(entry);
-                    }
-
-                    mount.appendChild(section);
-                }
-            };
-
-            const dispose = () => {
-                for (const { editor } of editors) {
-                    editor.destroy();
-                }
-                editors.length = 0;
+                editors = form.renderSections(
+                    mount,
+                    schema,
+                    form.toForm(shared.getConfig()?.settings),
+                    { editorOptions: EDITOR_OPTIONS });
             };
 
             // Schema and config are loaded once, before this import resolves, so the first
@@ -176,22 +71,15 @@ export default function (view) {
                 e.preventDefault();
                 if (!editors.length) return;
 
-                const edited = {};
-                const initial = {};
-                for (const entry of editors) {
-                    const value = entry.editor.getValue();
-                    Object.assign(edited, value);
-                    Object.assign(initial, entry.initial ?? value);
-                }
-
+                const { edited, initial } = form.collect(editors);
                 const config = shared.getConfig() ?? {};
-                const settings = toConfig(settingsToPersist(config.settings, initial, edited));
+                const settings = form.toConfig(settingsToPersist(config.settings, initial, edited));
 
                 shared.setConfig({ ...config, settings });
                 shared.saveConfig();
             });
 
-            view.addEventListener("viewhide", dispose);
+            view.addEventListener("viewhide", () => form.destroy(editors));
         });
     });
 }

--- a/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.html
@@ -1,0 +1,144 @@
+<div data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+     data-require="emby-button,emby-select,emby-checkbox,emby-input"
+     data-controller="__plugin/Targeting.js">
+    <style>
+        #sf-groups .sf-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75em;
+            padding: 0.6em 0.25em;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+            cursor: pointer;
+        }
+        #sf-groups .sf-row:hover { background: rgba(255, 255, 255, 0.04); }
+        #sf-groups .sf-row .sf-name { font-weight: 600; flex: 1 1 auto; }
+        #sf-groups .sf-row .sf-meta { opacity: 0.7; font-size: 0.9em; }
+        #sf-empty { opacity: 0.7; padding: 1em 0.25em; }
+
+        /* The member picker: a plain list of the server's users, so an administrator sees
+           who exists rather than having to know a Jellyfin user id. */
+        #sf-members { max-height: 16em; overflow-y: auto; margin: 0.5em 0 1em; }
+        #sf-members label {
+            display: flex;
+            align-items: center;
+            gap: 0.5em;
+            padding: 0.25em;
+        }
+
+        /* Overrides are rendered by the same generated form the Application tab uses, in
+           the same collapsible sections, so an admin recognises the layout. */
+        #sf-overrides .sf-section { border-bottom: 1px solid rgba(255, 255, 255, 0.12); }
+        #sf-overrides .sf-section > summary {
+            cursor: pointer;
+            padding: 0.75em 0.25em;
+            font-size: 1.15em;
+            font-weight: 600;
+            list-style-position: inside;
+        }
+        #sf-overrides .sf-section > summary:hover { background: rgba(255, 255, 255, 0.04); }
+        #sf-overrides .sf-group {
+            margin: 1em 0 0.35em;
+            padding-left: 0.25em;
+            font-size: 0.95em;
+            font-weight: 600;
+            opacity: 0.75;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        /* Each section's editor wraps its settings in a root object whose header reads
+           "root". That header is noise; its controls are not, because this is the page
+           where the button beside them is how a setting joins or leaves the override. */
+        #sf-overrides .je-object__container > .je-header { display: none; }
+        #sf-overrides .je-indented-panel { margin: 0; padding: 0; border: none; }
+        /* A setting is itself an object, so put its own header back, and take away its
+           property picker: which fields a setting has is not an admin's decision. */
+        #sf-overrides .je-indented-panel .je-object__container > .je-header { display: block; }
+        #sf-overrides .je-indented-panel .je-object__controls { display: none; }
+
+        #sf-overrides .je-object__container { margin: 0 0 0.35em; padding: 0.35em 0.5em; }
+        #sf-overrides .je-header > label { font-weight: 600; }
+        #sf-overrides .je-desc { opacity: 0.7; margin: 0.1em 0 0.4em; font-size: 0.9em; }
+        #sf-overrides .je-indented-panel .je-indented-panel {
+            border-left: 2px solid rgba(255, 255, 255, 0.08);
+            padding-left: 0.6em;
+        }
+
+        .sf-hidden { display: none; }
+    </style>
+
+    <div class="content-primary" style="max-width: 53em; height: 100%">
+        <div class="verticalSection">
+            <div class="sectionTitleContainer">
+                <h1 class="sectionTitle">Streamyfin</h1>
+            </div>
+            <div class="sectionTitleContainer">
+                <h2 class="sectionTitle">Targeting</h2>
+            </div>
+        </div>
+
+        <p>Settings are resolved from the least specific to the most: the server defaults on the Application tab, then any group the user belongs to, then anything set for the user themselves. A group only carries the settings it means to change.</p>
+
+        <!-- List -->
+        <div id="sf-list">
+            <div class="verticalSection">
+                <h3 class="sectionTitle">Groups</h3>
+                <div id="sf-groups"></div>
+                <div id="sf-empty" class="sf-hidden">No groups yet. A group lets you point a set of settings at some of your users.</div>
+                <button id="sf-new" is="emby-button" type="button" class="raised" style="margin-top: 1em;">
+                    <span>Add a group</span>
+                </button>
+            </div>
+
+            <div class="verticalSection" style="margin-top: 2em;">
+                <h3 class="sectionTitle">One user</h3>
+                <p>Settings for a single user, which win over every group they belong to.</p>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="sf-user">User</label>
+                    <select id="sf-user" is="emby-select" class="emby-select-withcolor emby-select"></select>
+                </div>
+                <button id="sf-edit-user" is="emby-button" type="button" class="raised">
+                    <span>Edit their settings</span>
+                </button>
+            </div>
+        </div>
+
+        <!-- Editor, for a group or for a user -->
+        <div id="sf-editor" class="sf-hidden">
+            <div class="verticalSection">
+                <h3 class="sectionTitle" id="sf-editor-title">Group</h3>
+
+                <div id="sf-group-fields">
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="sf-group-name">Name</label>
+                        <input id="sf-group-name" type="text" is="emby-input" />
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="sf-group-priority">Priority</label>
+                        <input id="sf-group-priority" type="number" step="1" is="emby-input" />
+                        <div class="fieldDescription">When a user is in more than one group, the higher priority wins.</div>
+                    </div>
+
+                    <h4>Members</h4>
+                    <div id="sf-members"></div>
+                </div>
+
+                <h4>Settings this <span id="sf-scope-word">group</span> overrides</h4>
+                <p id="sf-overrides-help">Only the settings you add here are changed. Everything else falls through to the level below. Use a section's properties button to add a setting or to drop one.</p>
+                <div id="sf-overrides"></div>
+
+                <div style="margin-top: 1.5em; display: flex; gap: 0.75em; flex-wrap: wrap;">
+                    <button id="sf-save" is="emby-button" type="submit" class="raised button-submit">
+                        <span>Save</span>
+                    </button>
+                    <button id="sf-cancel" is="emby-button" type="button" class="raised">
+                        <span>Cancel</span>
+                    </button>
+                    <button id="sf-delete" is="emby-button" type="button" class="raised button-delete">
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.js
@@ -1,0 +1,281 @@
+// The Targeting page is the screen P1.2 to P1.4 never got. Those parts built the whole
+// engine — groups with a priority, memberships, per user overrides, resolution from
+// server default to group to user — with seven routes and their tests, and no way for an
+// administrator to reach any of it short of hand writing HTTP requests.
+//
+// The settings a level overrides are rendered by the same generated form the Application
+// tab uses, with one option flipped: there, every declared setting renders because the
+// page answers "what does this server default to". Here the page answers "what does this
+// group change", so an editor starts with the keys the level actually carries and the
+// admin adds or drops one through json-editor's own property picker.
+
+const url = (path) => window.ApiClient.getUrl(`streamyfin/v1/${path}`);
+
+const readJson = (path) =>
+    window.ApiClient.ajax({ type: "GET", url: url(path), contentType: "application/json" })
+        .then((response) => response.json());
+
+const send = (type, path, body) =>
+    window.ApiClient.ajax({
+        type,
+        url: url(path),
+        data: body === undefined ? undefined : JSON.stringify(body),
+        contentType: "application/json"
+    });
+
+// The server omits a setting a level does not carry, so what arrives is already the
+// overrides and nothing else. The null guard is for a level written by hand through the
+// API, where a null can arrive spelled out.
+const overrides = (settings) => Object.fromEntries(
+    Object.entries(settings ?? {}).filter(([, value]) => value !== null && value !== undefined));
+
+// The count in a section's heading says how much of that category this level changes,
+// which is the question an admin has on this page. On the Application tab the same
+// heading counts the settings the category holds.
+const overriddenOf = (seed) => (category, keys) =>
+    `${category} (${keys.filter((key) => key in seed).length} of ${keys.length})`;
+
+const EDITOR_OPTIONS = {
+    // A level carries only the settings it means to change, so an editor starts with
+    // those and no others, and the property picker is what adds or drops one. This is
+    // the one place this page differs from the Application tab, and it is the whole
+    // difference between "the server's defaults" and "what this group changes".
+    required_by_default: false,
+    disable_properties: false
+};
+
+// Deleting a group takes everyone's membership of it with it, so it asks first. Older
+// dashboards reject a cancelled confirmation rather than resolving false, and a
+// rejection here would be reported as a failed delete, so both shapes answer false.
+const confirmed = (message) => {
+    if (window.Dashboard?.confirm) {
+        return Promise.resolve(window.Dashboard.confirm(message, "Streamyfin"))
+            .then((answer) => answer !== false, () => false);
+    }
+
+    return Promise.resolve(window.confirm(message));
+};
+
+export default function (view) {
+    let users = [];
+    let groups = [];
+    let editors = [];
+    // null when the list is showing, otherwise the level being edited.
+    let editing = null;
+    let form = null;
+    let shared = null;
+
+    const el = (id) => view.querySelector(`#${id}`);
+    const show = (id, visible) => el(id).classList.toggle("sf-hidden", !visible);
+
+    const memberIds = () => [...el("sf-members").querySelectorAll("input:checked")]
+        .map((input) => input.value);
+
+    const renderMembers = (selected) => {
+        const host = el("sf-members");
+        host.textContent = "";
+
+        for (const user of users) {
+            const label = document.createElement("label");
+            const input = document.createElement("input");
+            const name = document.createElement("span");
+
+            input.type = "checkbox";
+            input.setAttribute("is", "emby-checkbox");
+            input.value = user.Id;
+            input.checked = selected.includes(user.Id);
+            name.textContent = user.Name;
+
+            label.append(input, name);
+            host.appendChild(label);
+        }
+    };
+
+    const renderOverrides = (settings) => {
+        form.destroy(editors);
+
+        const seed = form.toForm(overrides(settings));
+        editors = form.renderSections(el("sf-overrides"), shared.getJsonSchema(), seed, {
+            editorOptions: EDITOR_OPTIONS,
+            heading: overriddenOf(seed)
+        });
+    };
+
+    const renderList = () => {
+        const host = el("sf-groups");
+        host.textContent = "";
+
+        for (const group of groups) {
+            const row = document.createElement("div");
+            const name = document.createElement("span");
+            const meta = document.createElement("span");
+
+            row.className = "sf-row";
+            name.className = "sf-name";
+            meta.className = "sf-meta";
+            name.textContent = group.name;
+
+            const members = group.userIds?.length ?? 0;
+            const settings = Object.keys(overrides(group.settings)).length;
+            meta.textContent = `priority ${group.priority} · `
+                + `${members} member${members === 1 ? "" : "s"} · `
+                + `${settings} setting${settings === 1 ? "" : "s"}`;
+
+            row.append(name, meta);
+            row.addEventListener("click", () => openGroup(group));
+            host.appendChild(row);
+        }
+
+        show("sf-empty", groups.length === 0);
+    };
+
+    const showList = () => {
+        editing = null;
+        form.destroy(editors);
+        show("sf-list", true);
+        show("sf-editor", false);
+    };
+
+    const openGroup = (group) => {
+        editing = { kind: "group", group };
+
+        el("sf-editor-title").textContent = group.id ? group.name : "New group";
+        el("sf-scope-word").textContent = "group";
+        el("sf-group-name").value = group.name ?? "";
+        el("sf-group-priority").value = group.priority ?? 0;
+        renderMembers(group.userIds ?? []);
+        renderOverrides(group.settings);
+
+        show("sf-group-fields", true);
+        show("sf-delete", Boolean(group.id));
+        show("sf-list", false);
+        show("sf-editor", true);
+    };
+
+    const openUser = async () => {
+        const userId = el("sf-user").value;
+        if (!userId) return;
+
+        const user = users.find((candidate) => candidate.Id === userId);
+        const stored = await readJson(`users/${userId}/settings`);
+
+        editing = { kind: "user", userId };
+
+        el("sf-editor-title").textContent = user?.Name ?? "User";
+        el("sf-scope-word").textContent = "user";
+        renderOverrides(stored?.settings);
+
+        show("sf-group-fields", false);
+        show("sf-delete", true);
+        show("sf-list", false);
+        show("sf-editor", true);
+    };
+
+    const load = async () => {
+        groups = await readJson("groups");
+        renderList();
+    };
+
+    const save = async () => {
+        const { edited } = form.collect(editors);
+        const settings = form.toConfig(edited);
+
+        if (editing.kind === "user") {
+            await send("PUT", `users/${editing.userId}/settings`, { settings });
+            return;
+        }
+
+        const name = el("sf-group-name").value.trim();
+        if (!name) {
+            throw new Error("A group needs a name");
+        }
+
+        const priority = Number.parseInt(el("sf-group-priority").value, 10) || 0;
+        const members = memberIds();
+
+        if (editing.group.id) {
+            await send("PUT", `groups/${editing.group.id}`, { name, priority, settings });
+            await send("PUT", `groups/${editing.group.id}/members`, { userIds: members });
+        } else {
+            await send("POST", "groups", { name, priority, settings, userIds: members });
+        }
+    };
+
+    const remove = async () => {
+        if (editing.kind === "user") {
+            if (!await confirmed("Clear the settings targeted at this user?")) return false;
+            await send("DELETE", `users/${editing.userId}/settings`);
+            return true;
+        }
+
+        if (!await confirmed(`Delete the group "${editing.group.name}" and everyone's membership of it?`)) {
+            return false;
+        }
+
+        await send("DELETE", `groups/${editing.group.id}`);
+        return true;
+    };
+
+    // A write is followed by a reload rather than by patching the list in place: the
+    // server decides the id of a new group and the order the list comes back in. An
+    // action that returns false was declined at its confirmation, so the editor stays.
+    const commit = (action) => async (event) => {
+        event?.preventDefault();
+        if (!editing) return;
+
+        window.Dashboard?.showLoadingMsg();
+
+        try {
+            if (await action() === false) return;
+            await load();
+            showList();
+        } catch (error) {
+            console.error(error);
+            window.Dashboard?.alert(error?.message ?? "Streamyfin could not save that. The server log has the reason.");
+        } finally {
+            window.Dashboard?.hideLoadingMsg();
+        }
+    };
+
+    view.addEventListener("viewshow", () => {
+        import(window.ApiClient.getUrl("web/configurationpage?name=shared.js")).then(async (loaded) => {
+            shared = loaded;
+            shared.setPage("Targeting");
+
+            form = await import(window.ApiClient.getUrl("web/configurationpage?name=settings-form.js"));
+            await form.loadJsonEditor();
+
+            users = await window.ApiClient.getUsers();
+            const picker = el("sf-user");
+            picker.textContent = "";
+            for (const user of users) {
+                const option = document.createElement("option");
+                option.value = user.Id;
+                option.textContent = user.Name;
+                picker.appendChild(option);
+            }
+
+            await load();
+            showList();
+
+            shared.keyedEventListener(el("sf-new"), "click", (event) => {
+                event.preventDefault();
+                openGroup({ name: "", priority: 0, settings: {}, userIds: [] });
+            });
+            shared.keyedEventListener(el("sf-edit-user"), "click", (event) => {
+                event.preventDefault();
+                openUser().catch((error) => console.error(error));
+            });
+            shared.keyedEventListener(el("sf-save"), "click", commit(save));
+            shared.keyedEventListener(el("sf-delete"), "click", commit(remove));
+            shared.keyedEventListener(el("sf-cancel"), "click", (event) => {
+                event.preventDefault();
+                showList();
+            });
+        });
+    });
+
+    view.addEventListener("viewhide", () => {
+        if (form) form.destroy(editors);
+    });
+}

--- a/Jellyfin.Plugin.Streamyfin/Pages/settings-form.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/settings-form.js
@@ -1,0 +1,158 @@
+// The generated settings form, shared by the two pages that render settings from the
+// schema the plugin serves. P3.1 built it for the Application tab; P3.3 needed the same
+// form for a group's overrides, so it lives here rather than being written a second time.
+//
+// The two pages differ in one thing only, and it is the thing that matters: the
+// Application tab answers "what does this server default to", so it renders every
+// declared setting; the Targeting tab answers "what does this group change", so it
+// renders only the keys that level carries and lets the admin add or drop one. That is
+// the difference between required_by_default true and false, passed in by the caller.
+
+// json-editor labels the "Max" playback-quality option as the empty string, and the hand
+// written page always turned a blank field into null, so the value round-trips blank <-> null:
+// a stored null shows as blank in the form, and a blank is saved as null.
+export const NO_VALUE = "";
+
+const mapSettingValues = (settings, map) => {
+    const out = {};
+    for (const [key, entry] of Object.entries(settings ?? {})) {
+        out[key] = entry && typeof entry === "object" && !Array.isArray(entry) && "value" in entry
+            ? { ...entry, value: map(entry.value) }
+            : entry;
+    }
+    return out;
+};
+
+export const toForm = (settings) => mapSettingValues(settings, (value) => (value === null ? NO_VALUE : value));
+export const toConfig = (settings) => mapSettingValues(settings, (value) => (value === NO_VALUE ? null : value));
+
+// The settings, arranged the way the app arranges them: one section per category,
+// subdivided where a category is large enough to need it. Both come from the schema, so
+// no page holds a list of its own to drift. Object key order is the order the settings
+// are declared in, which is the order the sections come out in.
+export const sectionsFrom = (schema) => {
+    const properties = schema?.definitions?.Settings?.properties ?? {};
+    const sections = new Map();
+
+    for (const [key, spec] of Object.entries(properties)) {
+        const category = spec["x-category"] ?? "Other";
+        const group = spec["x-group"] ?? "";
+
+        if (!sections.has(category)) {
+            sections.set(category, new Map());
+        }
+
+        const groups = sections.get(category);
+        if (!groups.has(group)) {
+            groups.set(group, []);
+        }
+
+        groups.get(group).push(key);
+    }
+
+    return sections;
+};
+
+// A schema of its own for one section, so its editor renders those settings and nothing
+// else. The definitions stay at the root, or the references inside the settings stop
+// resolving.
+const schemaFor = (schema, keys) => ({
+    type: "object",
+    title: "",
+    properties: Object.fromEntries(keys.map((key) => [key, schema.definitions.Settings.properties[key]])),
+    definitions: schema.definitions,
+});
+
+const pick = (values, keys) => Object.fromEntries(
+    keys.filter((key) => key in (values ?? {})).map((key) => [key, values[key]]));
+
+// Set on every editor either page builds. What a page decides for itself is
+// required_by_default and disable_properties, which together are what makes an editor
+// render every setting or only the ones a level carries.
+export const BASE_EDITOR_OPTIONS = {
+    theme: "html",
+    iconlib: null,
+    disable_edit_json: true,
+    no_additional_properties: true,
+    show_errors: "never",
+};
+
+// json-editor is 535 KB and both pages need it, so it is fetched once and left on the
+// window rather than re-imported per page.
+export const loadJsonEditor = async () => {
+    if (!window.JSONEditor) {
+        await import(window.ApiClient.getUrl("web/configurationpage?name=json-editor.js"));
+    }
+};
+
+const countHeading = (category, keys) => `${category} (${keys.length})`;
+
+/// One collapsible section per category, one editor per group inside it, seeded from
+/// `seed`. Returns an entry per editor carrying the value that editor settled on once
+/// ready, which is what a save compares against: an editor fills in a default for every
+/// key its start value was missing, so comparing against what it was seeded with counts
+/// an untouched default as a change.
+export const renderSections = (mount, schema, seed, { editorOptions = {}, heading = countHeading } = {}) => {
+    mount.textContent = "";
+    const editors = [];
+
+    for (const [category, groups] of sectionsFrom(schema)) {
+        const section = document.createElement("details");
+        section.className = "sf-section";
+
+        const summary = document.createElement("summary");
+        summary.textContent = heading(category, [...groups.values()].flat(), seed);
+        section.appendChild(summary);
+
+        for (const [group, keys] of groups) {
+            if (group) {
+                const label = document.createElement("h3");
+                label.className = "sf-group";
+                label.textContent = group;
+                section.appendChild(label);
+            }
+
+            const host = document.createElement("div");
+            section.appendChild(host);
+
+            const editor = new window.JSONEditor(host, {
+                ...BASE_EDITOR_OPTIONS,
+                ...editorOptions,
+                schema: schemaFor(schema, keys),
+                startval: pick(seed, keys),
+            });
+
+            const entry = { editor, initial: null };
+            editor.on("ready", () => {
+                entry.initial = editor.getValue();
+            });
+            editors.push(entry);
+        }
+
+        mount.appendChild(section);
+    }
+
+    return editors;
+};
+
+/// The sections' editors read back as one settings object, alongside the first value
+/// they held.
+export const collect = (editors) => {
+    const edited = {};
+    const initial = {};
+
+    for (const entry of editors) {
+        const value = entry.editor.getValue();
+        Object.assign(edited, value);
+        Object.assign(initial, entry.initial ?? value);
+    }
+
+    return { edited, initial };
+};
+
+export const destroy = (editors) => {
+    for (const { editor } of editors) {
+        editor.destroy();
+    }
+    editors.length = 0;
+};

--- a/Jellyfin.Plugin.Streamyfin/Pages/shared.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/shared.js
@@ -155,6 +155,11 @@ export const StreamyfinTabs = () => [
         name: "Application"
     },
     {
+        href: "configurationpage?name=Targeting",
+        resource: "Targeting",
+        name: "Targeting"
+    },
+    {
         href: "configurationpage?name=Notifications",
         resource: "Notifications",
         name: "Notifications"

--- a/Jellyfin.Plugin.Streamyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Streamyfin/Plugin.cs
@@ -39,8 +39,6 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // Reading base.Configuration here is what makes Jellyfin parse the old XML, so
         // this is the last point at which its contents are available to carry over.
         Settings.Import(Configuration?.Config, applicationPaths.PluginConfigurationsPath);
-
-        _prefix = GetType().Namespace;
     }
 
     /// <summary>
@@ -61,7 +59,10 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <inheritdoc />
     public override string Name => "Streamyfin";
 
-    private static string? _prefix;
+    // The namespace the pages are embedded under. Taken from the type rather than
+    // assigned in the constructor, so the page list answers without a running server and
+    // a test can hold every EmbeddedResourcePath to account.
+    private static readonly string _prefix = typeof(StreamyfinPlugin).Namespace!;
 
     /// <inheritdoc />
     public override Guid Id => PluginId;
@@ -90,6 +91,18 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             Name = "Application.js",
             EmbeddedResourcePath = _prefix + ".Pages.Application.index.js"
+        },
+
+        new PluginPageInfo
+        {
+            Name = "Targeting",
+            EmbeddedResourcePath = _prefix + ".Pages.Targeting.index.html"
+        },
+
+        new PluginPageInfo
+        {
+            Name = "Targeting.js",
+            EmbeddedResourcePath = _prefix + ".Pages.Targeting.index.js"
         },
 
         new PluginPageInfo
@@ -281,6 +294,13 @@ public class StreamyfinPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             Name = "shared.js",
             EmbeddedResourcePath = _prefix + ".Pages.shared.js"
+        };
+
+        // The generated settings form, shared by the Application and Targeting pages.
+        yield return new PluginPageInfo
+        {
+            Name = "settings-form.js",
+            EmbeddedResourcePath = _prefix + ".Pages.settings-form.js"
         };
         // endregion libraries
     }

--- a/docs/rewrite/README.md
+++ b/docs/rewrite/README.md
@@ -15,6 +15,8 @@ goes in one of these files instead.
 | [pull-request-triage.md](pull-request-triage.md) | The pull requests that were open when the rewrite started. |
 | [app-side-work.md](app-side-work.md) | What the app repository has to do, and what it is waiting on. |
 | [settings-parity.md](settings-parity.md) | Which of the app's settings the plugin declares, and the manifest that keeps the two from drifting. |
+| [admin-ui-generated.md](admin-ui-generated.md) | P3.1: the admin form generated from the schema, and what a real dashboard found that the tests could not. |
+| [admin-ui-targeting.md](admin-ui-targeting.md) | P3.3: the group and user targeting screen, and why it reuses the generated form. |
 
 ## How the work is organised
 

--- a/docs/rewrite/admin-ui-targeting.md
+++ b/docs/rewrite/admin-ui-targeting.md
@@ -1,0 +1,153 @@
+# The targeting screen
+
+This is P3.3. Groups and per user overrides get the screen they never had. P3.2 (home
+sections), P3.4 (JSON import and export) and P3.5 (embedded pages versus
+`jellyfin-plugin-pages`) are out of scope and named at the end.
+
+## The drift this closes
+
+P1.2, P1.3 and P1.4 built the whole targeting engine: groups with a priority,
+memberships, per user overrides, resolution from server default to group to user, and
+credentials filtered out of what a non admin receives. Seven routes, a database table
+each, and tests. **And no screen at all.**
+
+So the feature exists and nobody can reach it. An administrator who wants one group to
+get a different default bitrate has to write the HTTP requests by hand, with a Jellyfin
+user id they have no interface to look up. That is the same shape as the finding P3.1
+closed, where 72 of 92 declared settings had no control: the work is done, the door is
+missing.
+
+| | |
+|---|---|
+| Targeting routes the plugin serves | 7, plus the one added here |
+| Ways an administrator could use them before | hand written HTTP |
+| Ways now | a tab |
+
+## The route that was missing
+
+`users/{userId}/settings` had a `PUT` and a `DELETE` and no `GET`. Nothing had needed to
+read one back, because nothing read one at all: the resolution reads the *caller's*
+override, never a named user's. A screen that edits an existing override needs to open
+it first, so this part adds:
+
+```
+GET v1/users/{userId}/settings
+```
+
+It is the only targeting route with **no unversioned shim**, and deliberately so. The
+shims in P1.6 exist for paths that were already being called by apps in the field. This
+path never was, so it starts life versioned and stays that way.
+
+It reads through `SettingsResolutionService.ReadLevel`, the same tolerant path the
+resolution uses, so an override whose stored JSON cannot be parsed still answers rather
+than throwing. A level an administrator cannot see is a level they cannot repair.
+
+## What the screen does
+
+A new tab, **Targeting**, beside Application, Notifications, Other and Yaml. Chosen over
+a section inside the Application page: that page already carries 92 settings, and "what
+this server defaults to" and "who gets what" are two questions, not one.
+
+- **The groups**, listed in the order that decides who wins, each row saying its
+  priority, how many members it has and how many settings it overrides.
+- **Editing a group**: name, priority, members ticked from the server's actual user list
+  rather than typed as ids, and the settings it overrides.
+- **One user**: pick a user, edit the settings aimed at them, or clear them.
+- **Create and delete**, with a confirmation on the delete, since removing a group
+  removes everyone's membership of it too.
+
+## The decision: the same form, one option flipped
+
+The plan called P3.3 a "hand written screen". That was written before P3.1 existed. Now
+that the generated form is built, tested and on `develop`, writing a second settings
+editor by hand would be duplication, so the group's overrides are rendered by the same
+json-editor mechanism the Application tab uses.
+
+The two pages differ in exactly one thing, and it is the thing that matters:
+
+| | Application | Targeting |
+|---|---|---|
+| The question | what does this server default to | what does this level change |
+| `required_by_default` | `true`, so every declared setting renders | `false`, so only the keys the level carries do |
+| `disable_properties` | `true` | `false`, so a setting can be added or dropped |
+| What a save writes | the keys already present, plus the ones actually edited | whatever the editor holds |
+
+That last row is why the Targeting page needs none of `settingsToPersist`. On the
+Application page an editor fills in a default for every key the config was missing, so a
+save has to diff against the editor's own first value or it writes all 92. Here the
+editor only ever holds the keys the level carries, so its value *is* the answer. The
+contract "a group only carries the settings it means to change" is enforced by the
+editor's shape rather than by a comparison.
+
+Dropping an override is json-editor's own property picker, which is why this page keeps
+the object controls its stylesheet otherwise hides. It is also the only affordance for
+*removing* a setting from a level, which a form that renders everything cannot offer at
+all.
+
+## What moved to be shared
+
+`Pages/settings-form.js`, a new module, holds what both pages do with the schema: the
+blank/null round trip for the "Max" quality option, the category and group sectioning
+read from `x-category` and `x-group`, the per section sub-schema, the editor options
+they agree on, and the render loop. `Pages/Application/index.js` keeps only what is its
+own: the save diff, and its two editor options.
+
+It is a third shared module rather than more of `shared.js`, which is the pages' runtime
+state — schema, config, tabs, save. This one is the form.
+
+## How it is validated
+
+**xUnit, for what C# can hold to account.** A page is registered by an
+`EmbeddedResourcePath` string, so a wrong one is not a build error: the dashboard serves
+an empty tab and nothing says why. `PluginPagesTests` now enumerates the plugin's *own*
+page list and asserts every resource path it claims is actually embedded, so a page added
+without its file fails, and so does a file renamed without its page. A second test names
+the five tabs, because enumerating the list cannot prove a page was never dropped from
+it, and a tab that stops being registered is exactly as invisible as one pointing at a
+missing resource.
+
+This needed one change in `Plugin.cs`: `_prefix` was a static field assigned in the
+constructor, so the page list only answered correctly on a running server. It is now
+taken from the type.
+
+**A pass on the beta**, LXC 132, real Jellyfin 12. Everything above is C#; the screen is
+JS and only a browser connected to a dashboard exercises it. The scenario to run, which
+is the one that proves the engine and the screen agree:
+
+1. Create a group, put one user in it, override one setting and lock it.
+2. `GET v1/config/resolved` as that user carries the group's value.
+3. The same call as a user outside the group does not.
+4. Set an override on that same user and it wins over their group.
+5. Reopen both and the form shows what was stored.
+
+**Not yet run.** Tailscale was up long enough to validate P4.1 and dropped again.
+
+## A casing gap to confirm on that pass
+
+Group and user settings travel as JSON through MVC, which keeps the CLR property names.
+Every settings type is already camel case in C#, so the wire matches the schema — except
+`LanguagePreference`, whose two members are `ThreeLetterISOLanguageName` and
+`DisplayName` in PascalCase, because the app matches them against the SDK's `CultureDto`.
+The schema camel cases them, as #137 established it must.
+
+If that reasoning holds, a group overriding a default audio or subtitle language would
+save and then not show the value back, silently, in 2 settings of 92. It is derived from
+how Jellyfin configures its JSON options rather than observed, so it is written here as
+a thing to check on the beta pass, not as a finding. If it is real it wants its own
+change and its own test, the way #137 did for the YAML reader.
+
+## Out of scope
+
+- **P3.2** home section editor. It would be built on the four nullable siblings
+  `items`, `nextUp`, `latest` and `custom` that P5.1 replaces with a discriminated type,
+  so building it now means building it twice.
+- **P3.4** JSON import and export.
+- **P3.5** the embedded pages versus `jellyfin-plugin-pages` decision. This slice stays
+  inside the embedded pages.
+- **Group section targeting** (P5.4), which needs the section model P5.1 has not
+  reshaped yet.
+
+## Delivery
+
+Branch `refonte/p3-3-targeting`, one pull request onto `develop`, squash, body in the
+`Part of #114. Covers P3.3.` form the sisters use. The tracking pull request is #121.

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -8,6 +8,87 @@ three months can catch up without reading a pull request thread.
 Append an entry whenever something lands or a decision is taken. A decision that
 lives only in a comment thread is a decision nobody will find.
 
+## 2026-09-01
+
+### P3.3, the targeting screen
+
+The engine P1.2 to P1.4 built had seven routes, its own tables, its tests, and no
+screen: creating a group meant writing HTTP by hand with a user id nothing in the
+interface would show you. That is the same failure mode P3.1 closed for the 72
+unreachable settings, and it is why P3.3 was taken before P3.2 and P3.4.
+
+A new **Targeting** tab: the groups with their priority, members and override count,
+an editor for one group or one user, and a delete that says what it takes with it.
+
+**The plan called this a hand written screen and half of it is not.** Its list and its
+member picker are hand written; the settings a level overrides are the generated form
+from P3.1, with `required_by_default` false and the property picker left on. That one
+flip is the whole difference between "what does this server default to" and "what does
+this group change", and it also means the Targeting page needs none of the save-diff
+logic the Application page needs: the editor only ever holds the keys the level carries,
+so its value is the answer. `Pages/settings-form.js` is the part they share.
+
+**One route was missing and nobody had noticed**: `users/{userId}/settings` had a PUT
+and a DELETE and no GET, because the resolution only ever reads the *caller's* override,
+never a named user's. Added as `GET v1/users/{userId}/settings`, versioned only, since
+unlike its siblings it is not a path any app in the field ever called.
+
+**`Plugin.cs` gave up a static field assigned from its constructor.** `_prefix` came from
+`GetType().Namespace` at construction, so the page list only answered correctly on a
+running server, and the test for it could only check a hand written copy of the list.
+Taken from the type instead, `PluginPagesTests` now enumerates the plugin's own pages and
+holds every `EmbeddedResourcePath` to account. 167 tests green on jf11 and jf12, Release
+builds clean on both.
+
+**Not yet seen in a browser.** The screen is JS, the beta pass is owed, and the scenario
+to run is written down in [admin-ui-targeting.md](admin-ui-targeting.md) along with a
+casing gap on `LanguagePreference` that the same pass should confirm or dismiss.
+
+### P4.1, and a detour that says something about ordering
+
+[#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141): the push
+notification client. `new HttpClient()` per send is gone, replaced by a named client from
+`IHttpClientFactory` with a 30 second timeout instead of the default 100, the HTTP status
+is checked before the body is parsed (a 429 was reading exactly like a success), and
+`_userManager` is guarded before it is dereferenced. Five tests with a stubbed handler.
+Deployed to the beta on Jellyfin 12 and it loads with no unresolved service, which was
+the real risk of the injection and the only part unit tests could not answer.
+
+The detour worth recording: P4 was picked over the rest of P3 **because Tailscale was
+down and P4 was the only large piece provable without a browser**. That is a tooling
+constraint deciding a priority, and it was the wrong reason. P3 is the admin interface,
+which is what was asked for. Noted here so the next gap in connectivity does not quietly
+reorder the plan again.
+
+## 2026-08-31
+
+### P3.1 landed, and the two fixes it uncovered
+
+[#136](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/136) generates the
+Application form from the schema, and
+[#139](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/139) groups it into
+the sections the app uses. The reasoning, what a real dashboard found that the unit tests
+could not, and why a per setting "platforms" field was investigated and dropped, are all
+in [admin-ui-generated.md](admin-ui-generated.md).
+
+Two things the generated form surfaced by offering settings the hand written page never
+had:
+
+- [#137](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/137), the default
+  audio and subtitle languages could not be saved at all. `LanguagePreference` is the one
+  settings type with PascalCase members, because the app matches them against the SDK's
+  `CultureDto`, and the YAML reader rejected the names its own schema described.
+- [#138](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/138), each video
+  player setting now says in its own description which platform it decides, rather than
+  leaving an administrator to guess.
+
+### The plugin is licensed
+
+[#140](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/140) merged into
+`main`: MPL-2.0, the same licence the app uses, so the two halves of one project do not
+disagree about their terms. It also credits SignPath, which is a condition of their free
+open source programme and the prerequisite for P0.10.
+
 ## 2026-08-27
 
 ### #1900 merged, and both written exceptions are gone

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -45,6 +45,14 @@ screen stay hand written. That hybrid is what KefinTweaks landed on in
 `scripts/configuration.js`: descriptor driven for the repetitive fields, hand
 written where the shape is genuinely irregular.
 
+Half of that held. **The targeting screen went the other way**: its list, its
+member picker and its editing flow are hand written, but the settings a group
+overrides are the same generated form, because by the time P3.3 was built P3.1
+had made one that worked and a second editor written by hand would have been
+duplication. The line is not "irregular shape, write it by hand" but "the settings
+themselves are always the schema's job". See
+[admin-ui-targeting.md](admin-ui-targeting.md).
+
 ## How it lands
 
 `develop` is the integration branch, `main` keeps serving the published plugin.
@@ -156,7 +164,10 @@ states: locked, pushed once, unmanaged.
 - **P3.1** Render simple settings from the JSON schema using the already vendored
   json-editor
 - **P3.2** Hand written editor for home sections
-- **P3.3** Hand written screen for group and user targeting
+- **P3.3** Screen for group and user targeting. Written as "hand written", and
+  delivered on the generated form instead: once P3.1 existed, a second settings editor
+  written by hand was duplication. See
+  [admin-ui-targeting.md](admin-ui-targeting.md)
 - **P3.4** JSON export and import
 - **P3.5** Decide between embedded pages and `jellyfin-plugin-pages`
 
@@ -243,10 +254,20 @@ Everything merged below is on `develop`, which reaches `main` through
 | P1.4 | [#131](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/131) | merged |
 | P1.5 | [#132](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/132) | merged |
 | P1.6 | [#133](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/133) | merged |
-| P1.7 | [#134](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/134) | open |
+| P1.7 | [#134](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/134), [#135](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/135) | merged |
+| P3.1 | [#136](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/136), [#139](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/139) | merged |
+| P3.3 | this branch | open |
+| P4.1 | [#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141) | open |
 
 Not a numbered sub part, landed alongside P1:
 [#130](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/130), the
 plugin's entry in the dashboard's left menu, and
 [#109](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/109), the
 two lockable mute subtitle keys that came out of the pull request triage.
+
+Also not numbered:
+[#137](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/137), which made
+the two language settings saveable at all, and
+[#138](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/138), which says in
+each video player setting's own description which platform it decides. Both came out of
+the generated form offering settings the hand written page never had.


### PR DESCRIPTION
Part of #114. Covers P3.3.

P1.2 to P1.4 built the whole targeting engine: groups with a priority, memberships, per user overrides, resolution from server default to group to user, and secrets filtered out of what a non admin receives. Seven routes, a table each, tests. **And no screen at all**, so creating a group meant writing the HTTP by hand with a Jellyfin user id nothing in the interface would show you.

That is the same shape as the finding P3.1 closed, where 72 of 92 declared settings had no control: the work is done, the door is missing.

## What this adds

A **Targeting** tab, beside Application, Notifications, Other and Yaml.

- The groups, listed in the order that decides who wins, each row saying its priority, how many members it has and how many settings it overrides.
- Editing a group: name, priority, members ticked from the server's own user list rather than typed as ids, and the settings it overrides.
- One user: pick a user, edit the settings aimed at them, or clear them.
- Create and delete, with a confirmation on the delete since removing a group removes everyone's membership of it too.

## The generated form, with one option flipped

The plan called P3.3 a "hand written screen". That was written before P3.1 existed. Its list, member picker and editing flow are hand written; the settings a level overrides are the same json-editor mechanism the Application tab uses, because writing a second settings editor by hand would be duplication.

The two pages differ in exactly one thing:

| | Application | Targeting |
|---|---|---|
| The question | what does this server default to | what does this level change |
| `required_by_default` | `true`, every declared setting renders | `false`, only the keys the level carries |
| `disable_properties` | `true` | `false`, so a setting can be added or dropped |
| What a save writes | keys already present, plus the ones actually edited | whatever the editor holds |

That last row is why this page needs none of `settingsToPersist`. On the Application page an editor fills in a default for every key the config was missing, so a save has to diff against the editor's own first value or it writes all 92. Here the editor only ever holds the keys the level carries, so its value *is* the answer, and "a group only carries the settings it means to change" is enforced by the editor's shape rather than by a comparison.

`Pages/settings-form.js` is the new shared module: the blank/null round trip, the category and group sectioning, the per section sub-schema, the shared editor options and the render loop. `Pages/Application/index.js` keeps only what is its own.

## One route was missing

`users/{userId}/settings` had a `PUT` and a `DELETE` and no `GET`, because the resolution only ever reads the *caller's* override and never a named user's, so a screen had nothing to open an existing one with.

```
GET v1/users/{userId}/settings
```

Versioned only, and deliberately: the shims from P1.6 exist for paths apps in the field already call, and this one was never served. It reads through `SettingsResolutionService.ReadLevel`, so an override whose stored JSON cannot be parsed still answers rather than throwing — a level an administrator cannot see is a level they cannot repair.

## A static field that needed a server to be right

`_prefix` came from `GetType().Namespace` at construction, so the page list only answered correctly on a running server, and the test for it could only check a hand written copy of the list. Taken from the type instead, `PluginPagesTests` now enumerates the plugin's **own** page list and asserts every `EmbeddedResourcePath` it claims is actually embedded. A page registered against a wrong path is not a build error today: the dashboard serves an empty tab and nothing says why.

## Verification

- **167 tests green** on jf11 and jf12, Release builds clean on both.
- **Not yet rendered in a browser.** The screen is JavaScript and only a dashboard exercises it. The scenario the beta pass owes it — create a group, one member, one locked setting, then check `v1/config/resolved` answers with the group's value for that member and not for the others — is written down in `docs/rewrite/admin-ui-targeting.md`, along with a casing gap on `LanguagePreference` that the same pass should confirm or dismiss.

## Documentation

`docs/rewrite/admin-ui-targeting.md` is new. `plan.md` records that the "hand written screen" decision was superseded and why, `log.md` catches up on the 31st and the 1st, and the README indexes both admin UI documents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Targeting administration page for managing groups, priorities, members, and settings overrides.
  * Added per-user settings override retrieval.
  * Added a Targeting tab to the plugin configuration interface.
  * Added shared settings-form behavior for generated configuration editors.
* **Improvements**
  * Streamlined the Application settings editor and save behavior.
* **Documentation**
  * Updated design, planning, and project log documentation.
* **Tests**
  * Added validation for embedded pages and page serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->