### PR TITLE
feat(settings): refuse a value the bounds do not allow

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsValidationTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsValidationTests.cs
@@ -1,0 +1,139 @@
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// What the server refuses to store.
+/// </summary>
+/// <remarks>
+/// Until this existed the admin form was the only thing that knew a skip time stops at
+/// sixty: the Yaml tab wrote whatever was typed, and the targeting routes took a JSON
+/// body from anything holding an API key. The bounds come from the same declaration the
+/// form draws from, so a setting is bounded once.
+/// </remarks>
+public class SettingsValidationTests
+{
+    /// <summary>
+    /// Settings within their bounds are stored.
+    /// </summary>
+    [Fact]
+    public void SettingsWithinTheirBoundsAreAccepted()
+    {
+        var settings = new Settings
+        {
+            forwardSkipTime = new Lockable<int> { value = 60, locked = false },
+            rewindSkipTime = new Lockable<int> { value = 0, locked = false },
+            subtitleSize = new Lockable<int> { value = 120, locked = true },
+        };
+
+        Assert.Empty(SettingsValidation.Problems(settings));
+        Assert.Null(SettingsValidation.Message(settings));
+    }
+
+    /// <summary>
+    /// A value past its bounds is refused, and the message names the setting the way an
+    /// administrator reads it rather than by its key.
+    /// </summary>
+    [Theory]
+    [InlineData(600)]
+    [InlineData(-5)]
+    public void AValueOutsideItsBoundsIsRefused(int value)
+    {
+        var settings = new Settings { forwardSkipTime = new Lockable<int> { value = value, locked = false } };
+
+        var problem = Assert.Single(SettingsValidation.Problems(settings));
+
+        Assert.Contains("Forward skip time", problem, System.StringComparison.Ordinal);
+        Assert.Contains("0 to 60", problem, System.StringComparison.Ordinal);
+        Assert.Contains(value.ToString(System.Globalization.CultureInfo.InvariantCulture), problem, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every setting out of bounds is named, not just the first, so one save says
+    /// everything that has to change.
+    /// </summary>
+    [Fact]
+    public void EverySettingOutOfBoundsIsNamed()
+    {
+        var settings = new Settings
+        {
+            forwardSkipTime = new Lockable<int> { value = 600, locked = false },
+            subtitleSize = new Lockable<int> { value = 900, locked = false },
+        };
+
+        Assert.Equal(2, SettingsValidation.Problems(settings).Count);
+    }
+
+    /// <summary>
+    /// A setting a level does not carry is not its business: it falls through to the
+    /// level below, and a partial level is the normal shape of a group.
+    /// </summary>
+    [Fact]
+    public void ASettingALevelDoesNotCarryIsNotChecked()
+    {
+        Assert.Empty(SettingsValidation.Problems(new Settings()));
+        Assert.Empty(SettingsValidation.Problems(null));
+    }
+
+    /// <summary>
+    /// A setting with no declared bounds accepts anything, which is what having no
+    /// bounds means.
+    /// </summary>
+    [Fact]
+    public void ASettingWithNoBoundsAcceptsAnything()
+    {
+        var settings = new Settings { maxAutoPlayEpisodeCount = new Lockable<int> { value = 9999, locked = false } };
+
+        Assert.Empty(SettingsValidation.Problems(settings));
+    }
+
+    /// <summary>
+    /// A null is not out of bounds. It is the app's own answer for a nullable setting,
+    /// the playback quality's "no cap", and refusing it here would refuse Max.
+    /// </summary>
+    [Fact]
+    public void ANullIsNotOutOfBounds()
+    {
+        var settings = new Settings { defaultBitrate = new Lockable<Configuration.Bitrate?> { value = null, locked = false } };
+
+        Assert.Empty(SettingsValidation.Problems(settings));
+    }
+
+    /// <summary>
+    /// Every bounded setting is a number, since bounds mean nothing on anything else.
+    /// </summary>
+    [Fact]
+    public void OnlyANumberCarriesBounds()
+    {
+        var wrong = SettingsSchema.Descriptors
+            .Where(d => d.Property.GetCustomAttribute<BoundsAttribute>() is not null)
+            .Where(d => SettingsForm.Describe().Single(f => f.Key == d.Key).Control != SettingsControl.Number)
+            .Select(d => d.Key)
+            .ToArray();
+
+        Assert.Empty(wrong);
+    }
+
+    /// <summary>
+    /// The bounds the server enforces are the bounds the form draws, because they are
+    /// the same declaration. A second list would drift the first time one moved.
+    /// </summary>
+    [Fact]
+    public void TheServerAndTheFormShareTheirBounds()
+    {
+        foreach (var field in SettingsForm.Describe().Where(f => f.Minimum is not null))
+        {
+            var bounds = SettingsSchema.Descriptors
+                .Single(d => d.Key == field.Key)
+                .Property.GetCustomAttribute<BoundsAttribute>();
+
+            Assert.NotNull(bounds);
+            Assert.Equal(field.Minimum, bounds!.Minimum);
+            Assert.Equal(field.Maximum, bounds.Maximum);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -125,6 +125,12 @@ public class StreamyfinController : ControllerBase
       return new ConfigSaveResponse { Error = true, Message = e.ToString() };
     }
 
+    var problem = SettingsValidation.Message(p.settings);
+    if (problem is not null)
+    {
+      return new ConfigSaveResponse { Error = true, Message = problem };
+    }
+
     StreamyfinPlugin.Instance!.Settings.Save(p);
 
     return new ConfigSaveResponse { Error = false };
@@ -413,6 +419,11 @@ public class StreamyfinController : ControllerBase
       return BadRequest("A group needs a name");
     }
 
+    if (SettingsValidation.Message(request.Settings) is { } problem)
+    {
+      return BadRequest(problem);
+    }
+
     var database = StreamyfinPlugin.Instance!.Database;
 
     var stored = database.SaveSettingsGroup(new SettingsGroup
@@ -449,6 +460,11 @@ public class StreamyfinController : ControllerBase
     if (string.IsNullOrWhiteSpace(request.Name))
     {
       return BadRequest("A group needs a name");
+    }
+
+    if (SettingsValidation.Message(request.Settings) is { } problem)
+    {
+      return BadRequest(problem);
     }
 
     var database = StreamyfinPlugin.Instance!.Database;
@@ -555,6 +571,7 @@ public class StreamyfinController : ControllerBase
   [HttpPut("users/{userId}/settings")]
   [Authorize(Policy = Policies.RequiresElevation)]
   [ProducesResponseType(StatusCodes.Status204NoContent)]
+  [ProducesResponseType(StatusCodes.Status400BadRequest)]
   public ActionResult SetUserSettingsOverride(
     [FromRoute, Required] Guid userId,
     [FromBody, Required] UserSettingsOverrideDto request)
@@ -567,6 +584,11 @@ public class StreamyfinController : ControllerBase
     {
       database.RemoveUserSettingsOverride(userId);
       return NoContent();
+    }
+
+    if (SettingsValidation.Message(request.Settings) is { } problem)
+    {
+      return BadRequest(problem);
     }
 
     database.SaveUserSettingsOverride(userId, _serializationHelperService.SerializeToJson(request.Settings));

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsValidation.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsValidation.cs
@@ -92,9 +92,10 @@ public static class SettingsValidation
         value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
 
     // 60 rather than 60.0, since every bound declared today is a whole number and an
-    // administrator reading the message is not thinking in doubles.
+    // administrator reading the message is not thinking in doubles. The comparison is a
+    // difference rather than an equality, which is how a double says "whole".
     private static string Number(double value) =>
-        value == Math.Floor(value) && Math.Abs(value) < 1e15
+        Math.Abs(value - Math.Truncate(value)) < 1e-9 && Math.Abs(value) < 1e15
             ? ((long)value).ToString(CultureInfo.InvariantCulture)
             : value.ToString(CultureInfo.InvariantCulture);
 }

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsValidation.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsValidation.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// What the server refuses to store.
+/// </summary>
+/// <remarks>
+/// The admin form already refuses a value outside a setting's bounds, and says which
+/// setting and why. It is the only thing that does: the Yaml tab writes whatever is
+/// typed, and the targeting routes take a JSON body from anything holding an API key.
+/// A skip time of 600 was accepted by all three, reached the app, and made a button
+/// jump ten minutes.
+///
+/// <para>
+/// The bounds come from <see cref="BoundsAttribute"/>, the same declaration the form
+/// draws from, so a setting is bounded once and both ends agree. Nothing here holds a
+/// list of keys.
+/// </para>
+/// </remarks>
+public static class SettingsValidation
+{
+    /// <summary>
+    /// The reasons these settings cannot be stored, one line each.
+    /// </summary>
+    /// <param name="settings">The settings, or the part of them a level carries.</param>
+    /// <returns>The problems, in declaration order. Empty when there are none.</returns>
+    public static IReadOnlyList<string> Problems(Settings? settings)
+    {
+        if (settings is null)
+        {
+            return [];
+        }
+
+        var problems = new List<string>();
+
+        foreach (var descriptor in SettingsSchema.Descriptors)
+        {
+            var bounds = descriptor.Property.GetCustomAttribute<BoundsAttribute>();
+            if (bounds is null)
+            {
+                continue;
+            }
+
+            // A level carries a setting or it does not. The absent ones are not this
+            // method's business: they fall through to the level below.
+            var lockable = descriptor.Property.GetValue(settings);
+            if (lockable is null)
+            {
+                continue;
+            }
+
+            var value = lockable.GetType().GetProperty("value")?.GetValue(lockable);
+            if (value is null || !IsNumber(value))
+            {
+                continue;
+            }
+
+            var number = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            if (number < bounds.Minimum || number > bounds.Maximum)
+            {
+                problems.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} accepts {1} to {2}, and this is {3}.",
+                    descriptor.DisplayName ?? descriptor.Key,
+                    Number(bounds.Minimum),
+                    Number(bounds.Maximum),
+                    Number(number)));
+            }
+        }
+
+        return problems;
+    }
+
+    /// <summary>
+    /// The problems as one message, or null when there are none.
+    /// </summary>
+    /// <param name="settings">The settings to check.</param>
+    /// <returns>The message, or <c>null</c>.</returns>
+    public static string? Message(Settings? settings)
+    {
+        var problems = Problems(settings);
+
+        return problems.Count == 0 ? null : string.Join(" ", problems);
+    }
+
+    private static bool IsNumber(object value) =>
+        value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
+
+    // 60 rather than 60.0, since every bound declared today is a whole number and an
+    // administrator reading the message is not thinking in doubles.
+    private static string Number(double value) =>
+        value == Math.Floor(value) && Math.Abs(value) < 1e15
+            ? ((long)value).ToString(CultureInfo.InvariantCulture)
+            : value.ToString(CultureInfo.InvariantCulture);
+}

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -184,6 +184,12 @@ serves without touching its files. The call has to go through reflection, since
 every plugin lives in its own `AssemblyLoadContext`, which is a real cost to
 weigh against dropping the embedded page machinery.
 
+**Server side validation** is not a numbered sub part and landed alongside P3.6:
+`SettingsValidation` refuses a value outside the `[Bounds]` a setting declares, on the
+YAML save and on both targeting writes, reading the same declaration the form draws
+from. What it does not catch is `value: null` on a whole number, which YamlDotNet reads
+as `0`; that needs the raw document rather than the deserialised settings.
+
 ## P4. Push notifications
 
 - **P4.1** Inject `IHttpClientFactory` with a named client and a timeout


### PR DESCRIPTION
Part of #114. Not a numbered sub part: the server enforces the bounds it publishes.

Until now the admin form was the only thing that knew a skip time stops at sixty. The Yaml tab writes whatever is typed, and the two targeting routes take a JSON body from anything holding an API key, so a skip time of 600 was accepted by all three, reached the app, and made a button jump ten minutes.

`SettingsValidation` reads the same `[Bounds]` the form draws from, so a setting is bounded once and both ends agree, and a test says so rather than a second list drifting from the first. Nothing in it holds a list of keys: it walks `SettingsSchema.Descriptors`.

It guards the four write paths, names **every** setting that is wrong rather than the first, and says it the way an administrator reads it:

```
Forward skip time accepts 0 to 60, and this is 600.
```

A setting a level does not carry is not checked, since that is the normal shape of a group, and **a null is not out of bounds**: that is the playback quality's Max.

## Verification

- **246 tests** on the plugin, run on jf11 and jf12 in CI. The new ones cover a value inside its bounds, past either end, several at once, a level that carries nothing, a setting with no bounds, and a null; plus two that keep the declaration single: every bounded setting is a number, and the bounds the server enforces are the ones the form draws.
- **Proven on the beta**, Jellyfin 12.0.0:

| Route | Sent | Answer |
|---|---|---|
| `POST v1/groups` | skip time 600 | 400, *Forward skip time accepts 0 to 60, and this is 600.* |
| `POST v1/groups` | skip time 45 | 200 |
| `PUT v1/groups/{id}` | subtitle size 900 | 400, *Subtitle scale size accepts 0 to 120, and this is 900.* |
| `PUT v1/users/{id}/settings` | rewind −5 | 400, *Rewind skip time accepts 0 to 60, and this is -5.* |
| `PUT v1/users/{id}/settings` | rewind 20 | 204 |
| `PUT v1/users/{id}/settings` | quality Max | 204 |
| `POST v1/config/yaml` | skip time 600 | refused, and the stored configuration still reads 15 |

## What this does not catch

`value: null` on a whole number is read by YamlDotNet as `0`, silently, so a hand written YAML can still set a subtitle size of zero by meaning nothing at all. After deserialisation a real 0 and a null are the same value, so refusing it means reading the raw document, which is a different change from this one. Written down in `log.md` rather than left implicit.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK
