### PR TITLE
build(release): let the release take the number it is given

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: "Create release"
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, such as 0.70.0.0. Left empty, it is computed from the commits since the last tag."
+        required: false
+        type: string
 
 permissions:
   pull-requests: write
@@ -25,6 +30,8 @@ jobs:
           node-version: "lts/*"
 
       - id: compute
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: echo "version=$(node scripts/next-version.js)" >> "$GITHUB_OUTPUT"
 
   build:

--- a/Jellyfin.Plugin.Streamyfin.Tests/Scripts/next-version.test.js
+++ b/Jellyfin.Plugin.Streamyfin.Tests/Scripts/next-version.test.js
@@ -1,0 +1,49 @@
+// The number a release goes out under. The script normally reads it from the commits
+// since the last tag, which answers "what does this change deserve"; a release is
+// sometimes a decision instead, and then the version is handed to it.
+
+import { describe, expect, test } from "bun:test";
+
+const run = (env) => {
+    const result = Bun.spawnSync(["node", "scripts/next-version.js"], {
+        env: { ...process.env, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+
+    return {
+        ok: result.exitCode === 0,
+        out: new TextDecoder().decode(result.stdout).trim(),
+        err: new TextDecoder().decode(result.stderr),
+    };
+};
+
+describe("next-version", () => {
+    test("computes a version from the commits when it is given none", () => {
+        const { ok, out } = run({ RELEASE_VERSION: "" });
+
+        expect(ok).toBe(true);
+        expect(out).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
+    });
+
+    test("an explicit version wins, padded to four segments", () => {
+        expect(run({ RELEASE_VERSION: "0.70.0.0" }).out).toBe("0.70.0.0");
+        expect(run({ RELEASE_VERSION: "0.70" }).out).toBe("0.70.0.0");
+        expect(run({ RELEASE_VERSION: "v1.2.3" }).out).toBe("1.2.3.0");
+    });
+
+    test("whitespace around it is not a version of its own", () => {
+        expect(run({ RELEASE_VERSION: "  0.70.0.0  " }).out).toBe("0.70.0.0");
+    });
+
+    // A typo in a release dialog must stop the release rather than tag something
+    // nobody meant.
+    test("something that is not a version stops the release", () => {
+        for (const bad of ["latest", "0.70.0.0.0", "1..2", "0.70.", "-1.0"]) {
+            const { ok, err } = run({ RELEASE_VERSION: bad });
+
+            expect(ok).toBe(false);
+            expect(err).toContain("RELEASE_VERSION is not a version");
+        }
+    });
+});

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
-# The admin pages are JavaScript that only a browser runs. These tests give them a DOM
-# (happy-dom) so the renderer can be held to account without a Jellyfin server.
+# The JavaScript this repository owns: the admin pages, which only a browser runs and
+# which get a DOM here (happy-dom), and the release scripts, which run under node.
 [test]
-root = "Jellyfin.Plugin.Streamyfin.Tests/Pages"
+root = "Jellyfin.Plugin.Streamyfin.Tests"
 preload = ["./Jellyfin.Plugin.Streamyfin.Tests/Pages/dom.setup.js"]

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -10,6 +10,18 @@ lives only in a comment thread is a decision nobody will find.
 
 ## 2026-09-11, later
 
+### The release takes the number it is given
+
+`scripts/next-version.js` reads the commits since the last tag, which answers what a
+change deserves: a `feat:` is a minor bump, so this release computed 0.69.0.0. A release
+is sometimes a decision instead, and no commit subject says 0.70 without also claiming a
+breaking change. The Create release workflow now takes an optional version, and the
+script uses it when it is given one and computes as before when it is not. A value that
+is not a version stops the release rather than tagging something nobody meant.
+
+`bun test` now looks at the whole test project rather than only its pages, since the
+release scripts are JavaScript this repository owns too.
+
 ### The Targeting tab moves onto the renderer, and json-editor goes
 
 The screen P3.3 built kept its shape and changed what draws a level's overrides. The

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -57,18 +57,24 @@ function applyBump([major, minor, patch], bump) {
 // the wrong one when a release is a decision: the rewrite is a minor bump by the rule
 // and a bigger number by intent, and there is no commit subject that says 0.70 without
 // also claiming a breaking change.
-const explicit = (process.env.RELEASE_VERSION || '').trim();
-if (explicit) {
+function chosen() {
+  const explicit = (process.env.RELEASE_VERSION || '').trim();
+  if (!explicit) return null;
   if (!VERSION_TAG_RE.test(explicit)) {
     throw new Error(`RELEASE_VERSION is not a version: ${explicit}`);
   }
-  process.stdout.write(parseVersion(explicit).join('.') + '\n');
-  process.exit(0);
+  return parseVersion(explicit);
 }
 
-const tag = lastVersionTag();
-const current = tag ? parseVersion(tag) : [0, 0, 0, 0];
-const next = applyBump(current, tag ? determineBump(commitsSince(tag)) : 'minor');
+function computed() {
+  const tag = lastVersionTag();
+  const current = tag ? parseVersion(tag) : [0, 0, 0, 0];
+  return applyBump(current, tag ? determineBump(commitsSince(tag)) : 'minor');
+}
+
+// One write and one exit path, and no process.exit: on a pipe, which is how the release
+// workflow reads this, exiting can cut a write that has not flushed.
+const next = chosen() ?? computed();
 
 if (next.some((n) => !Number.isInteger(n) || n < 0)) {
   throw new Error(`Computed invalid version: ${next.join('.')}`);

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -52,6 +52,20 @@ function applyBump([major, minor, patch], bump) {
   return [major, minor, patch + 1, 0];
 }
 
+// An explicit version wins over the computed one. The conventional commit rule answers
+// "what does this change deserve", which is the right answer for a routine release and
+// the wrong one when a release is a decision: the rewrite is a minor bump by the rule
+// and a bigger number by intent, and there is no commit subject that says 0.70 without
+// also claiming a breaking change.
+const explicit = (process.env.RELEASE_VERSION || '').trim();
+if (explicit) {
+  if (!VERSION_TAG_RE.test(explicit)) {
+    throw new Error(`RELEASE_VERSION is not a version: ${explicit}`);
+  }
+  process.stdout.write(parseVersion(explicit).join('.') + '\n');
+  process.exit(0);
+}
+
 const tag = lastVersionTag();
 const current = tag ? parseVersion(tag) : [0, 0, 0, 0];
 const next = applyBump(current, tag ? determineBump(commitsSince(tag)) : 'minor');


### PR DESCRIPTION
Part of #114, and needed before the tag.

`scripts/next-version.js` reads the commits since the last tag, which answers what a change deserves: a `feat:` is a minor bump, so this release computes **0.69.0.0** from 0.68.1.0. A release is sometimes a decision instead. There is no commit subject that says 0.70 without also claiming a breaking change, and `workflow_dispatch` took no inputs, so the number could not be chosen at all.

The **Create release** workflow now takes an optional `version`. Given one, the script uses it; given none, it computes as before, so nothing changes for a routine release. A value that is not a version stops the release rather than tagging something nobody meant.

```
$ RELEASE_VERSION=0.70.0.0 make print JELLYFIN_TARGET=jf12
version=0.70.0.0 target=jf12 tfm=net10.0 abi=12.0.0.0 file=streamyfin-0.70.0.0-jf12.zip manifest=manifest-jf12.json

$ RELEASE_VERSION=nope node scripts/next-version.js
Error: RELEASE_VERSION is not a version: nope

$ node scripts/next-version.js
0.69.0.0
```

`bun test` now looks at the whole test project rather than only its pages, since the release scripts are JavaScript this repository owns too. Four tests on the script: it computes when given nothing, an explicit version wins and is padded to four segments, surrounding whitespace is not part of it, and five malformed values each stop the release.

## Verification

- 59 tests under `bun test`, the four new ones included, in the `pages` job.
- The three commands above, run locally, and `make print` proves the number reaches the zip name and the manifest choice rather than only the script's own output.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Manual releases can now use an optional, explicitly specified version.
  - When no version is provided, release versioning continues to be calculated automatically.
  - Invalid version values are rejected with a clear error.

- **Documentation**
  - Added documentation covering configurable release versions, fallback behavior, validation, and expanded test coverage.

- **Tests**
  - Expanded automated coverage for version calculation, normalization, whitespace handling, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->