### PR TITLE
build(jf12): compile against Jellyfin 12.0.0, the release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,14 +7,16 @@
       JellyfinTarget=jf11  -> Jellyfin 10.11, .NET 9
       JellyfinTarget=jf12  -> Jellyfin 12,    .NET 10
 
-    Build the other target with: dotnet build -p:JellyfinTarget=jf12
+    Build the other target with: dotnet build -p:JellyfinTarget=jf11
 
-    The default stays jf11 while 12 is a release candidate. Flip it the day 12
-    goes stable, and drop the jf11 block entirely the day 10.11 support ends.
-    See Jellyfin.Plugin.Streamyfin/Compat/README.md for the removal procedure.
+    The default is jf12 since 12.0.0 shipped on 2026-09-08; it was jf11 while 12
+    was a release candidate. CI and the release always name the target, so the
+    default only decides what a bare build on a developer's machine produces.
+    Drop the jf11 block entirely the day 10.11 support ends. See
+    Jellyfin.Plugin.Streamyfin/Compat/README.md for the removal procedure.
   -->
   <PropertyGroup>
-    <JellyfinTarget Condition="'$(JellyfinTarget)' == ''">jf11</JellyfinTarget>
+    <JellyfinTarget Condition="'$(JellyfinTarget)' == ''">jf12</JellyfinTarget>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,9 +39,9 @@
 
   <PropertyGroup Condition="'$(JellyfinTarget)' == 'jf12'">
     <TargetFramework>net10.0</TargetFramework>
-    <JellyfinVersion>12.0.0-rc5</JellyfinVersion>
+    <JellyfinVersion>12.0.0</JellyfinVersion>
     <JellyfinAbi>12.0.0.0</JellyfinAbi>
-    <EfCoreVersion>10.0.10</EfCoreVersion>
+    <EfCoreVersion>10.0.11</EfCoreVersion>
     <DefineConstants>$(DefineConstants);JF12</DefineConstants>
   </PropertyGroup>
 

--- a/Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
+++ b/Jellyfin.Plugin.Streamyfin/Jellyfin.Plugin.Streamyfin.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
     <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
     <PackageReference Include="Namotion.Reflection" Version="3.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.16" />
     <PackageReference Include="NJsonSchema" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ $(error Failed to compute VERSION via scripts/next-version.js)
 endif
 
 # Which Jellyfin line to build for. See Directory.Build.props.
-JELLYFIN_TARGET ?= jf11
+JELLYFIN_TARGET ?= jf12
 
 # Ask MSBuild what this target compiles to instead of repeating the mapping
 # here, where it would drift from Directory.Build.props the first time a target


### PR DESCRIPTION
Part of #114. Not a numbered sub part: the `jf12` target follows Jellyfin 12.0.0, released on 2026-09-08, where it still compiled against `12.0.0-rc5`.

The release pins EF Core 10.0.11, so `EfCoreVersion` follows, and EF Core Design 10.0.11 asks for Newtonsoft.Json 13.0.4 where the csproj pinned 13.0.3: under the warning policy that downgrade is `NU1605` and the restore fails. `JellyfinAbi` stays `12.0.0.0`.

The second commit does what `Directory.Build.props` promised for the day 12 went stable: `jf12` is the default target there and in the `Makefile`. CI and the release always name the target, so this only decides what a bare build on a developer's machine produces.

## Verification

- 172 tests green on `net10.0` against the release packages, `jf11` restores and builds with the Newtonsoft patch. A bare `dotnet msbuild -getProperty:TargetFramework` answers `net10.0` and a bare `make print` says `jf12`. CI runs both targets.
- Loaded on the beta, Jellyfin 12.0.0, on 2026-09-11: the plugin loads with no error in the log against the release packages, and the push receipt task keeps running on it.
