### PR TITLE
fix(api): take an administrator to post a notification

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
@@ -135,4 +135,24 @@ public class ApiSurfaceTests
         Assert.Contains($"v1/{singular}", served);
         Assert.Contains(singular, served);
     }
+
+    /// <summary>
+    /// Posting a notification takes an administrator.
+    /// </summary>
+    /// <remarks>
+    /// A notification with no target goes to every registered device, so with a plain
+    /// <c>Authorize</c> any account on the server could push to everyone. The app never
+    /// calls this route: it registers and removes its own device and nothing else. An
+    /// API key counts as an administrator in Jellyfin, so integrations keep working.
+    /// </remarks>
+    [Fact]
+    public void PostingANotificationRequiresElevation()
+    {
+        var method = typeof(StreamyfinController).GetMethod(nameof(StreamyfinController.PostNotifications));
+
+        Assert.NotNull(method);
+        var authorize = method!.GetCustomAttribute<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>();
+        Assert.NotNull(authorize);
+        Assert.Equal(MediaBrowser.Common.Api.Policies.RequiresElevation, authorize!.Policy);
+    }
 }

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -225,14 +225,21 @@ public class StreamyfinController : ControllerBase
   }
 
   /// <summary>
-  /// Forward notifications to expos push service using persisted device tokens
+  /// Forward notifications to Expo's push service using the persisted device tokens.
   /// </summary>
-  /// <param name="notifications"></param>
-  /// <returns></returns>
+  /// <param name="notifications">What to send, each with an optional target.</param>
+  /// <returns>Expo's answer, or 202 when there was nobody to send to.</returns>
+  /// <remarks>
+  /// Elevated. A notification with no target goes to every registered device, so with a
+  /// plain <c>Authorize</c> any account on the server could push to everyone. The app
+  /// never calls this route: it registers and removes its own device and nothing else.
+  /// The callers are administrators and integrations holding an API key, which Jellyfin
+  /// treats as an administrator, so the webhook senders keep working.
+  /// </remarks>
   [HttpPost("v1/notifications")]
   [HttpPost("v1/notification")]
   [HttpPost("notification")]
-  [Authorize]
+  [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status200OK)]
   [ProducesResponseType(StatusCodes.Status202Accepted)]
   public ActionResult PostNotifications([FromBody, Required] List<Notification> notifications)


### PR DESCRIPTION
Part of #114. Found while reading the callers of the plugin's routes for the audit of #145.

`POST v1/notification` carried a plain `[Authorize]`. A notification with no target goes to every registered device, so any signed in account could push a message to every phone and TV on the server. P1.4 closed the read side of the configuration; this is the write side of the notifications.

The app never calls this route: it registers its own device on `POST device` and removes it on `DELETE device/{id}` at sign out, and nothing else. The callers are administrators and integrations holding an API key, which Jellyfin treats as an administrator, so the webhook senders keep working. The route now takes `Policies.RequiresElevation`, like the configuration and targeting writes, and a test holds the policy.

## Verification

- 173 tests green on `jf11`, the new one pins the policy on the action. CI runs both targets.
- Proven on the beta, Jellyfin 12.0.0, on 2026-09-11 with this branch's jf12 build: a non administrator token answers **403** on `POST v1/notification` where it answered 200 before, an administrator token targeting a user with no device answers **202**, and the same non administrator still registers and removes its own device on `POST device` and `DELETE device/{id}` (200, 200).
