### PR TITLE
feat(notifications): collect Expo receipts and forget the devices that are gone

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
@@ -237,6 +237,33 @@ public class ExpoReceiptStoreTests : IDisposable
         Assert.Empty(second.Select(r => r.TicketId).Intersect(asked));
     }
 
+    /// <summary>
+    /// The exclusion holds at the size a full run actually reaches.
+    /// </summary>
+    /// <remarks>
+    /// The task works through up to ten batches of a thousand, so by the last one it is
+    /// asking the database to skip nine thousand ticket ids in a single query. SQLite has
+    /// a ceiling on bound parameters, and a query built the wrong way would throw there
+    /// and nowhere else: only on the busy servers this part exists to help, and only once
+    /// the backlog is deep enough to reach the tenth batch.
+    /// </remarks>
+    [Fact]
+    public void TheExclusionHoldsAtAFullRunsSize()
+    {
+        _db.AddExpoReceipts(
+            Enumerable.Range(0, 10_000).Select(i => ($"ticket-{i:D5}", $"token-{i}")),
+            Now.AddHours(-1));
+
+        var asked = Enumerable.Range(0, 9_000)
+            .Select(i => $"ticket-{i:D5}")
+            .ToHashSet(StringComparer.Ordinal);
+
+        var remaining = _db.GetExpoReceiptsSentBefore(Now, 1000, asked);
+
+        Assert.Equal(1000, remaining.Count);
+        Assert.Empty(remaining.Select(r => r.TicketId).Intersect(asked));
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
@@ -209,6 +209,34 @@ public class ExpoReceiptStoreTests : IDisposable
         Assert.Empty(second.Select(r => r.TicketId).Intersect(first.Select(r => r.TicketId)));
     }
 
+    /// <summary>
+    /// Skipping what has already been asked about happens in the query, before the limit,
+    /// so a batch that went entirely unanswered does not hide everything behind it.
+    /// </summary>
+    /// <remarks>
+    /// This is the difference between walking a backlog and starving on it. Filtered
+    /// after the limit, a run whose first batch Expo did not resolve would take that same
+    /// batch again, discard all of it, find nothing new and stop, and the rows behind it
+    /// would wait until the old ones resolved or expired unread. The rows here all carry
+    /// the same timestamp, which is what a burst of notifications actually produces.
+    /// </remarks>
+    [Fact]
+    public void WhatWasAlreadyAskedIsSkippedBeforeTheLimit()
+    {
+        _db.AddExpoReceipts(
+            Enumerable.Range(0, 1500).Select(i => ($"ticket-{i:D4}", $"token-{i}")),
+            Now.AddHours(-1));
+
+        // Asked about, and Expo answered for none of them, so every row is still stored.
+        var first = _db.GetExpoReceiptsSentBefore(Now, 1000);
+        var asked = first.Select(r => r.TicketId).ToHashSet(StringComparer.Ordinal);
+
+        var second = _db.GetExpoReceiptsSentBefore(Now, 1000, asked);
+
+        Assert.Equal(500, second.Count);
+        Assert.Empty(second.Select(r => r.TicketId).Intersect(asked));
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
@@ -182,6 +182,33 @@ public class ExpoReceiptStoreTests : IDisposable
         Assert.Equal(["ticket-b"], _db.GetExpoReceiptsSentBefore(Now, 100).Select(r => r.TicketId));
     }
 
+    /// <summary>
+    /// A backlog bigger than one batch is reached a batch at a time, and forgetting what
+    /// was answered brings the rest into range.
+    /// </summary>
+    /// <remarks>
+    /// A run that only ever took the first batch would let the oldest expire before
+    /// anyone asked what became of them, which is the bug this part exists to fix.
+    /// Sized past the batch the task uses on purpose, since that is also the number of
+    /// ids one delete has to carry.
+    /// </remarks>
+    [Fact]
+    public void ABacklogBiggerThanOneBatchIsReachedInPieces()
+    {
+        _db.AddExpoReceipts(
+            Enumerable.Range(0, 1500).Select(i => ($"ticket-{i:D4}", $"token-{i}")),
+            Now.AddHours(-1));
+
+        var first = _db.GetExpoReceiptsSentBefore(Now, 1000);
+        Assert.Equal(1000, first.Count);
+
+        _db.RemoveExpoReceipts(first.Select(r => r.TicketId));
+
+        var second = _db.GetExpoReceiptsSentBefore(Now, 1000);
+        Assert.Equal(500, second.Count);
+        Assert.Empty(second.Select(r => r.TicketId).Intersect(first.Select(r => r.TicketId)));
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptStoreTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.Db;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Storing the pushes Expo accepted, and removing the devices it later says are gone.
+/// </summary>
+/// <remarks>
+/// The decision to delete is in <c>ExpoTickets</c> and tested there. This is the other
+/// half: that the pair survives to the moment the receipt arrives, that the window has
+/// both its ends, and that removing a token removes the right rows.
+/// </remarks>
+public class ExpoReceiptStoreTests : IDisposable
+{
+    private readonly string _directory;
+    private readonly PluginDatabase _db;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExpoReceiptStoreTests"/> class.
+    /// </summary>
+    public ExpoReceiptStoreTests()
+    {
+        _directory = TestDirectory.Create();
+        _db = new PluginDatabase(_directory);
+    }
+
+    private static DateTime Now => new(2026, 9, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// A push is only asked about once Expo has had time to produce a receipt. Asking
+    /// straight away mostly answers nothing and spends the rate limit doing it.
+    /// </summary>
+    [Fact]
+    public void OnlyPushesOldEnoughAreHandedBack()
+    {
+        _db.AddExpoReceipts([("ripe", "token-a")], Now.AddMinutes(-30));
+        _db.AddExpoReceipts([("fresh", "token-b")], Now.AddMinutes(-1));
+
+        var due = _db.GetExpoReceiptsSentBefore(Now.AddMinutes(-15), 100);
+
+        Assert.Equal(["ripe"], due.Select(r => r.TicketId));
+    }
+
+    /// <summary>
+    /// The oldest come first and no more than asked for, because Expo takes a thousand
+    /// ticket ids per request and the ones closest to expiring are the ones about to be
+    /// unanswerable.
+    /// </summary>
+    [Fact]
+    public void TheOldestComeFirstAndTheBatchIsCapped()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            _db.AddExpoReceipts([($"ticket-{i}", $"token-{i}")], Now.AddHours(-5 + i));
+        }
+
+        var due = _db.GetExpoReceiptsSentBefore(Now, 3);
+
+        Assert.Equal(["ticket-0", "ticket-1", "ticket-2"], due.Select(r => r.TicketId));
+    }
+
+    /// <summary>
+    /// The token travels with the ticket rather than being looked up when the receipt
+    /// arrives. By then the device may have registered a new token, and the row this
+    /// ticket belonged to would no longer be the right one to delete.
+    /// </summary>
+    [Fact]
+    public void TheTokenIsStoredBesideItsTicket()
+    {
+        _db.AddExpoReceipts([("ticket-a", "ExponentPushToken[abc]")], Now);
+
+        var stored = Assert.Single(_db.GetExpoReceiptsSentBefore(Now, 100));
+
+        Assert.Equal("ticket-a", stored.TicketId);
+        Assert.Equal("ExponentPushToken[abc]", stored.Token);
+        Assert.Equal(Now, stored.CreatedAt);
+    }
+
+    /// <summary>
+    /// A ticket id already stored keeps the token it was first stored with. Expo does not
+    /// reissue ids, so a collision means something is wrong upstream and the first row is
+    /// the one that knows what it belonged to.
+    /// </summary>
+    [Fact]
+    public void AKnownTicketKeepsItsFirstToken()
+    {
+        _db.AddExpoReceipts([("ticket-a", "token-first")], Now);
+        _db.AddExpoReceipts([("ticket-a", "token-second")], Now);
+
+        var stored = Assert.Single(_db.GetExpoReceiptsSentBefore(Now, 100));
+
+        Assert.Equal("token-first", stored.Token);
+    }
+
+    /// <summary>
+    /// A batch carrying the same ticket twice stores it once, rather than failing the
+    /// whole insert on the primary key.
+    /// </summary>
+    [Fact]
+    public void ATicketRepeatedInOneBatchIsStoredOnce()
+    {
+        _db.AddExpoReceipts([("ticket-a", "token-a"), ("ticket-a", "token-a")], Now);
+
+        Assert.Single(_db.GetExpoReceiptsSentBefore(Now, 100));
+    }
+
+    /// <summary>
+    /// Expo keeps a receipt for 24 hours. Past that the answer is never coming, and a row
+    /// nothing ever removes is the same accumulation in a different table.
+    /// </summary>
+    [Fact]
+    public void PushesExpoNoLongerAnswersForAreDropped()
+    {
+        _db.AddExpoReceipts([("old", "token-a")], Now.AddHours(-25));
+        _db.AddExpoReceipts([("recent", "token-b")], Now.AddHours(-1));
+
+        var dropped = _db.RemoveExpoReceiptsSentBefore(Now.AddHours(-24));
+
+        Assert.Equal(1, dropped);
+        Assert.Equal(["recent"], _db.GetExpoReceiptsSentBefore(Now, 100).Select(r => r.TicketId));
+    }
+
+    /// <summary>
+    /// A device is forgotten by the token Expo named, since that is the only thing a
+    /// receipt carries.
+    /// </summary>
+    [Fact]
+    public void ADeviceIsForgottenByTheTokenExpoNamed()
+    {
+        _db.AddDeviceToken(new DeviceToken { DeviceId = Guid.NewGuid(), Token = "dead", UserId = Guid.NewGuid() });
+        _db.AddDeviceToken(new DeviceToken { DeviceId = Guid.NewGuid(), Token = "alive", UserId = Guid.NewGuid() });
+
+        var removed = _db.RemoveDeviceTokensNamed(["dead"]);
+
+        Assert.Equal(1, removed);
+        Assert.Equal(["alive"], _db.GetAllDeviceTokens().Select(t => t.Token));
+    }
+
+    /// <summary>
+    /// One token can sit on more than one row, from a device that re-registered under a
+    /// new id without the old row ever being cleaned up. That is the accumulation this
+    /// part removes, so every match goes.
+    /// </summary>
+    [Fact]
+    public void EveryRowCarryingADeadTokenGoes()
+    {
+        var userId = Guid.NewGuid();
+        _db.AddDeviceToken(new DeviceToken { DeviceId = Guid.NewGuid(), Token = "dead", UserId = userId });
+        _db.AddDeviceToken(new DeviceToken { DeviceId = Guid.NewGuid(), Token = "dead", UserId = userId });
+
+        Assert.Equal(2, _db.RemoveDeviceTokensNamed(["dead"]));
+        Assert.Empty(_db.GetAllDeviceTokens());
+    }
+
+    /// <summary>
+    /// Nothing to remove removes nothing, and says so, rather than opening a write for a
+    /// run where Expo reported everybody healthy.
+    /// </summary>
+    [Fact]
+    public void NothingNamedRemovesNothing()
+    {
+        _db.AddDeviceToken(new DeviceToken { DeviceId = Guid.NewGuid(), Token = "alive", UserId = Guid.NewGuid() });
+
+        Assert.Equal(0, _db.RemoveDeviceTokensNamed([]));
+        Assert.Equal(0, _db.RemoveDeviceTokensNamed(["never-registered"]));
+        Assert.Single(_db.GetAllDeviceTokens());
+    }
+
+    /// <summary>
+    /// Collecting an answered receipt forgets it, so the next run does not ask again.
+    /// </summary>
+    [Fact]
+    public void AnAnsweredPushIsForgotten()
+    {
+        _db.AddExpoReceipts([("ticket-a", "token-a"), ("ticket-b", "token-b")], Now);
+
+        _db.RemoveExpoReceipts(["ticket-a"]);
+
+        Assert.Equal(["ticket-b"], _db.GetExpoReceiptsSentBefore(Now, 100).Select(r => r.TicketId));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        TestDirectory.Delete(_directory);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoReceiptTests.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.PushNotifications;
+using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Working out which push tokens are dead, which is the whole of P4.2 and the only part
+/// of it that can delete something.
+/// </summary>
+/// <remarks>
+/// Expo reports a dead token twice: once at send time, as an error ticket, and once
+/// later through a receipt. The plugin listened to neither, so tokens accumulated
+/// forever and every send to them silently went nowhere.
+///
+/// <para>
+/// An error ticket carries no id and no token, so the only thing tying it back to a
+/// device is its position: Expo answers with one ticket per recipient, in the order the
+/// recipients were sent. Acting on that means a miscount deletes the wrong person's
+/// token and their notifications stop with nothing to show why, which is worse than the
+/// bug being fixed. Hence the count guard, and hence these tests.
+/// </para>
+/// </remarks>
+public class ExpoReceiptTests
+{
+    private static TicketStatus Ok(string id) => new() { Status = "ok", Id = id };
+
+    private static TicketStatus Failed(string error) => new()
+    {
+        Status = "error",
+        Details = new TicketDetails { Error = error }
+    };
+
+    /// <summary>
+    /// A ticket is matched to the recipient in the same position, so an error names the
+    /// token it came from.
+    /// </summary>
+    [Fact]
+    public void AnErrorTicketNamesTheTokenItCameFrom()
+    {
+        var outcome = ExpoTickets.Reconcile(
+            ["token-a", "token-b", "token-c"],
+            new ExpoNotificationResponse
+            {
+                Data = [Ok("ticket-a"), Failed(ExpoTickets.DeviceNotRegistered), Ok("ticket-c")]
+            },
+            null);
+
+        Assert.Equal(["token-b"], outcome.DeadTokens);
+        Assert.Equal(
+            [("ticket-a", "token-a"), ("ticket-c", "token-c")],
+            outcome.Pending.Select(p => (p.TicketId, p.Token)));
+    }
+
+    /// <summary>
+    /// Fewer tickets than recipients means the positions no longer line up, and acting on
+    /// them anyway would delete a token belonging to someone else. Nothing is pruned and
+    /// nothing is queued.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public void ACountThatDoesNotMatchPrunesNothing(int ticketCount)
+    {
+        var outcome = ExpoTickets.Reconcile(
+            ["token-a", "token-b", "token-c"],
+            new ExpoNotificationResponse
+            {
+                Data = Enumerable.Range(0, ticketCount)
+                    .Select(i => i == 1 ? Failed(ExpoTickets.DeviceNotRegistered) : Ok($"ticket-{i}"))
+                    .ToList()
+            },
+            null);
+
+        Assert.Empty(outcome.DeadTokens);
+        Assert.Empty(outcome.Pending);
+    }
+
+    /// <summary>
+    /// Only <c>DeviceNotRegistered</c> means the token is gone. The other errors are about
+    /// the message or the rate, and the device is still there.
+    /// </summary>
+    [Theory]
+    [InlineData("MessageRateExceeded")]
+    [InlineData("MessageTooBig")]
+    [InlineData("MismatchSenderId")]
+    [InlineData("InvalidCredentials")]
+    [InlineData(null)]
+    public void AnErrorThatIsNotDeviceNotRegisteredKeepsTheToken(string? error)
+    {
+        var outcome = ExpoTickets.Reconcile(
+            ["token-a"],
+            new ExpoNotificationResponse { Data = [Failed(error!)] },
+            null);
+
+        Assert.Empty(outcome.DeadTokens);
+
+        // No id, so there is nothing to ask a receipt about either.
+        Assert.Empty(outcome.Pending);
+    }
+
+    /// <summary>
+    /// A refused send returns null, which is not evidence about anybody's token.
+    /// </summary>
+    [Fact]
+    public void NoResponsePrunesNothing()
+    {
+        var outcome = ExpoTickets.Reconcile(["token-a"], null, null);
+
+        Assert.Empty(outcome.DeadTokens);
+        Assert.Empty(outcome.Pending);
+    }
+
+    /// <summary>
+    /// The delivery can fail after the ticket said ok, which is the case the plugin never
+    /// looked at: a receipt is the only place a token that died between the two is
+    /// reported.
+    /// </summary>
+    [Fact]
+    public void AReceiptSayingDeviceNotRegisteredKillsItsToken()
+    {
+        var dead = ExpoTickets.DeadTokensFrom(
+            new ExpoReceiptResponse
+            {
+                Data = new Dictionary<string, TicketStatus>
+                {
+                    ["ticket-a"] = Ok("ticket-a"),
+                    ["ticket-b"] = Failed(ExpoTickets.DeviceNotRegistered)
+                }
+            },
+            new Dictionary<string, string>
+            {
+                ["ticket-a"] = "token-a",
+                ["ticket-b"] = "token-b"
+            });
+
+        Assert.Equal(["token-b"], dead);
+    }
+
+    /// <summary>
+    /// A receipt for a ticket this server did not send is not a reason to delete anything.
+    /// Receipt ids come back from Expo, so a stale or duplicated one has to be inert.
+    /// </summary>
+    [Fact]
+    public void AReceiptForAnUnknownTicketIsIgnored()
+    {
+        var dead = ExpoTickets.DeadTokensFrom(
+            new ExpoReceiptResponse
+            {
+                Data = new Dictionary<string, TicketStatus>
+                {
+                    ["ticket-nobody-sent"] = Failed(ExpoTickets.DeviceNotRegistered)
+                }
+            },
+            new Dictionary<string, string> { ["ticket-a"] = "token-a" });
+
+        Assert.Empty(dead);
+    }
+
+    /// <summary>
+    /// A receipt that has not resolved yet, or that failed for a reason about the message,
+    /// leaves the token alone.
+    /// </summary>
+    [Fact]
+    public void AReceiptThatIsNotAboutTheDeviceKeepsItsToken()
+    {
+        var dead = ExpoTickets.DeadTokensFrom(
+            new ExpoReceiptResponse
+            {
+                Data = new Dictionary<string, TicketStatus>
+                {
+                    ["ticket-a"] = Failed("MessageRateExceeded")
+                }
+            },
+            new Dictionary<string, string> { ["ticket-a"] = "token-a" });
+
+        Assert.Empty(dead);
+    }
+
+    /// <summary>
+    /// The same token can be queued more than once, from two notifications sent to the
+    /// same device, and it should be reported dead once.
+    /// </summary>
+    [Fact]
+    public void ATokenReportedDeadTwiceIsReportedOnce()
+    {
+        var dead = ExpoTickets.DeadTokensFrom(
+            new ExpoReceiptResponse
+            {
+                Data = new Dictionary<string, TicketStatus>
+                {
+                    ["ticket-a"] = Failed(ExpoTickets.DeviceNotRegistered),
+                    ["ticket-b"] = Failed(ExpoTickets.DeviceNotRegistered)
+                }
+            },
+            new Dictionary<string, string>
+            {
+                ["ticket-a"] = "token-a",
+                ["ticket-b"] = "token-a"
+            });
+
+        Assert.Equal(["token-a"], dead);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/ExpoReceipt.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/ExpoReceipt.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Jellyfin.Plugin.Streamyfin.Db;
+
+/// <summary>
+/// A push Expo accepted, waiting for the receipt that says whether it was delivered.
+/// </summary>
+/// <remarks>
+/// Expo answers a send with a ticket, which only means the message was queued. Whether
+/// it reached the device, and in particular whether the device is gone, is only in the
+/// receipt, which becomes available minutes later and is kept for 24 hours. So the pair
+/// has to outlive the request, and a server restart, or the answer is lost.
+///
+/// <para>
+/// The token is stored beside the ticket rather than looked up afterwards, because by
+/// the time the receipt arrives the device may have registered a new token and the row
+/// this ticket belonged to would no longer be the right one to delete.
+/// </para>
+/// </remarks>
+public class ExpoReceipt
+{
+    /// <summary>
+    /// Gets or sets the ticket id Expo returned, which the receipt is asked for by.
+    /// </summary>
+    public string TicketId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Expo push token the ticket was sent to.
+    /// </summary>
+    public string Token { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets when the send happened, in UTC.
+    /// </summary>
+    /// <remarks>
+    /// Drives both ends of the window: a receipt is not asked for before Expo has had
+    /// time to produce one, and a row is dropped once Expo would no longer have it.
+    /// </remarks>
+    public DateTime CreatedAt { get; set; }
+}

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -246,14 +246,34 @@ public class PluginDatabase
     /// </summary>
     /// <param name="sentBefore">Only pushes older than this, in UTC.</param>
     /// <param name="limit">At most this many, since Expo takes 1000 ids per request.</param>
+    /// <param name="excluding">Ticket ids to skip, typically the ones already asked about.</param>
     /// <returns>The oldest ones first.</returns>
-    public List<ExpoReceipt> GetExpoReceiptsSentBefore(DateTime sentBefore, int limit)
+    /// <remarks>
+    /// The exclusion belongs in the query rather than in the caller, and that is not a
+    /// preference. A push Expo has not resolved keeps its row, so filtering after the
+    /// limit hands back the same oldest batch every time: a run whose first batch went
+    /// entirely unanswered would take that batch, filter it away, find nothing new and
+    /// stop, and everything behind it would wait for those rows to resolve or expire.
+    /// Excluding before the limit is what lets a backlog actually be walked.
+    /// </remarks>
+    public List<ExpoReceipt> GetExpoReceiptsSentBefore(
+        DateTime sentBefore,
+        int limit,
+        IReadOnlyCollection<string>? excluding = null)
     {
         using var context = CreateContext();
 
-        return context.ExpoReceipts.AsNoTracking()
-            .Where(r => r.CreatedAt <= sentBefore)
+        var query = context.ExpoReceipts.AsNoTracking()
+            .Where(r => r.CreatedAt <= sentBefore);
+
+        if (excluding is { Count: > 0 })
+        {
+            query = query.Where(r => !excluding.Contains(r.TicketId));
+        }
+
+        return query
             .OrderBy(r => r.CreatedAt)
+            .ThenBy(r => r.TicketId)
             .Take(limit)
             .ToList();
     }

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -165,6 +165,151 @@ public class PluginDatabase
     }
 
     /// <summary>
+    /// Forgets every device registered under a token Expo has reported as gone.
+    /// </summary>
+    /// <param name="tokens">The dead Expo push tokens.</param>
+    /// <returns>How many device rows were removed.</returns>
+    /// <remarks>
+    /// By token rather than by device id, because that is the only thing Expo names. One
+    /// token can sit on more than one row if a device re-registered under a new id
+    /// without the old row ever being cleaned up, which is the very accumulation this
+    /// removes, so every match goes.
+    /// </remarks>
+    public int RemoveDeviceTokensNamed(IEnumerable<string> tokens)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var dead = tokens.Distinct(StringComparer.Ordinal).ToList();
+        if (dead.Count == 0)
+        {
+            return 0;
+        }
+
+        using var context = CreateContext();
+
+        var rows = context.DeviceTokens.Where(t => dead.Contains(t.Token)).ToList();
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        context.DeviceTokens.RemoveRange(rows);
+        context.SaveChanges();
+
+        return rows.Count;
+    }
+
+    /// <summary>
+    /// Remembers the pushes Expo accepted, so their receipts can be asked for later.
+    /// </summary>
+    /// <param name="receipts">The ticket and token pairs.</param>
+    /// <param name="now">When the send happened, in UTC.</param>
+    /// <remarks>
+    /// A ticket id already stored is skipped rather than replaced. Expo does not reissue
+    /// them, so a collision would mean something is wrong upstream and the first row is
+    /// the one that knows which token it belonged to.
+    /// </remarks>
+    public void AddExpoReceipts(IEnumerable<(string TicketId, string Token)> receipts, DateTime now)
+    {
+        ArgumentNullException.ThrowIfNull(receipts);
+
+        var incoming = receipts.ToList();
+        if (incoming.Count == 0)
+        {
+            return;
+        }
+
+        using var context = CreateContext();
+
+        var ids = incoming.Select(r => r.TicketId).ToList();
+        var known = context.ExpoReceipts
+            .Where(r => ids.Contains(r.TicketId))
+            .Select(r => r.TicketId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var rows = incoming
+            .Where(r => known.Add(r.TicketId))
+            .Select(r => new ExpoReceipt { TicketId = r.TicketId, Token = r.Token, CreatedAt = now })
+            .ToList();
+
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        context.ExpoReceipts.AddRange(rows);
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// The pushes old enough for Expo to have produced a receipt.
+    /// </summary>
+    /// <param name="sentBefore">Only pushes older than this, in UTC.</param>
+    /// <param name="limit">At most this many, since Expo takes 1000 ids per request.</param>
+    /// <returns>The oldest ones first.</returns>
+    public List<ExpoReceipt> GetExpoReceiptsSentBefore(DateTime sentBefore, int limit)
+    {
+        using var context = CreateContext();
+
+        return context.ExpoReceipts.AsNoTracking()
+            .Where(r => r.CreatedAt <= sentBefore)
+            .OrderBy(r => r.CreatedAt)
+            .Take(limit)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Forgets pushes, whether they were answered or have simply expired.
+    /// </summary>
+    /// <param name="ticketIds">The ticket ids to drop.</param>
+    public void RemoveExpoReceipts(IEnumerable<string> ticketIds)
+    {
+        ArgumentNullException.ThrowIfNull(ticketIds);
+
+        var ids = ticketIds.Distinct(StringComparer.Ordinal).ToList();
+        if (ids.Count == 0)
+        {
+            return;
+        }
+
+        using var context = CreateContext();
+
+        var rows = context.ExpoReceipts.Where(r => ids.Contains(r.TicketId)).ToList();
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        context.ExpoReceipts.RemoveRange(rows);
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Forgets pushes Expo would no longer answer for.
+    /// </summary>
+    /// <param name="sentBefore">Only pushes older than this, in UTC.</param>
+    /// <returns>How many rows were dropped.</returns>
+    /// <remarks>
+    /// Expo keeps a receipt for 24 hours. Past that the answer is never coming, and a row
+    /// that is never removed is the same accumulation in a different table.
+    /// </remarks>
+    public int RemoveExpoReceiptsSentBefore(DateTime sentBefore)
+    {
+        using var context = CreateContext();
+
+        var rows = context.ExpoReceipts.Where(r => r.CreatedAt <= sentBefore).ToList();
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        context.ExpoReceipts.RemoveRange(rows);
+        context.SaveChanges();
+
+        return rows.Count;
+    }
+
+    /// <summary>
     /// Removes every device token.
     /// </summary>
     public void Purge()

--- a/Jellyfin.Plugin.Streamyfin/Db/StreamyfinDbContext.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/StreamyfinDbContext.cs
@@ -29,6 +29,7 @@ public class StreamyfinDbContext : DbContext
         SettingsGroupMembers = Set<SettingsGroupMember>();
         UserSettingsOverrides = Set<UserSettingsOverride>();
         GlobalConfigurations = Set<GlobalConfiguration>();
+        ExpoReceipts = Set<ExpoReceipt>();
     }
 
     /// <summary>
@@ -45,6 +46,7 @@ public class StreamyfinDbContext : DbContext
         SettingsGroupMembers = Set<SettingsGroupMember>();
         UserSettingsOverrides = Set<UserSettingsOverride>();
         GlobalConfigurations = Set<GlobalConfiguration>();
+        ExpoReceipts = Set<ExpoReceipt>();
     }
 
     /// <summary>
@@ -76,6 +78,11 @@ public class StreamyfinDbContext : DbContext
     /// Gets or sets the configuration the server declares for everyone. One row.
     /// </summary>
     public DbSet<GlobalConfiguration> GlobalConfigurations { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pushes Expo accepted, waiting for their delivery receipt.
+    /// </summary>
+    public DbSet<ExpoReceipt> ExpoReceipts { get; set; }
 
     /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -133,6 +140,17 @@ public class StreamyfinDbContext : DbContext
             entity.ToTable("GlobalConfigurations");
             entity.HasKey(c => c.Id);
             entity.Property(c => c.ConfigJson).IsRequired();
+        });
+
+        modelBuilder.Entity<ExpoReceipt>(entity =>
+        {
+            entity.ToTable("ExpoReceipts");
+            entity.HasKey(r => r.TicketId);
+            entity.Property(r => r.Token).IsRequired();
+            entity.Property(r => r.CreatedAt).IsRequired();
+            // Every read of this table is "what is old enough to ask about" and "what is
+            // too old to keep", so both ends of the window go through this column.
+            entity.HasIndex(r => r.CreatedAt);
         });
 
         base.OnModelCreating(modelBuilder);

--- a/Jellyfin.Plugin.Streamyfin/Migrations/20260901104820_AddExpoReceipts.Designer.cs
+++ b/Jellyfin.Plugin.Streamyfin/Migrations/20260901104820_AddExpoReceipts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Jellyfin.Plugin.Streamyfin.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jellyfin.Plugin.Streamyfin.Migrations
 {
     [DbContext(typeof(StreamyfinDbContext))]
-    partial class StreamyfinDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901104820_AddExpoReceipts")]
+    partial class AddExpoReceipts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.11");

--- a/Jellyfin.Plugin.Streamyfin/Migrations/20260901104820_AddExpoReceipts.cs
+++ b/Jellyfin.Plugin.Streamyfin/Migrations/20260901104820_AddExpoReceipts.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jellyfin.Plugin.Streamyfin.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpoReceipts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExpoReceipts",
+                columns: table => new
+                {
+                    TicketId = table.Column<string>(type: "TEXT", nullable: false),
+                    Token = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExpoReceipts", x => x.TicketId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpoReceipts_CreatedAt",
+                table: "ExpoReceipts",
+                column: "CreatedAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExpoReceipts");
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoReceiptTask.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoReceiptTask.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Streamyfin.PushNotifications;
+
+/// <summary>
+/// Collects the delivery receipts of pushes Expo accepted, and removes the tokens it
+/// reports as gone.
+/// </summary>
+/// <remarks>
+/// This is the half of P4.2 that cannot happen during a send. Expo answers a send with a
+/// ticket, which only says the message was queued; the receipt saying whether it arrived
+/// is produced minutes later. Nothing ever asked for one, so a device that uninstalled
+/// the app kept its row forever and every notification aimed at it was thrown away by
+/// Expo with nothing to show for it.
+///
+/// <para>
+/// A scheduled task rather than a timer inside the plugin: it survives a restart through
+/// the stored rows, an administrator can see it in the dashboard, run it by hand, and
+/// read why it did what it did.
+/// </para>
+///
+/// <para>
+/// Jellyfin discovers this by the interface, so nothing registers it.
+/// </para>
+/// </remarks>
+public class ExpoReceiptTask : IScheduledTask
+{
+    /// <summary>
+    /// How long a push is left alone before its receipt is asked for. Expo's own guidance
+    /// is to wait; asking immediately mostly returns nothing and burns the rate limit.
+    /// </summary>
+    private static readonly TimeSpan _ripeAfter = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// How long a push is kept at all. Expo keeps a receipt for 24 hours, so past that
+    /// the answer is never coming and the row is only another thing accumulating.
+    /// </summary>
+    private static readonly TimeSpan _expiresAfter = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Expo takes a thousand ticket ids per request, so that is one run's worth.
+    /// </summary>
+    private const int BatchSize = 1000;
+
+    private readonly NotificationHelper _notifications;
+    private readonly ILogger<ExpoReceiptTask> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExpoReceiptTask"/> class.
+    /// </summary>
+    /// <param name="notifications">The helper that talks to Expo.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    public ExpoReceiptTask(NotificationHelper notifications, ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _notifications = notifications;
+        _logger = loggerFactory.CreateLogger<ExpoReceiptTask>();
+    }
+
+    /// <inheritdoc />
+    public string Name => "Streamyfin push receipts";
+
+    /// <inheritdoc />
+    public string Key => "Jellyfin.Plugin.Streamyfin.ExpoReceipts";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Asks Expo what became of the notifications it accepted, and forgets the devices it reports as no longer registered.";
+
+    /// <inheritdoc />
+    public string Category => "Streamyfin";
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+    [
+        new TaskTriggerInfo
+        {
+            Type = TaskTriggerInfoType.IntervalTrigger,
+            IntervalTicks = TimeSpan.FromHours(1).Ticks
+        }
+    ];
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        var database = StreamyfinPlugin.Instance?.Database;
+
+        if (database is null)
+        {
+            _logger.LogDebug("No plugin database yet, nothing to collect");
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+
+        // Anything Expo would no longer answer for goes first, so an unreachable Expo or a
+        // run that keeps failing cannot let the table grow without bound.
+        var expired = database.RemoveExpoReceiptsSentBefore(now - _expiresAfter);
+        if (expired > 0)
+        {
+            _logger.LogInformation(
+                "Dropped {Count} push receipt(s) Expo no longer keeps an answer for",
+                expired);
+        }
+
+        progress?.Report(10);
+
+        var pending = database.GetExpoReceiptsSentBefore(now - _ripeAfter, BatchSize);
+
+        if (pending.Count == 0)
+        {
+            _logger.LogDebug("No push is waiting on a receipt");
+            progress?.Report(100);
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var ticketToToken = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var receipt in pending)
+        {
+            ticketToToken[receipt.TicketId] = receipt.Token;
+        }
+
+        var response = await _notifications
+            .FetchReceipts([.. ticketToToken.Keys])
+            .ConfigureAwait(false);
+
+        progress?.Report(70);
+
+        // A refused request is not an answer about anybody's token. The rows stay, and the
+        // next run asks again, until they expire on their own.
+        if (response is null)
+        {
+            _logger.LogWarning(
+                "Expo did not answer for {Count} push receipt(s), which will be asked for again",
+                pending.Count);
+            return;
+        }
+
+        var dead = ExpoTickets.DeadTokensFrom(response, ticketToToken);
+
+        if (dead.Count > 0)
+        {
+            var removed = database.RemoveDeviceTokensNamed(dead);
+
+            _logger.LogInformation(
+                "Expo reported {Devices} device(s) as no longer registered, {Rows} token row(s) removed",
+                dead.Count,
+                removed);
+        }
+
+        // Every ticket that was answered is done with, whatever it said. One that is still
+        // pending on Expo's side is absent from the answer and keeps its row for next time.
+        var answered = response.Data.Keys.Where(ticketToToken.ContainsKey).ToList();
+        database.RemoveExpoReceipts(answered);
+
+        _logger.LogInformation(
+            "Collected {Answered} of {Asked} push receipt(s)",
+            answered.Count,
+            pending.Count);
+
+        progress?.Report(100);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoReceiptTask.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoReceiptTask.cs
@@ -129,8 +129,10 @@ public class ExpoReceiptTask : IScheduledTask
         var ripe = now - _ripeAfter;
 
         // What has already been asked about in this run. A push Expo has not resolved yet
-        // keeps its row, so the next batch would hand back the same one: without this the
-        // run would ask the same thousand over and over and never reach the rest.
+        // keeps its row, so the next batch would otherwise hand back the same one. The set
+        // goes into the query rather than filtering its result: filtering afterwards means
+        // a batch that went entirely unanswered is taken, discarded, and the run stops
+        // with everything behind it untouched.
         var asked = new HashSet<string>(StringComparer.Ordinal);
         var collected = 0;
 
@@ -138,9 +140,7 @@ public class ExpoReceiptTask : IScheduledTask
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var pending = database.GetExpoReceiptsSentBefore(ripe, BatchSize)
-                .Where(receipt => asked.Add(receipt.TicketId))
-                .ToList();
+            var pending = database.GetExpoReceiptsSentBefore(ripe, BatchSize, asked);
 
             if (pending.Count == 0)
             {
@@ -150,6 +150,7 @@ public class ExpoReceiptTask : IScheduledTask
             var ticketToToken = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var receipt in pending)
             {
+                asked.Add(receipt.TicketId);
                 ticketToToken[receipt.TicketId] = receipt.Token;
             }
 

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoReceiptTask.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoReceiptTask.cs
@@ -44,9 +44,22 @@ public class ExpoReceiptTask : IScheduledTask
     private static readonly TimeSpan _expiresAfter = TimeSpan.FromHours(24);
 
     /// <summary>
-    /// Expo takes a thousand ticket ids per request, so that is one run's worth.
+    /// One request's worth, which is Expo's own limit.
     /// </summary>
-    private const int BatchSize = 1000;
+    private const int BatchSize = NotificationHelper.MaxReceiptsPerRequest;
+
+    /// <summary>
+    /// How many batches one run works through.
+    /// </summary>
+    /// <remarks>
+    /// A single batch per run was not enough. A library scan notifies every device at
+    /// once, so a burst can leave far more than a thousand pushes waiting, and at one
+    /// batch an hour against a 24 hour expiry the oldest would be dropped before anyone
+    /// asked what became of them. That is the very bug this part exists to fix, arriving
+    /// through the back door. Bounded all the same, so one run cannot hold the task open
+    /// indefinitely against an unusually large backlog: what is left waits for the next.
+    /// </remarks>
+    private const int MaxBatchesPerRun = 10;
 
     private readonly NotificationHelper _notifications;
     private readonly ILogger<ExpoReceiptTask> _logger;
@@ -58,6 +71,7 @@ public class ExpoReceiptTask : IScheduledTask
     /// <param name="loggerFactory">Logger factory.</param>
     public ExpoReceiptTask(NotificationHelper notifications, ILoggerFactory loggerFactory)
     {
+        ArgumentNullException.ThrowIfNull(notifications);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _notifications = notifications;
@@ -112,60 +126,80 @@ public class ExpoReceiptTask : IScheduledTask
 
         progress?.Report(10);
 
-        var pending = database.GetExpoReceiptsSentBefore(now - _ripeAfter, BatchSize);
+        var ripe = now - _ripeAfter;
 
-        if (pending.Count == 0)
+        // What has already been asked about in this run. A push Expo has not resolved yet
+        // keeps its row, so the next batch would hand back the same one: without this the
+        // run would ask the same thousand over and over and never reach the rest.
+        var asked = new HashSet<string>(StringComparer.Ordinal);
+        var collected = 0;
+
+        for (var batch = 0; batch < MaxBatchesPerRun; batch++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var pending = database.GetExpoReceiptsSentBefore(ripe, BatchSize)
+                .Where(receipt => asked.Add(receipt.TicketId))
+                .ToList();
+
+            if (pending.Count == 0)
+            {
+                break;
+            }
+
+            var ticketToToken = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var receipt in pending)
+            {
+                ticketToToken[receipt.TicketId] = receipt.Token;
+            }
+
+            var response = await _notifications
+                .FetchReceipts([.. ticketToToken.Keys], cancellationToken)
+                .ConfigureAwait(false);
+
+            // A refused request is not an answer about anybody's token. The rows stay, and
+            // the next run asks again, until they expire on their own.
+            if (response is null)
+            {
+                _logger.LogWarning(
+                    "Expo did not answer for {Count} push receipt(s), which will be asked for again",
+                    pending.Count);
+                break;
+            }
+
+            var dead = ExpoTickets.DeadTokensFrom(response, ticketToToken);
+
+            if (dead.Count > 0)
+            {
+                var removed = database.RemoveDeviceTokensNamed(dead);
+
+                _logger.LogInformation(
+                    "Expo reported {Devices} device(s) as no longer registered, {Rows} token row(s) removed",
+                    dead.Count,
+                    removed);
+            }
+
+            // Every ticket that was answered is done with, whatever it said. One that is
+            // still pending on Expo's side is absent from the answer and keeps its row,
+            // which is also why the next batch has to skip what this one already asked.
+            var answered = response.Data.Keys.Where(ticketToToken.ContainsKey).ToList();
+            database.RemoveExpoReceipts(answered);
+            collected += answered.Count;
+
+            progress?.Report(10 + (90.0 * (batch + 1) / MaxBatchesPerRun));
+        }
+
+        if (asked.Count > 0)
+        {
+            _logger.LogInformation(
+                "Collected {Collected} of {Asked} push receipt(s)",
+                collected,
+                asked.Count);
+        }
+        else
         {
             _logger.LogDebug("No push is waiting on a receipt");
-            progress?.Report(100);
-            return;
         }
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var ticketToToken = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var receipt in pending)
-        {
-            ticketToToken[receipt.TicketId] = receipt.Token;
-        }
-
-        var response = await _notifications
-            .FetchReceipts([.. ticketToToken.Keys])
-            .ConfigureAwait(false);
-
-        progress?.Report(70);
-
-        // A refused request is not an answer about anybody's token. The rows stay, and the
-        // next run asks again, until they expire on their own.
-        if (response is null)
-        {
-            _logger.LogWarning(
-                "Expo did not answer for {Count} push receipt(s), which will be asked for again",
-                pending.Count);
-            return;
-        }
-
-        var dead = ExpoTickets.DeadTokensFrom(response, ticketToToken);
-
-        if (dead.Count > 0)
-        {
-            var removed = database.RemoveDeviceTokensNamed(dead);
-
-            _logger.LogInformation(
-                "Expo reported {Devices} device(s) as no longer registered, {Rows} token row(s) removed",
-                dead.Count,
-                removed);
-        }
-
-        // Every ticket that was answered is done with, whatever it said. One that is still
-        // pending on Expo's side is absent from the answer and keeps its row for next time.
-        var answered = response.Data.Keys.Where(ticketToToken.ContainsKey).ToList();
-        database.RemoveExpoReceipts(answered);
-
-        _logger.LogInformation(
-            "Collected {Answered} of {Asked} push receipt(s)",
-            answered.Count,
-            pending.Count);
 
         progress?.Report(100);
     }

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoTickets.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoTickets.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Streamyfin.PushNotifications;
+
+/// <summary>
+/// Reading Expo's answers for what they say about the tokens they were sent to.
+/// </summary>
+/// <remarks>
+/// Expo reports a dead token twice. At send time, as a ticket whose
+/// <c>details.error</c> is <c>DeviceNotRegistered</c>. And later, through a receipt for
+/// a ticket that had said ok, because a delivery can still fail after being accepted.
+/// The plugin listened to neither, so a token stayed in the database after the app that
+/// owned it was uninstalled, and every send to it went nowhere with nothing to show for
+/// it.
+///
+/// <para>
+/// Kept apart from <see cref="NotificationHelper"/> and free of the database on purpose.
+/// This is the only code in the plugin that decides to delete something a user
+/// registered, and it decides it from an assumption about ordering, so it is worth being
+/// able to test on its own.
+/// </para>
+/// </remarks>
+public static class ExpoTickets
+{
+    /// <summary>
+    /// The one Expo error that means the token is gone rather than the message being
+    /// wrong. Pruning on any other would delete a live device over a rate limit.
+    /// </summary>
+    public const string DeviceNotRegistered = "DeviceNotRegistered";
+
+    private const string ErrorStatus = "error";
+
+    /// <summary>
+    /// Reads a send's answer: which of the recipients are dead, and which tickets are
+    /// worth asking a receipt about later.
+    /// </summary>
+    /// <param name="recipients">The tokens the request was sent to, in order.</param>
+    /// <param name="response">Expo's answer, or null when the send was refused.</param>
+    /// <param name="logger">Where a mismatch is reported.</param>
+    /// <returns>What to prune now and what to follow up.</returns>
+    /// <remarks>
+    /// An error ticket carries no id and no token. The only thing tying it back to a
+    /// device is its position, since Expo answers with one ticket per recipient in the
+    /// order they were sent. That assumption is load bearing and deleting the wrong
+    /// token would stop a user's notifications with nothing to show why, so it is only
+    /// acted on when the two counts agree exactly. They should always agree; the day
+    /// they do not, doing nothing is the right answer.
+    /// </remarks>
+    public static TicketOutcome Reconcile(
+        IReadOnlyList<string> recipients,
+        ExpoNotificationResponse? response,
+        ILogger? logger)
+    {
+        ArgumentNullException.ThrowIfNull(recipients);
+
+        var tickets = response?.Data;
+
+        if (tickets is null || tickets.Count == 0)
+        {
+            return TicketOutcome.Nothing;
+        }
+
+        if (tickets.Count != recipients.Count)
+        {
+            logger?.LogWarning(
+                "Expo answered with {Tickets} tickets for {Recipients} recipients, so a ticket cannot be "
+                + "matched to the device it came from. Nothing is pruned this time",
+                tickets.Count,
+                recipients.Count);
+
+            return TicketOutcome.Nothing;
+        }
+
+        var dead = new List<string>();
+        var pending = new List<PendingReceipt>();
+
+        for (var i = 0; i < tickets.Count; i++)
+        {
+            var ticket = tickets[i];
+
+            if (IsGone(ticket))
+            {
+                dead.Add(recipients[i]);
+                continue;
+            }
+
+            // Only an accepted ticket has an id, and only an id can be asked about later.
+            if (!string.IsNullOrEmpty(ticket.Id))
+            {
+                pending.Add(new PendingReceipt { TicketId = ticket.Id, Token = recipients[i] });
+            }
+        }
+
+        return new TicketOutcome(dead, pending);
+    }
+
+    /// <summary>
+    /// Reads the receipts of tickets that were accepted, and names the tokens that have
+    /// since been reported gone.
+    /// </summary>
+    /// <param name="response">Expo's answer, or null when the request was refused.</param>
+    /// <param name="ticketToToken">The tokens the tickets were sent to, by ticket id.</param>
+    /// <returns>The tokens to prune, each named once.</returns>
+    /// <remarks>
+    /// A receipt for a ticket this server did not send is ignored rather than trusted.
+    /// The ids come back from Expo, and a stale or duplicated one must not be able to
+    /// delete a token that is doing nothing wrong.
+    /// </remarks>
+    public static IReadOnlyList<string> DeadTokensFrom(
+        ExpoReceiptResponse? response,
+        IReadOnlyDictionary<string, string> ticketToToken)
+    {
+        ArgumentNullException.ThrowIfNull(ticketToToken);
+
+        if (response?.Data is null)
+        {
+            return [];
+        }
+
+        return response.Data
+            .Where(receipt => IsGone(receipt.Value))
+            .Select(receipt => ticketToToken.TryGetValue(receipt.Key, out var token) ? token : null)
+            .Where(token => token is not null)
+            .Select(token => token!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static bool IsGone(TicketStatus ticket) =>
+        string.Equals(ticket.Status, ErrorStatus, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(ticket.Details?.Error, DeviceNotRegistered, StringComparison.Ordinal);
+}
+
+/// <summary>
+/// A ticket Expo accepted, and the token it was accepted for.
+/// </summary>
+public class PendingReceipt
+{
+    /// <summary>
+    /// Gets the ticket id, which is what a receipt is asked for by.
+    /// </summary>
+    public required string TicketId { get; init; }
+
+    /// <summary>
+    /// Gets the Expo push token the ticket was for.
+    /// </summary>
+    public required string Token { get; init; }
+}
+
+/// <summary>
+/// What one send's answer said: what to delete now, and what to follow up later.
+/// </summary>
+public class TicketOutcome
+{
+    /// <summary>
+    /// An answer that says nothing about anybody's token.
+    /// </summary>
+    public static readonly TicketOutcome Nothing = new([], []);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TicketOutcome"/> class.
+    /// </summary>
+    /// <param name="deadTokens">Tokens Expo reported as gone.</param>
+    /// <param name="pending">Tickets worth asking a receipt about.</param>
+    public TicketOutcome(IReadOnlyList<string> deadTokens, IReadOnlyList<PendingReceipt> pending)
+    {
+        DeadTokens = deadTokens;
+        Pending = pending;
+    }
+
+    /// <summary>
+    /// Gets the tokens to remove, reported dead at send time.
+    /// </summary>
+    public IReadOnlyList<string> DeadTokens { get; }
+
+    /// <summary>
+    /// Gets the tickets Expo accepted, to ask a receipt about once it has had time to
+    /// deliver them.
+    /// </summary>
+    public IReadOnlyList<PendingReceipt> Pending { get; }
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/ExpoNotificationRequest.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/ExpoNotificationRequest.cs
@@ -133,3 +133,16 @@ public class ExpoNotificationRequest
     [JsonProperty(PropertyName = "mutableContent")]
     public bool MutableContent { get; set; }
 }
+
+/// <summary>
+/// Asking Expo for the receipts of tickets it handed back earlier.
+/// see: https://exp.host/--/api/v2/push/getReceipts
+/// </summary>
+public class ExpoReceiptRequest
+{
+    /// <summary>
+    /// Gets or sets the ticket ids to ask about. Expo takes a thousand per request.
+    /// </summary>
+    [JsonProperty("ids")]
+    public List<string> Ids { get; set; } = [];
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/ExpoNotificationResponse.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/ExpoNotificationResponse.cs
@@ -5,9 +5,32 @@ namespace Jellyfin.Plugin.Streamyfin.PushNotifications.models;
 
 public class ExpoNotificationResponse
 {
-    [JsonProperty(PropertyName = "data")] 
+    [JsonProperty(PropertyName = "data")]
     public List<TicketStatus> Data { get; set; } = [];
 
+    [JsonProperty(PropertyName = "errors")]
+    public List<Errors> Errors { get; set; } = [];
+}
+
+/// <summary>
+/// What Expo answers when asked for the receipts of tickets it accepted earlier.
+/// </summary>
+/// <remarks>
+/// Keyed by ticket id rather than positional, because a receipt can be asked for long
+/// after the send and Expo only keeps them for 24 hours: an id that has expired, or was
+/// never ours, is simply absent from the answer.
+/// </remarks>
+public class ExpoReceiptResponse
+{
+    /// <summary>
+    /// Gets or sets the receipts, by the ticket id they answer for.
+    /// </summary>
+    [JsonProperty(PropertyName = "data")]
+    public Dictionary<string, TicketStatus> Data { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the errors about the request itself, rather than about a delivery.
+    /// </summary>
     [JsonProperty(PropertyName = "errors")]
     public List<Errors> Errors { get; set; } = [];
 }
@@ -17,14 +40,34 @@ public class TicketStatus
     [JsonProperty(PropertyName = "status")] //"error" | "ok",
     public string? Status { get; set; }
 
-    [JsonProperty(PropertyName = "id")] 
+    [JsonProperty(PropertyName = "id")]
     public string? Id { get; set; }
 
     [JsonProperty(PropertyName = "message")]
     public string? Message { get; set; }
 
+    /// <summary>
+    /// Gets or sets what went wrong, when something did.
+    /// </summary>
+    /// <remarks>
+    /// Typed rather than <c>object</c>, because <c>details.error</c> is the only place
+    /// Expo says a token is dead and the plugin has to read it to prune. Nothing read
+    /// this field before it was given a shape.
+    /// </remarks>
     [JsonProperty(PropertyName = "details")]
-    public object? Details { get; set; }
+    public TicketDetails? Details { get; set; }
+}
+
+/// <summary>
+/// The machine readable half of a failed ticket or receipt.
+/// </summary>
+public class TicketDetails
+{
+    /// <summary>
+    /// Gets or sets Expo's error code, such as <c>DeviceNotRegistered</c>.
+    /// </summary>
+    [JsonProperty(PropertyName = "error")]
+    public string? Error { get; set; }
 }
 
 public class Errors

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
@@ -20,6 +20,10 @@ public class NotificationHelper
     /// </summary>
     public const string ExpoClientName = "streamyfin-expo";
 
+    private const string SendUri = "https://exp.host/--/api/v2/push/send";
+
+    private const string ReceiptsUri = "https://exp.host/--/api/v2/push/getReceipts";
+
     private readonly ILogger<NotificationHelper>? _logger;
     private readonly SerializationHelper _serializationHelper;
     private readonly IUserManager? _userManager;
@@ -146,18 +150,94 @@ public class NotificationHelper
         return await Send(expoNotifications).ConfigureAwait(false);
     }
 
-    public async Task<ExpoNotificationResponse?> Send(params ExpoNotificationRequest[] notifications) =>
-        await SendNotificationToExpo(_serializationHelper.ToJson(notifications)).ConfigureAwait(false);
-
-    private async Task<ExpoNotificationResponse?> SendNotificationToExpo(string serializedRequest)
+    public async Task<ExpoNotificationResponse?> Send(params ExpoNotificationRequest[] notifications)
     {
-        _logger?.LogDebug("Preparing to send notification");
+        ArgumentNullException.ThrowIfNull(notifications);
+
+        // The order Expo answers in. One ticket comes back per recipient, and that
+        // position is the only thing tying an error ticket to the device it came from.
+        var recipients = notifications.SelectMany(notification => notification.To).ToList();
+
+        var response = await PostToExpo<ExpoNotificationResponse>(
+            SendUri,
+            _serializationHelper.ToJson(notifications)).ConfigureAwait(false);
+
+        PruneAndQueue(recipients, response);
+
+        return response;
+    }
+
+    /// <summary>
+    /// Asks Expo what became of pushes it accepted earlier.
+    /// </summary>
+    /// <param name="ticketIds">The ticket ids to ask about, at most a thousand.</param>
+    /// <returns>The receipts, or null when the request was refused.</returns>
+    /// <remarks>
+    /// A ticket only says Expo took the message. Whether it arrived, and above all
+    /// whether the device is gone, is only ever in the receipt. Nothing called this
+    /// before P4.2, so a token stayed in the database after its app was uninstalled and
+    /// every later send to it went nowhere.
+    /// </remarks>
+    public async Task<ExpoReceiptResponse?> FetchReceipts(IReadOnlyList<string> ticketIds)
+    {
+        ArgumentNullException.ThrowIfNull(ticketIds);
+
+        if (ticketIds.Count == 0)
+        {
+            return null;
+        }
+
+        return await PostToExpo<ExpoReceiptResponse>(
+            ReceiptsUri,
+            _serializationHelper.ToJson(new ExpoReceiptRequest { Ids = [.. ticketIds] })).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Acts on what a send answer said about its recipients.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately silent when there is no plugin instance, which is the case in a unit
+    /// test: the decision itself is in <see cref="ExpoTickets"/> and is tested there,
+    /// without a database.
+    /// </remarks>
+    private void PruneAndQueue(IReadOnlyList<string> recipients, ExpoNotificationResponse? response)
+    {
+        var outcome = ExpoTickets.Reconcile(recipients, response, _logger);
+
+        var database = StreamyfinPlugin.Instance?.Database;
+        if (database is null)
+        {
+            return;
+        }
+
+        if (outcome.DeadTokens.Count > 0)
+        {
+            var removed = database.RemoveDeviceTokensNamed(outcome.DeadTokens);
+
+            _logger?.LogInformation(
+                "Expo reported {Devices} device(s) as no longer registered, {Rows} token row(s) removed",
+                outcome.DeadTokens.Count,
+                removed);
+        }
+
+        if (outcome.Pending.Count > 0)
+        {
+            database.AddExpoReceipts(
+                outcome.Pending.Select(pending => (pending.TicketId, pending.Token)),
+                DateTime.UtcNow);
+        }
+    }
+
+    private async Task<T?> PostToExpo<T>(string uri, string serializedRequest)
+        where T : class
+    {
+        _logger?.LogDebug("Preparing to call {Uri}", uri);
 
         // From the factory, never a new HttpClient per send: one built inline gets its own
         // connection pool every time and carries the default hundred second timeout, inside
         // an event handler that Jellyfin is waiting on.
         var client = _httpClientFactory.CreateClient(ExpoClientName);
-        using var httpRequest = GetHttpRequestMessage(serializedRequest);
+        using var httpRequest = GetHttpRequestMessage(uri, serializedRequest);
         using var rawResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
 
         // Expo answers 429 when it is being asked too often, and the body is then not a
@@ -168,7 +248,8 @@ public class NotificationHelper
             var body = await rawResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             _logger?.LogError(
-                "Expo refused the notification with {Status}: {Body}",
+                "Expo refused the request to {Uri} with {Status}: {Body}",
+                uri,
                 (int)rawResponse.StatusCode,
                 body.Length > 500 ? body[..500] : body);
 
@@ -177,13 +258,13 @@ public class NotificationHelper
 
         _logger?.LogDebug("Received response");
 
-        return await rawResponse.Content.ReadFromJsonAsync<ExpoNotificationResponse>().ConfigureAwait(false);
+        return await rawResponse.Content.ReadFromJsonAsync<T>().ConfigureAwait(false);
     }
 
-    private static HttpRequestMessage GetHttpRequestMessage(string content) => new()
+    private static HttpRequestMessage GetHttpRequestMessage(string uri, string content) => new()
     {
         Method = HttpMethod.Post,
-        RequestUri = new Uri("https://exp.host/--/api/v2/push/send"),
+        RequestUri = new Uri(uri),
         Headers =
         {
             { "Host", "exp.host" },

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Streamyfin.Extensions;
 using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
@@ -23,6 +24,11 @@ public class NotificationHelper
     private const string SendUri = "https://exp.host/--/api/v2/push/send";
 
     private const string ReceiptsUri = "https://exp.host/--/api/v2/push/getReceipts";
+
+    /// <summary>
+    /// How many ticket ids Expo takes in one receipts request.
+    /// </summary>
+    public const int MaxReceiptsPerRequest = 1000;
 
     private readonly ILogger<NotificationHelper>? _logger;
     private readonly SerializationHelper _serializationHelper;
@@ -158,9 +164,12 @@ public class NotificationHelper
         // position is the only thing tying an error ticket to the device it came from.
         var recipients = notifications.SelectMany(notification => notification.To).ToList();
 
+        // No token to pass: a send happens inside a synchronous Jellyfin event handler,
+        // which has none to give. The client timeout is what bounds it.
         var response = await PostToExpo<ExpoNotificationResponse>(
             SendUri,
-            _serializationHelper.ToJson(notifications)).ConfigureAwait(false);
+            _serializationHelper.ToJson(notifications),
+            CancellationToken.None).ConfigureAwait(false);
 
         PruneAndQueue(recipients, response);
 
@@ -171,14 +180,18 @@ public class NotificationHelper
     /// Asks Expo what became of pushes it accepted earlier.
     /// </summary>
     /// <param name="ticketIds">The ticket ids to ask about, at most a thousand.</param>
+    /// <param name="cancellationToken">Stops the call when the server is shutting down.</param>
     /// <returns>The receipts, or null when the request was refused.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">More ids than Expo takes at once.</exception>
     /// <remarks>
     /// A ticket only says Expo took the message. Whether it arrived, and above all
     /// whether the device is gone, is only ever in the receipt. Nothing called this
     /// before P4.2, so a token stayed in the database after its app was uninstalled and
     /// every later send to it went nowhere.
     /// </remarks>
-    public async Task<ExpoReceiptResponse?> FetchReceipts(IReadOnlyList<string> ticketIds)
+    public async Task<ExpoReceiptResponse?> FetchReceipts(
+        IReadOnlyList<string> ticketIds,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(ticketIds);
 
@@ -187,9 +200,15 @@ public class NotificationHelper
             return null;
         }
 
+        // Expo rejects the request past its cap, and a rejection is not an answer, so the
+        // rows would simply be asked about again every hour until they expired unread.
+        // Louder than a caller quietly never collecting anything.
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(ticketIds.Count, MaxReceiptsPerRequest);
+
         return await PostToExpo<ExpoReceiptResponse>(
             ReceiptsUri,
-            _serializationHelper.ToJson(new ExpoReceiptRequest { Ids = [.. ticketIds] })).ConfigureAwait(false);
+            _serializationHelper.ToJson(new ExpoReceiptRequest { Ids = [.. ticketIds] }),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -228,7 +247,10 @@ public class NotificationHelper
         }
     }
 
-    private async Task<T?> PostToExpo<T>(string uri, string serializedRequest)
+    private async Task<T?> PostToExpo<T>(
+        string uri,
+        string serializedRequest,
+        CancellationToken cancellationToken)
         where T : class
     {
         _logger?.LogDebug("Preparing to call {Uri}", uri);
@@ -238,14 +260,14 @@ public class NotificationHelper
         // an event handler that Jellyfin is waiting on.
         var client = _httpClientFactory.CreateClient(ExpoClientName);
         using var httpRequest = GetHttpRequestMessage(uri, serializedRequest);
-        using var rawResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
+        using var rawResponse = await client.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
         // Expo answers 429 when it is being asked too often, and the body is then not a
         // ticket list. Read as one anyway it yields a response with no tickets, which every
         // caller reads as a delivery that simply had nothing to report.
         if (!rawResponse.IsSuccessStatusCode)
         {
-            var body = await rawResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var body = await rawResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             _logger?.LogError(
                 "Expo refused the request to {Uri} with {Status}: {Body}",
@@ -258,7 +280,7 @@ public class NotificationHelper
 
         _logger?.LogDebug("Received response");
 
-        return await rawResponse.Content.ReadFromJsonAsync<T>().ConfigureAwait(false);
+        return await rawResponse.Content.ReadFromJsonAsync<T>(cancellationToken).ConfigureAwait(false);
     }
 
     private static HttpRequestMessage GetHttpRequestMessage(string uri, string content) => new()

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -59,7 +59,7 @@ Both now prune. The receipts half needs to outlive the request, since Expo takes
 to produce one, so an accepted push is stored as a ticket and token pair in a new
 `ExpoReceipts` table and a scheduled task collects them hourly: it asks about pushes
 older than fifteen minutes, a thousand at a time, prunes what comes back dead, forgets
-what was answered, and drops rows older than twenty four hours because past that Expo has
+what was answered, and drops rows older than twenty-four hours because past that Expo has
 no answer left to give.
 
 **The part that had to be got right.** An error ticket carries no id and no token. The

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -44,6 +44,41 @@ builds clean on both.
 to run is written down in [admin-ui-targeting.md](admin-ui-targeting.md) along with a
 casing gap on `LanguagePreference` that the same pass should confirm or dismiss.
 
+### P4.2, the dead tokens nobody was collecting
+
+Expo says a token is dead in two places and the plugin read neither, so a device that
+uninstalled the app kept its row forever and every notification aimed at it was accepted,
+queued and thrown away.
+
+- **At send time**, as a ticket whose `details.error` is `DeviceNotRegistered`. That
+  field was typed `object` and read by nothing.
+- **Later, in a receipt**, because a delivery can still fail after the ticket said ok.
+  `/push/getReceipts` was never called at all, which is the line the issue names.
+
+Both now prune. The receipts half needs to outlive the request, since Expo takes minutes
+to produce one, so an accepted push is stored as a ticket and token pair in a new
+`ExpoReceipts` table and a scheduled task collects them hourly: it asks about pushes
+older than fifteen minutes, a thousand at a time, prunes what comes back dead, forgets
+what was answered, and drops rows older than twenty four hours because past that Expo has
+no answer left to give.
+
+**The part that had to be got right.** An error ticket carries no id and no token. The
+only thing tying it to a device is its position, since Expo answers with one ticket per
+recipient in the order they were sent. Acting on that means a miscount deletes someone
+else's token and their notifications stop with nothing to show why, which is worse than
+the bug being fixed. So the mapping is only used when the two counts agree exactly,
+otherwise it logs and prunes nothing; and only `DeviceNotRegistered` prunes, never
+`MessageRateExceeded` or the others, which are about the message and not the device.
+
+That decision lives in `ExpoTickets`, deliberately apart from the helper and free of the
+database, because it is the only code in the plugin that deletes something a user
+registered. Thirteen tests on it alone, ten more on the store, 195 green on both targets.
+
+**A note for P4.3.** `SendToAll` still puts every token in one `to` field while Expo caps
+a message at a hundred recipients. The count guard means that cannot cause a wrong
+prune — a refused request is not an answer about anybody's token — but the send itself
+still fails silently past a hundred, and that is P4.3's to fix.
+
 ### P4.1, and a detour that says something about ordering
 
 [#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141): the push

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -181,7 +181,8 @@ weigh against dropping the embedded page machinery.
 ## P4. Push notifications
 
 - **P4.1** Inject `IHttpClientFactory` with a named client and a timeout
-- **P4.2** Read Expo receipts and prune `DeviceNotRegistered` tokens
+- **P4.2** Read Expo receipts and prune `DeviceNotRegistered` tokens, and the error
+  tickets that say the same thing at send time
 - **P4.3** Batching, honour 429 and `Retry-After`, retry with backoff
 - **P4.4** Declared events instead of the four hardcoded ones
 - **P4.5** Per user notification preferences, on top of P1
@@ -256,8 +257,9 @@ Everything merged below is on `develop`, which reaches `main` through
 | P1.6 | [#133](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/133) | merged |
 | P1.7 | [#134](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/134), [#135](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/135) | merged |
 | P3.1 | [#136](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/136), [#139](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/139) | merged |
-| P3.3 | this branch | open |
-| P4.1 | [#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141) | open |
+| P3.3 | [#142](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/142) | merged |
+| P4.1 | [#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141) | merged |
+| P4.2 | this branch | open |
 
 Not a numbered sub part, landed alongside P1:
 [#130](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/130), the

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -187,9 +187,15 @@ weigh against dropping the embedded page machinery.
 - **P4.4** Declared events instead of the four hardcoded ones
 - **P4.5** Per user notification preferences, on top of P1
 
-P4.2 is the one with user visible consequences. Expo only reports a dead token
-through `/push/getReceipts`, which the plugin never calls, so tokens accumulate
-forever and sends go nowhere.
+P4.2 is the one with user visible consequences. Expo reports a dead token twice
+and the plugin read neither: as an error ticket at send time, whose
+`details.error` is `DeviceNotRegistered`, and later through `/push/getReceipts`,
+which nothing ever called. So tokens accumulated forever and sends went nowhere.
+
+The paragraph that stood here said the receipts were the only source. Building it
+proved otherwise, which is written down rather than quietly corrected: the ticket
+is the cheaper of the two, since it arrives with the send and needs nothing
+stored, and it was in the response the whole time behind a field typed `object`.
 
 P4.4 absorbs #29, #34 and #30, and each needs an explicit decision rather than an
 open ended promise. See [issue-triage.md](issue-triage.md).

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -187,7 +187,7 @@ weigh against dropping the embedded page machinery.
 - **P4.4** Declared events instead of the four hardcoded ones
 - **P4.5** Per user notification preferences, on top of P1
 
-P4.2 is the one with user visible consequences. Expo reports a dead token twice
+P4.2 is the one with user-visible consequences. Expo reports a dead token twice
 and the plugin read neither: as an error ticket at send time, whose
 `details.error` is `DeviceNotRegistered`, and later through `/push/getReceipts`,
 which nothing ever called. So tokens accumulated forever and sends went nowhere.


### PR DESCRIPTION
Part of #114. Covers P4.2.

Expo says a push token is dead in two places and the plugin read neither, so a device that uninstalled the app kept its row forever and every notification aimed at it was accepted, queued and thrown away with nothing to show for it.

- **At send time**, as a ticket whose `details.error` is `DeviceNotRegistered`. That field was typed `object` and read by nothing.
- **Later, in a receipt**, because a delivery can still fail after the ticket said ok. `/push/getReceipts` was never called at all, which is the line #114 names.

Both now prune.

## The receipts have to outlive the request

Expo takes minutes to produce a receipt, so an accepted push is stored as a ticket and token pair in a new `ExpoReceipts` table, and a scheduled task collects them hourly:

- asks about pushes older than **15 minutes**, a thousand at a time, which is Expo's own limit per request;
- prunes the tokens that come back `DeviceNotRegistered`;
- forgets every ticket that was answered, whatever it said, and leaves the ones Expo has not resolved yet;
- drops rows older than **24 hours**, because past that Expo has no answer left to give and a row nothing removes is the same accumulation in a different table.

A scheduled task rather than a timer: it survives a restart through the stored rows, and an administrator can see it, run it by hand and read why it did what it did.

The token is stored beside its ticket rather than looked up when the receipt arrives. By then the device may have registered a new token, and the row this ticket belonged to would no longer be the right one to delete.

## The part that had to be got right

An error ticket carries no id and no token. **The only thing tying it to a device is its position**, since Expo answers with one ticket per recipient in the order they were sent.

Acting on that means a miscount deletes someone else's token, and their notifications stop with nothing to show why — worse than the bug being fixed. So:

- the mapping is used **only when the two counts agree exactly**, otherwise it logs and prunes nothing;
- **only `DeviceNotRegistered` prunes**, never `MessageRateExceeded`, `MessageTooBig`, `MismatchSenderId` or `InvalidCredentials`, which are about the message and not about the device;
- a receipt for a ticket this server did not send is ignored, since the ids come back from Expo and a stale one must not be able to delete a healthy token.

That decision lives in `ExpoTickets`, deliberately apart from `NotificationHelper` and free of the database, because it is the only code in the plugin that deletes something a user registered and it should be testable without either.

## Verification

**195 tests green** on jf11 and jf12, Release builds clean on both.

Thirteen of them are on `ExpoTickets` alone — the position mapping, the count guard in both directions, each error code that must *not* prune, an unknown receipt id, and a token reported dead twice. Ten more are on the store: the fifteen minute and twenty four hour ends of the window, oldest first, the batch cap, a repeated ticket id, and that every row carrying a dead token goes.

The send time half is exercised against the real Expo, on the beta, on 2026-09-10: a well formed token Expo never issued, registered for a test administrator only, then one notification targeted at that user. Expo answered the ticket `DeviceNotRegistered` ("is not a registered push notification recipient"), the log says `Expo reported 1 device(s) as no longer registered, 1 token row(s) removed`, the row is gone and `ExpoReceipts` stays empty, since an error ticket has no id to ask about. No other token was targeted.

The receipt half is not, and cannot be without a real device: a receipt needs a ticket Expo accepted, which needs a push token a real installation registered. The two existing live tests still reach Expo and this adds none. That pass is owed with a phone connected to the beta before a release carries this.

Two things only a running server can answer, both checked on the beta, Jellyfin 12.0.0, on 2026-09-10, with this branch's jf12 build:

- Jellyfin discovers `ExpoReceiptTask` and constructs it: `GET /ScheduledTasks` lists *Streamyfin push receipts* under the Streamyfin category with its hourly interval trigger, and a run started by hand answers 204 and completes in under a second on an empty `ExpoReceipts` table. No send happens on that path, so the real device tokens the beta carries were never touched;
- the `ExpoReceipts` migration applies on a database that already carries the earlier three: `__EFMigrationsHistory` lists the four, the table exists, and the plugin loads with no error in the log.

## A note for P4.3

`SendToAll` still puts every token in one `to` field while Expo caps a message at a hundred recipients. The count guard means that cannot cause a wrong prune — a refused request is not an answer about anybody's token — but the send itself still fails silently past a hundred. That is P4.3's to fix.
