### PR TITLE
fix(devices): register a device in one statement, so two at once cannot race

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/DatabaseTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/DatabaseTests.cs
@@ -52,6 +52,36 @@ public class DatabaseTests : IDisposable
     }
 
     /// <summary>
+    /// Two registrations of the same device at the same time both succeed and leave
+    /// one row.
+    /// </summary>
+    /// <remarks>
+    /// The app posts its push token twice on sign in. With a lookup followed by an
+    /// insert, the second post found nothing, inserted, and failed on the primary key
+    /// with a 500 while the first was still saving. Seen on the beta on 2026-09-11.
+    /// The write is one statement now, so there is no window between the two.
+    /// </remarks>
+    [Fact]
+    public void TwoRegistrationsOfTheSameDeviceAtOnceBothSucceed()
+    {
+        var deviceId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        for (var round = 0; round < 30; round++)
+        {
+            System.Threading.Tasks.Parallel.Invoke(
+                () => _db.AddDeviceToken(new DeviceToken { DeviceId = deviceId, Token = "left", UserId = userId }),
+                () => _db.AddDeviceToken(new DeviceToken { DeviceId = deviceId, Token = "right", UserId = userId }));
+        }
+
+        var stored = _db.GetDeviceTokenForDeviceId(deviceId);
+
+        Assert.NotNull(stored);
+        Assert.Contains(stored.Token, new[] { "left", "right" });
+        Assert.Equal(1, _db.TotalDevicesCount());
+    }
+
+    /// <summary>
     /// The timestamp is written by the store, not by the caller.
     /// </summary>
     [Fact]

--- a/Jellyfin.Plugin.Streamyfin.Tests/DatabaseTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/DatabaseTests.cs
@@ -69,6 +69,9 @@ public class DatabaseTests : IDisposable
 
         for (var round = 0; round < 30; round++)
         {
+            // Each round starts with no row, or only the first one could ever race: a
+            // lookup followed by an insert takes the update path once the row exists.
+            _db.RemoveDeviceToken(deviceId);
             System.Threading.Tasks.Parallel.Invoke(
                 () => _db.AddDeviceToken(new DeviceToken { DeviceId = deviceId, Token = "left", UserId = userId }),
                 () => _db.AddDeviceToken(new DeviceToken { DeviceId = deviceId, Token = "right", UserId = userId }));

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -112,25 +112,20 @@ public class PluginDatabase
         using var context = CreateContext();
 
         var timestamp = DateTime.UtcNow.ToFileTime();
-        var existing = context.DeviceTokens.FirstOrDefault(t => t.DeviceId == token.DeviceId);
 
-        // Updated in place rather than removed and re-added. Two SaveChanges calls
-        // are two transactions, and a failure between them would leave the device
-        // with no token at all, which the hand written store avoided by doing both
-        // inside one transaction.
-        if (existing is not null)
-        {
-            existing.Token = token.Token;
-            existing.UserId = token.UserId;
-            existing.Timestamp = timestamp;
-        }
-        else
-        {
-            token.Timestamp = timestamp;
-            context.DeviceTokens.Add(token);
-        }
-
-        context.SaveChanges();
+        // One statement, so two registrations of the same device cannot race each
+        // other. The app posts its token twice on sign in, and a lookup followed by an
+        // insert let the second one fail on the device id with a 500 while the first
+        // was still saving. An existing row is updated in place, never removed and
+        // re-added, so a device is never left without a token between two writes.
+        context.Database.ExecuteSqlInterpolated($"""
+            INSERT INTO DeviceTokens (DeviceId, Token, UserId, Timestamp)
+            VALUES ({token.DeviceId}, {token.Token}, {token.UserId}, {timestamp})
+            ON CONFLICT(DeviceId) DO UPDATE SET
+                Token = excluded.Token,
+                UserId = excluded.UserId,
+                Timestamp = excluded.Timestamp
+            """);
 
         token.Timestamp = timestamp;
         return token;


### PR DESCRIPTION
Part of #114. Found on 2026-09-11 while proving P4.2 with a real iPhone on the beta.

The app posts its push token twice on sign in, within a second, because the api and the user object change identity as it signs in. The plugin registered a device with a lookup followed by an insert, so the second post found nothing, inserted, and failed on the primary key:

```
Microsoft.Data.Sqlite.SqliteException: SQLite Error 19: 'UNIQUE constraint failed: DeviceTokens.DeviceId'
   at Jellyfin.Plugin.Streamyfin.Db.PluginDatabase.AddDeviceToken(DeviceToken token)
```

The first post had already stored the token, so the only symptom was a 500 in the server log on every sign in that happened to race, and a "Failed to push expo push token to plugin" line in the app's log.

The write is one upsert statement now (`INSERT ... ON CONFLICT(DeviceId) DO UPDATE`), so there is no window between a lookup and an insert. An existing row is still updated in place rather than removed and re-added, which is what P0.3 established to keep a device from ever being left without a token between two writes. The app side stops posting twice in streamyfin/streamyfin (a separate pull request), but the server must not answer 500 to a second registration whatever the client does.

## Verification

- 199 tests green on `jf11`; the new one registers the same device from two threads, thirty rounds, and expects one row with one of the two tokens. CI runs both targets.
- Proven on the beta, Jellyfin 12.0.0, on 2026-09-11 with this branch's jf12 build: ten rounds of two simultaneous registrations of the same device, twenty answers of 200, one row for the device, and not one `UNIQUE constraint` or `Error processing request` line in the log. Before the change the same double post from a phone had produced the 500 above.
