### PR TITLE
ci: give the repository the checks its siblings already have

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,76 @@
+name: Something is broken
+description: The plugin does not do what it says, or stops the server doing what it says.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The server log is what answers most of these. It is in the dashboard under
+        Logs, or on disk at `config/log/`. Please redact anything that identifies your
+        users or your server before pasting it.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: What you saw, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: How to get there
+      description: The shortest path from a working server to what you saw.
+      placeholder: |
+        1. Open the Streamyfin tab in the dashboard
+        2. …
+    validations:
+      required: true
+
+  - type: input
+    id: plugin
+    attributes:
+      label: Plugin version
+      description: The dashboard lists it under Plugins, and the Streamyfin tab shows it beside its name.
+      placeholder: "0.70.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: jellyfin
+    attributes:
+      label: Jellyfin version
+      placeholder: "12.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How Jellyfin runs
+      options:
+        - Docker
+        - Linux package
+        - Windows
+        - macOS
+        - Unraid, Synology or another appliance
+        - Something else
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: What the server log says
+      description: The lines around the moment it went wrong. Redact user names, addresses and keys.
+      render: text
+
+  - type: textarea
+    id: plugins
+    attributes:
+      label: The other plugins on this server
+      description: >
+        With their versions. Plugins share one process, so the one that breaks is not
+        always the one that reports it.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: A question about the app rather than the plugin
+    url: https://github.com/streamyfin/streamyfin/issues
+    about: Playback, downloads, the interface on a phone or a TV. The plugin is the server half.
+  - name: Ask the community
+    url: https://discord.gg/rgGVfjmnyM
+    about: Faster than an issue when you are not sure whether something is a bug.

--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -1,0 +1,33 @@
+name: Something is missing
+description: A setting, a screen or a behaviour the plugin should have.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What you are trying to do
+      description: >
+        The situation rather than the solution. A setting is easy to add and hard to
+        remove, so what it is for decides its shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you had in mind
+      description: Optional. If you already know how it should look, say so.
+
+  - type: dropdown
+    id: side
+    attributes:
+      label: Where it belongs
+      description: >
+        The plugin decides what a server offers. The app decides what a phone or a TV
+        does with it. A new app setting starts in the app.
+      options:
+        - The plugin, on the server
+        - The app
+        - I am not sure
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!--
+The title is a conventional commit: feat(settings): …, fix(api): …, docs(rewrite): …
+It becomes the commit message when this is squashed, so write it for someone reading
+`git log` in a year.
+-->
+
+## What this changes
+
+<!-- What it does, and what it was before. If it fixes something, say what was wrong
+     rather than only what is now right. -->
+
+## Why
+
+<!-- Part of #114? Fixes #N? If a decision was taken here rather than elsewhere, this is
+     where it is written down. -->
+
+## How it was checked
+
+<!-- Tests are the floor. Say which, and say what a test could not answer: the admin
+     pages are JavaScript that only a dashboard exercises, and the plugin only loads on
+     a real Jellyfin. A screenshot of a page goes here, with user names and addresses
+     redacted. -->
+
+- [ ] `dotnet test` on both targets, or CI says so
+- [ ] Seen on a real server, and which one

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Jellyfin's own packages pin the oldest server each target supports, which is a decision rather than a version to keep current. Directory.Build.props says why.",
+      "matchPackageNames": ["Jellyfin.Controller", "Jellyfin.Model"],
+      "enabled": false
+    },
+    {
+      "description": "EF Core follows the server's own pin, not the newest release: the host provides the runtime assembly, and a plugin ahead of it fails to load.",
+      "matchPackageNames": ["Microsoft.EntityFrameworkCore**"],
+      "enabled": false
+    },
+    {
+      "description": "Everything else that is only a build or test dependency can travel together.",
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "test and build tooling"
+    },
+    {
+      "description": "An action pinned by tag is updated in place; a major is a behaviour change and gets its own pull request, since a green job does not prove the job still does its work.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
@@ -110,7 +110,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: build-artifacts
           message: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # What a pull request adds to the dependency tree, before it is merged. The scheduled
+  # scan in security.yml reads what is already there; this reads what is arriving, and
+  # it is the only one that can run on a fork's pull request, since it needs no write.
+  dependencies:
+    name: dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
   build:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -75,8 +94,44 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  # The admin pages are JavaScript that only a browser runs. Their tests run under a
-  # test DOM, once, since nothing in them depends on the Jellyfin target.
+  # A reviewer who wants to try a pull request should not have to build it. The two
+  # artifacts above are one download away; this says so on the pull request, once, and
+  # says where the file goes on a server.
+  #
+  # Only for a branch in this repository: a fork's pull request gets a read only token
+  # whatever the permissions below say, so the job would fail rather than stay quiet.
+  artifacts:
+    name: point at the build
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: build-artifacts
+          message: |
+            **This branch is built.** Two DLLs, one per Jellyfin line, on [the run that produced them](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts):
+
+            | Artifact | For |
+            |---|---|
+            | `Jellyfin.Plugin.Streamyfin-jf11` | Jellyfin 10.11.9 and later |
+            | `Jellyfin.Plugin.Streamyfin-jf12` | Jellyfin 12 |
+
+            To try one, stop the server, drop the DLL over the one in
+            `config/data/plugins/Streamyfin_<version>/`, and start it again. Keep the
+            file you replaced: that is the way back.
+
+  # The JavaScript this repository owns: the admin pages, which only a browser runs and
+  # which get a test DOM here, and the release scripts. Once, since nothing in either
+  # depends on the Jellyfin target.
+  #
+  # --frozen-lockfile is the lockfile check as well as the install: it fails when
+  # package.json asks for something bun.lock does not carry, which is how a dependency
+  # gets added in a pull request and resolved differently on the next machine.
   pages:
     name: pages
     runs-on: ubuntu-latest
@@ -88,7 +143,7 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install
+      - name: Install, and check the lockfile agrees with package.json
         run: bun install --frozen-lockfile
 
       - name: Test

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -58,10 +58,14 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           stale-issue-message: >
-            This has been waiting on an answer for a month. It closes in three weeks
-            unless there is one; a comment reopens it at any time.
+            This has been waiting on an answer for a month. A comment keeps it open;
+            without one it closes in three weeks.
           stale-pr-message: >
-            This pull request has been waiting on its author for a month. It closes in
-            three weeks unless something moves; a comment reopens it at any time.
-          close-issue-message: "Closed for want of an answer. Comment to reopen."
-          close-pr-message: "Closed for want of an answer. Comment to reopen."
+            This pull request has been waiting on its author for a month. A comment
+            keeps it open; without one it closes in three weeks.
+          close-issue-message: >
+            Closed for want of an answer, which is bookkeeping rather than a verdict.
+            Reopen it, or open a new one and link here, and it gets read again.
+          close-pr-message: >
+            Closed for want of an answer, which is bookkeeping rather than a verdict.
+            Reopen it when there is something to say.

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -29,7 +29,7 @@ jobs:
       # The rewrite lands as a stack of pull requests onto develop, so one merging takes
       # the next one out of mergeable without touching it. Saying so on the pull request
       # beats finding out at merge time.
-      - uses: eps1lon/actions-label-merge-conflict@v3
+      - uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         with:
           dirtyLabel: merge conflict
           removeOnDirtyLabel: ""
@@ -48,7 +48,7 @@ jobs:
       # Only threads that were asked a question and never answered. An issue nobody has
       # replied to is waiting on the maintainers, and closing it for their own silence
       # is how a tracker stops being read. #81 sat nine months for exactly that reason.
-      - uses: actions/stale@v9
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           only-labels: waiting for the author
           exempt-issue-labels: confirmed,pinned,security

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,67 @@
+name: Housekeeping
+
+# The two things that go wrong on a repository nobody is watching: a pull request that
+# quietly stops merging, and a thread waiting on an answer that never comes. Neither is
+# about the code, so they live together and away from the build.
+on:
+  push:
+    branches: [develop]
+  pull_request_target:
+    branches: [develop, main]
+    types: [synchronize, opened, reopened]
+  schedule:
+    - cron: "20 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conflicts:
+    name: Label a pull request that stopped merging
+    if: github.event_name == 'push' || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      # The rewrite lands as a stack of pull requests onto develop, so one merging takes
+      # the next one out of mergeable without touching it. Saying so on the pull request
+      # beats finding out at merge time.
+      - uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: merge conflict
+          removeOnDirtyLabel: ""
+          commentOnDirty: "This pull request no longer merges cleanly into its base. Rebasing it will clear the label."
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+
+  stale:
+    name: Close what is waiting on nobody
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      # Only threads that were asked a question and never answered. An issue nobody has
+      # replied to is waiting on the maintainers, and closing it for their own silence
+      # is how a tracker stops being read. #81 sat nine months for exactly that reason.
+      - uses: actions/stale@v9
+        with:
+          only-labels: waiting for the author
+          exempt-issue-labels: confirmed,pinned,security
+          exempt-pr-labels: pinned
+          days-before-stale: 30
+          days-before-close: 21
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This has been waiting on an answer for a month. It closes in three weeks
+            unless there is one; a comment reopens it at any time.
+          stale-pr-message: >
+            This pull request has been waiting on its author for a month. It closes in
+            three weeks unless something moves; a comment reopens it at any time.
+          close-issue-message: "Closed for want of an answer. Comment to reopen."
+          close-pr-message: "Closed for want of an answer. Comment to reopen."

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/tags#get-a-tag","status":"404"} # v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -16,11 +16,11 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/tags#get-a-tag","status":"404"} # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
@@ -35,7 +35,7 @@ jobs:
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:   
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,90 @@
+name: Security
+
+# Two scanners on a schedule and on what lands, rather than on every pull request.
+# CodeQL reads the C# and the workflows themselves; Trivy reads the dependency tree and
+# looks for a secret or a misconfiguration. Both report to GitHub code scanning, which
+# needs a write token a fork's pull request never gets, so neither runs on one: the
+# dependency review in build.yml is what guards a pull request.
+on:
+  push:
+    branches: [main, develop]
+  schedule:
+    # Friday morning, so a finding has a working day in front of it.
+    - cron: "40 7 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [csharp, actions]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The plugin builds against Jellyfin 12 here. CodeQL needs one build, not both:
+      # the source is the same and the boundary between the two targets is held by
+      # CompatBoundaryTests rather than by a second scan.
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended
+
+      - name: Build
+        if: matrix.language == 'csharp'
+        run: dotnet build --configuration Release -p:JellyfinTarget=jf12
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}
+
+  trivy:
+    name: Dependencies and secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Unfixed findings are left out: a vulnerability with no released fix is a thing
+      # to know, not a thing this repository can act on, and it would drown the rest.
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          format: sarif
+          output: trivy.sarif
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif
+          category: trivy

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,10 +70,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Pinned by commit rather than by tag, and this is why: the dependency review on
+      # this pull request refused 0.28.0, a version published while this action's
+      # release pipeline was compromised. A tag is a name its owner can move; a commit
+      # is the code that was reviewed. Renovate reads the version in the comment.
+      #
       # Unfixed findings are left out: a vulnerability with no released fix is a thing
       # to know, not a thing this repository can act on, and it would drown the rest.
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -10,6 +10,47 @@ lives only in a comment thread is a decision nobody will find.
 
 ## 2026-09-11, later
 
+### The repository catches up with its siblings
+
+The app and seerr both carry a set of workflows this repository never had, and the
+plugin had two: a build and a pull request title lint. Read tab by tab against
+`streamyfin/streamyfin`, `streamyfin/seerr` and `intro-skipper/intro-skipper`, and what
+applies here was taken:
+
+- **`security.yml`**: CodeQL over the C# and over the workflows themselves, and a Trivy
+  filesystem scan for a vulnerable dependency, a leaked secret or a misconfiguration.
+  Both on what lands and weekly, never on a pull request, since uploading to code
+  scanning needs a write token a fork never gets.
+- **A dependency review on every pull request**, which is the half a scheduled scan
+  cannot do and the only one that runs on a fork, since it needs no write.
+- **`--frozen-lockfile` as the lockfile check**, now that `bun.lock` exists: it fails
+  when `package.json` asks for something the lockfile does not carry.
+- **A comment pointing at the build.** Two DLLs, one per Jellyfin line, are already
+  uploaded on every pull request; nothing said so, so nobody used them. It now says
+  where the file goes on a server and that the replaced one is the way back.
+- **`housekeeping.yml`**: a label on a pull request that stopped merging, which a stack
+  of pull requests onto `develop` produces every time one of them lands, and a stale
+  sweep that only touches threads waiting on their author. An issue nobody has answered
+  is waiting on us, and closing it for our own silence is how a tracker stops being
+  read: #81 sat nine months for that reason.
+- **Issue templates and a pull request template**, which this repository had none of,
+  and a Renovate configuration, which it also had none of. Renovate leaves the Jellyfin
+  and EF Core packages alone: those pin the oldest server each target supports and the
+  runtime the host provides, which are decisions rather than versions to keep current.
+
+What was deliberately not taken: the app's Crowdin sync, its Expo build matrix, seerr's
+Helm and Cypress jobs, and intro-skipper's SPDX header pass. The duplicate issue
+detector and the notification workflow are worth a second look once the release is out.
+
+**On sharing these across the organisation**: the `.github` repository gives every
+repository its community health files (issue templates, contributing, security policy,
+a pull request template) automatically, and workflow templates that are offered when
+someone creates a workflow. It does not run a workflow on other repositories. The rule
+that does, required workflows in an organisation ruleset, is a GitHub Enterprise
+feature, and this organisation is on the free plan. What works everywhere is a reusable
+workflow called by a few lines in each repository, which is the shape to move these into
+once they have proven themselves here.
+
 ### The release takes the number it is given
 
 `scripts/next-version.js` reads the commits since the last tag, which answers what a


### PR DESCRIPTION
Part of #114. The plugin had two workflows, a build and a title lint. The app and seerr carry a set this repository never had, so they were read tab by tab, along with intro-skipper's, and what applies here was taken.

## What arrives

**`security.yml`** — CodeQL over the C# and over the workflows themselves, and a Trivy filesystem scan for a vulnerable dependency, a leaked secret or a misconfiguration. Both on what lands and weekly, **never on a pull request**: uploading to code scanning needs a write token a fork's pull request never gets, so running it there would only produce a red job nobody can fix.

**A dependency review on every pull request**, in `build.yml`. That is the half a scheduled scan cannot do, it reads what is arriving rather than what is already there, and it is the only scan a fork can run since it needs no write.

**The lockfile check**, now that `bun.lock` exists: `bun install --frozen-lockfile` is the install and the check at once, and fails when `package.json` asks for something the lockfile does not carry.

**A comment pointing at the build.** Two DLLs, one per Jellyfin line, have been uploaded on every pull request since #117 and nothing ever said so, so nobody used them. A sticky comment now names both, says which server each is for, and says where the file goes and that the one it replaces is the way back. Same-repository branches only, since a fork's token cannot comment.

**`housekeeping.yml`** — a label on a pull request that stopped merging, which a stack of pull requests onto `develop` produces every time one of them lands, and a daily stale sweep. The sweep only touches threads **waiting on their author**: an issue nobody has answered is waiting on us, and closing it for our own silence is how a tracker stops being read. #81 sat nine months for exactly that reason.

**The templates this repository had none of**: two issue forms (one asks for the plugin version, the Jellyfin version, how the server runs, and the other plugins installed, since plugins share one process and the one that breaks is not always the one that reports it), a pull request template, and a Renovate configuration.

Renovate leaves `Jellyfin.Controller`, `Jellyfin.Model` and the EF Core packages alone on purpose: those pin the oldest server each target supports and the runtime the host provides, which are decisions recorded in `Directory.Build.props` rather than versions to keep current. A major bump of an action gets its own pull request, since a green job does not prove the job still does its work.

## What was deliberately left

The app's Crowdin sync and Expo build matrix, seerr's Helm and Cypress jobs, and intro-skipper's SPDX header pass: none of them have anything to act on here. The duplicate issue detector and the notification workflow are worth a second look once the release is out.

## On sharing these across the organisation

Asked for, and worth being exact about, because the mechanisms differ:

| | What it does | Here |
|---|---|---|
| Community health files in `streamyfin/.github` | Apply automatically to every repository that has none of its own: issue templates, contributing, security policy, code of conduct, funding, pull request template | Works today, nothing is there yet |
| Workflow templates in `streamyfin/.github` | Offered when someone creates a workflow. Not applied | Works today |
| Reusable workflows (`workflow_call`) | The real workflow lives once, each repository calls it in a few lines | Works today, and is the shape to move these into |
| Required workflows in an organisation ruleset | Runs a workflow on every repository and blocks the merge until it passes | **Not available**: GitHub Enterprise, and this organisation is on the free plan |

So there is no way to run one workflow everywhere without a line in each repository. The plan is to let these prove themselves here first, then lift the repository-agnostic ones (title lint, conflict label, stale, Trivy, CodeQL) into `streamyfin/.github` as reusable workflows and leave a caller in each repository.

## What this found on its own first run

The dependency review refused the Trivy action this pull request introduced: `0.28.0` was published while that project's release pipeline was compromised (`GHSA-69fq-xp46-6x23`). The check earned its place before it was merged.

It never ran: `security.yml` fires on a push to `main` or `develop`, on a schedule and by hand, so it did not run on this pull request, and no runner ever held a secret with that action loaded. Every third party action is pinned to the commit it was reviewed at now, with the version in a comment so Renovate still reads it, and `lint_pr.yml` came along since it was on floating tags too. A tag is a name its owner can move; an action runs with a token this repository handed it.

## Verification

- Every file parses, and the three templates and the Renovate config with them.
- What the workflows do cannot be proven before they run: this pull request is itself the first run of the dependency review, the lockfile check and the artifact comment, and the comment should appear below.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK
