### PR TITLE
docs(rewrite): fix two things the review of #142 found after it merged

### DIFF
--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -488,14 +488,20 @@ public class StreamyfinController : ControllerBase
   /// The settings targeted at one user.
   /// </summary>
   /// <param name="userId">The Jellyfin user id.</param>
-  /// <returns>The settings, or an empty body when the user has none.</returns>
+  /// <returns>The settings, in an object that carries none when the user has no override.</returns>
   /// <remarks>
+  /// Always a JSON object and never an empty body: a user with no override answers with
+  /// the settings simply absent. That is what lets the targeting screen read every answer
+  /// the same way instead of special casing one of them.
+  ///
+  /// <para>
   /// The only one of the targeting routes with no unversioned shim, because it is the
   /// only one that was never served: P1.2 gave this level a write and a delete and no
   /// read, which left the targeting screen nothing to open an existing override with.
   /// Read through the same tolerant path the resolution uses, so an override whose JSON
   /// cannot be read still answers rather than failing, and an administrator can see it
   /// to repair it.
+  /// </para>
   /// </remarks>
   [HttpGet("v1/users/{userId}/settings")]
   [Authorize(Policy = Policies.RequiresElevation)]

--- a/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.html
@@ -18,11 +18,13 @@
         /* The member picker: a plain list of the server's users, so an administrator sees
            who exists rather than having to know a Jellyfin user id. */
         #sf-members { max-height: 16em; overflow-y: auto; margin: 0.5em 0 1em; }
+        /* Not a flex row. The dashboard's checkbox positions its input absolutely, so a
+           flex row took the box out of the flow and drew it on top of the first letters
+           of every name. The label leaves room for it instead. */
         #sf-members label {
-            display: flex;
-            align-items: center;
-            gap: 0.5em;
-            padding: 0.25em;
+            position: relative;
+            display: block;
+            padding: 0.35em 0 0.35em 2em;
         }
 
         /* Overrides are rendered by the same generated form the Application tab uses, in
@@ -62,6 +64,42 @@
         #sf-overrides .je-indented-panel .je-indented-panel {
             border-left: 2px solid rgba(255, 255, 255, 0.08);
             padding-left: 0.6em;
+        }
+
+        /* json-editor draws the property picker as a bare white panel, and the dashboard's
+           own text colour is white, so every setting name in it came out invisible. That
+           picker is the only way to add an override or drop one, so an unreadable one
+           makes this page useless exactly where it matters. Found on the beta; no unit
+           test can see a colour. */
+        #sf-overrides .je-modal {
+            background: #1c1c1c;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            border-radius: 4px;
+            padding: 0.4em 0.7em;
+            max-height: 22em;
+            overflow-y: auto;
+        }
+        #sf-overrides .je-modal label {
+            display: block;
+            color: rgba(255, 255, 255, 0.9);
+            padding: 0.2em 0;
+            white-space: nowrap;
+        }
+
+        /* json-editor's own buttons, which the Application tab hides outright. Here the
+           properties button is the affordance for adding a setting, so it stays, and it
+           is dressed to look like it belongs rather than like raw browser chrome. */
+        #sf-overrides button[class*="json-editor-btn"] {
+            background: rgba(255, 255, 255, 0.08);
+            color: inherit;
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            border-radius: 3px;
+            padding: 0.15em 0.6em;
+            font-size: 0.85em;
+            margin-right: 0.4em;
+        }
+        #sf-overrides button[class*="json-editor-btn"]:hover {
+            background: rgba(255, 255, 255, 0.16);
         }
 
         .sf-hidden { display: none; }

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -41,7 +41,8 @@ months.
 **Generated admin forms.** `@json-editor/json-editor` 2.15.2 is already vendored
 in `Pages/Libraries/` and imported by nothing. Simple settings render from the
 JSON schema the plugin already publishes. The home editor and the group targeting
-screen stay hand written. That hybrid is what KefinTweaks landed on in
+screen were to stay hand written, which held for one of the two and not for the
+other, as the paragraph below records. That hybrid is what KefinTweaks landed on in
 `scripts/configuration.js`: descriptor driven for the repetitive fields, hand
 written where the shape is genuinely irregular.
 


### PR DESCRIPTION
Two review findings on #142 that landed after it was merged. Both are documentation, no behaviour changes.

**The route said it could answer with an empty body.** `GET v1/users/{userId}/settings` always returns a JSON object; a user with no override gets one with the settings absent. That is what lets the targeting page read every answer the same way, and it calls `response.json()`, which an empty body would have thrown on. The remark now says so.

**The plan contradicted itself about the targeting screen.** The decisions section still stated it would stay hand written, two paragraphs above the one recording that it went the other way. Qualified rather than rewritten, so both the decision and the fact it was superseded stay readable.

172 tests green on both targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed member names being obscured by selection checkboxes on the targeting screen.
  * Improved visibility and readability of the override picker, including labels and action buttons.
  * Ensured user settings responses remain consistently readable when no override is configured or saved data cannot be read.

* **Documentation**
  * Updated planning documentation to clarify the status of the administration screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->