### PR TITLE
ci: watch NuGet for a Jellyfin line the build does not know about

### DIFF
--- a/.github/workflows/nuget-watch.yml
+++ b/.github/workflows/nuget-watch.yml
@@ -1,0 +1,96 @@
+name: Watch for a new Jellyfin line
+
+# The 12.0 packages appeared on NuGet before anyone here noticed, and the plugin spent
+# three days compiling against a release candidate that had been superseded. This looks
+# once a day and opens an issue the first time a version the build does not know about
+# is published. It reads a public API and touches nothing else.
+on:
+  schedule:
+    - cron: "15 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nuget-watch
+  cancel-in-progress: true
+
+jobs:
+  look:
+    name: Jellyfin.Controller on NuGet
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Compare what is published against what is built
+        id: look
+        run: |
+          set -euo pipefail
+
+          # What this repository builds against, read from the file that decides it
+          # rather than from a list kept here, which would drift the day a target moves.
+          known=$(grep -o '<JellyfinVersion>[^<]*</JellyfinVersion>' Directory.Build.props \
+            | sed 's/<[^>]*>//g' | cut -d. -f1 | sort -u | tr '\n' ' ')
+          echo "Built against major versions: $known"
+
+          published=$(curl -fsS https://api.nuget.org/v3-flatcontainer/jellyfin.controller/index.json \
+            | jq -r '.versions[]' | cut -d. -f1 | sort -un | tr '\n' ' ')
+          echo "Published major versions: $published"
+
+          new=""
+          for major in $published; do
+            case " $known " in
+              *" $major "*) ;;
+              *) new="$new $major" ;;
+            esac
+          done
+
+          # A major older than everything built here is a line that was dropped on
+          # purpose, not news. Only something newer than the newest is.
+          newest_known=$(echo $known | tr ' ' '\n' | sort -n | tail -1)
+          worth=""
+          for major in $new; do
+            if [ "$major" -gt "$newest_known" ]; then worth="$worth $major"; fi
+          done
+
+          echo "worth=$(echo $worth | xargs)" >> "$GITHUB_OUTPUT"
+
+      - name: Say so, once
+        if: steps.look.outputs.worth != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          WORTH: ${{ steps.look.outputs.worth }}
+        with:
+          script: |
+            const majors = process.env.WORTH.trim().split(/\s+/);
+            const title = `Jellyfin ${majors.join(' and ')} packages are on NuGet`;
+
+            // One issue per line, reopened rather than duplicated: this runs every day.
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} in:title "${title}" type:issue`,
+            });
+            if (existing.data.total_count > 0) {
+              core.info(`Already said: #${existing.data.items[0].number}`);
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: ['dependencies'],
+              body: [
+                `\`Jellyfin.Controller\` now publishes ${majors.length > 1 ? 'versions' : 'a version'} this repository does not build against: **${majors.join(', ')}**.`,
+                '',
+                'Adding a target is four steps, written down in',
+                '[`Jellyfin.Plugin.Streamyfin/Compat/README.md`](../blob/develop/Jellyfin.Plugin.Streamyfin/Compat/README.md#adding-a-jellyfin-line-when-the-time-comes),',
+                'along with the two things that are worth checking before assuming a target is only a version number.',
+                '',
+                'Opened automatically by `nuget-watch.yml`. Closing it is the right answer if the line is not one this plugin will follow.',
+              ].join('\n'),
+            });

--- a/Jellyfin.Plugin.Streamyfin/Compat/README.md
+++ b/Jellyfin.Plugin.Streamyfin/Compat/README.md
@@ -18,3 +18,34 @@ domain is exactly what makes old runtimes impossible to retire.
 
 Nothing else in the codebase should need to change. If it does, something
 leaked out of this folder and the guard test was bypassed.
+
+## Adding a Jellyfin line, when the time comes
+
+The reverse of the list above, and it is meant to stay this short. As of
+2026-09-11 Jellyfin's `master` is versioned 13.0.0 and carries no API change
+against 12.0: the ten commits between them are a version bump, translations and
+issue templates. Nothing publishes a `13.*` package yet, so there is nothing to
+compile against. `nuget-watch.yml` says so the day there is.
+
+1. Add a `PropertyGroup` to `Directory.Build.props` for the new target, with its
+   `TargetFramework`, `JellyfinVersion`, `JellyfinAbi`, `EfCoreVersion` and its
+   `DefineConstants`. The floor is the oldest server the plugin actually uses,
+   not the oldest of the line: 10.11.9 is the floor of `jf11` because
+   `IUserManager.Users` became `GetUsers()` inside that patch line.
+2. Add it to the matrices in `build.yml` and `release.yml`, with the SDK it
+   needs.
+3. Give it its own manifest file name in the `MANIFEST` line of the `Makefile`.
+   The oldest line keeps `manifest.json`, so servers already pointed at that URL
+   do not break, and every newer line gets a `manifest-jfNN.json` beside it.
+4. Build both. Anything that fails to compile is a real difference, and it goes
+   in this folder behind `#if`, not where it was found.
+
+Two things that are worth checking before assuming a target is only a version
+number, because both bit this plugin on the 10.11 to 12 move:
+
+- **The EF Core version the host provides.** The plugin references it but the
+  server loads it, so a plugin ahead of its host fails to load. Read
+  `Directory.Packages.props` in the Jellyfin release rather than taking the
+  newest.
+- **A breaking change inside a patch line.** `IUserManager.Users` disappeared in
+  10.11.9, which is why no single artifact covers 10.11.0 through 10.11.11.


### PR DESCRIPTION
## What this is

Preparation for Jellyfin 13, which turns out to be preparation rather than a target.

Jellyfin's `master` already declares `13.0.0` in `SharedVersion.cs`, but it sits ten commits ahead of `v12.0` and every one of them is a version bump, a Weblate translation or an issue-template change. No API change, no milestone, and NuGet publishes nothing above `12.0.0`. There is nothing to compile against, so adding a `jf13` target today would only pin the build to a moving branch.

What can be done now is making sure nobody has to notice by hand.

## The watch

`nuget-watch.yml` runs once a day. It reads the majors out of `Directory.Build.props`, which is the file that decides what the build targets, compares them against the majors `jellyfin.controller` publishes, and opens one issue the first time something newer than the newest known target appears. A major older than everything built here is a line dropped on purpose, not news, so it stays quiet about those. The issue is deduplicated by title, since this runs every day, and it points at the procedure rather than repeating it.

It reads one public API and needs `issues: write` and nothing else.

The 12.0 packages appeared on NuGet before anyone here noticed, and the plugin spent three days compiling against a release candidate that had been superseded. That is the failure this closes.

## The procedure

`Compat/README.md` already told you how to drop a Jellyfin line. It now tells you how to add one: the four steps, and the two things worth checking before assuming a new target is only a version number, both of which bit this plugin on the 10.11 to 12 move.

- **The EF Core version the host provides.** The plugin references it, the server loads it, and a plugin ahead of its host fails to load. Read `Directory.Packages.props` in the Jellyfin release rather than taking the newest.
- **A breaking change inside a patch line.** `IUserManager.Users` became `GetUsers()` in 10.11.9, which is why no single artifact covers 10.11.0 through 10.11.11 and why the `jf11` floor is a patch version rather than a minor.

## Checked

- Every workflow parses.
- Both actions in the new file are pinned by commit, matching the convention the other workflows use.
- The steps were read back against `Directory.Build.props` and the `Makefile` rather than written from memory: the property names and the manifest naming are the ones actually there.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK