### PR TITLE
fix: close the two code scanning alerts on the integration branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
@@ -51,10 +51,10 @@ jobs:
             dotnet: 10.0.x
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
@@ -71,7 +71,7 @@ jobs:
         run: dotnet test Jellyfin.Plugin.Streamyfin.Tests --configuration Release --no-build -p:JellyfinTarget=${{ matrix.target }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
 
@@ -87,7 +87,7 @@ jobs:
           make update-manifest JELLYFIN_TARGET=${{ matrix.target }} DRY_RUN=1
 
       - name: Upload plugin
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Jellyfin.Plugin.Streamyfin-${{ matrix.target }}
           path: Jellyfin.Plugin.Streamyfin/bin/Release/*/Jellyfin.Plugin.Streamyfin.dll
@@ -137,9 +137,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
     outputs:
       version: ${{ steps.compute.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
 
@@ -43,17 +43,17 @@ jobs:
       matrix:
         target: [jf11, jf12]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             9.0.x
             10.0.x
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
 
@@ -69,7 +69,7 @@ jobs:
           make zip JELLYFIN_TARGET=${{ matrix.target }}
           make print JELLYFIN_TARGET=${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: streamyfin-${{ matrix.target }}
           path: dist/*.zip
@@ -82,21 +82,21 @@ jobs:
     env:
       VERSION: ${{ needs.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             9.0.x
             10.0.x
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,19 +34,19 @@ jobs:
         language: [csharp, actions]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # The plugin builds against Jellyfin 12 here. CodeQL needs one build, not both:
       # the source is the same and the boundary between the two targets is held by
       # CompatBoundaryTests rather than by a second scan.
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 10.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@faaca9a8f6edddba5725ffe5adefdab6669a2eca # v3.38.0
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended
@@ -56,7 +56,7 @@ jobs:
         run: dotnet build --configuration Release -p:JellyfinTarget=jf12
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@faaca9a8f6edddba5725ffe5adefdab6669a2eca # v3.38.0
         with:
           category: /language:${{ matrix.language }}
 
@@ -68,7 +68,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Pinned by commit rather than by tag, and this is why: the dependency review on
       # this pull request refused 0.28.0, a version published while this action's
@@ -89,7 +89,7 @@ jobs:
           output: trivy.sarif
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@faaca9a8f6edddba5725ffe5adefdab6669a2eca # v3.38.0
         with:
           sarif_file: trivy.sarif
           category: trivy

--- a/Jellyfin.Plugin.Streamyfin.Tests/RecordingLogger.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/RecordingLogger.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// A logger that keeps what it was told, so a test can read a log line.
+/// </summary>
+/// <typeparam name="T">The category, which nothing here uses.</typeparam>
+public sealed class RecordingLogger<T> : ILogger<T>
+{
+    /// <summary>
+    /// Gets the messages, formatted as a real logger would format them.
+    /// </summary>
+    public List<string> Messages { get; } = [];
+
+    /// <inheritdoc/>
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    /// <inheritdoc/>
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        Messages.Add(formatter(state, exception));
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/SettingsGroupTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SettingsGroupTests.cs
@@ -300,6 +300,44 @@ public class SettingsGroupTests : IDisposable
         Assert.Equal(42, _resolution.ReadLevel(stored, "a test")?.subtitleSize?.value);
     }
 
+    /// <summary>
+    /// The warning about an unreadable level stays on one line, whatever it is told
+    /// the level is called.
+    /// </summary>
+    /// <remarks>
+    /// Callers name a level by its id, so this is defence rather than a live hole,
+    /// but a log line assembled from a name someone typed is how a forged entry gets
+    /// written, and this one only appears when stored data is already wrong.
+    /// </remarks>
+    [Fact]
+    public void TheWarningAboutAnUnreadableLevelStaysOnOneLine()
+    {
+        var log = new RecordingLogger<SettingsResolutionService>();
+        var resolution = new SettingsResolutionService(_serialization, log);
+
+        Assert.Null(resolution.ReadLevel("{ this is not json", "group Night\r\nfatal: everything is fine"));
+
+        var written = Assert.Single(log.Messages);
+        Assert.DoesNotContain("\n", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", written, StringComparison.Ordinal);
+        Assert.Contains("group Night", written, StringComparison.Ordinal);
+        Assert.Contains("fatal: everything is fine", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A level named by nothing at all still says something.
+    /// </summary>
+    [Fact]
+    public void ALevelNamedByNothingStillSaysSomething()
+    {
+        var log = new RecordingLogger<SettingsResolutionService>();
+        var resolution = new SettingsResolutionService(_serialization, log);
+
+        Assert.Null(resolution.ReadLevel("{ this is not json", "   "));
+
+        Assert.Contains("an unnamed level", Assert.Single(log.Messages), StringComparison.Ordinal);
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -673,7 +673,7 @@ public class StreamyfinController : ControllerBase
     Id = group.Id,
     Name = group.Name,
     Priority = group.Priority,
-    Settings = Resolution.ReadLevel(group.SettingsJson, $"group {group.Name}"),
+    Settings = Resolution.ReadLevel(group.SettingsJson, $"group {group.Id}"),
     UserIds = members
   };
 

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Jellyfin.Plugin.Streamyfin.Db;
 using Microsoft.Extensions.Logging;
 
@@ -43,7 +45,7 @@ public sealed class SettingsResolutionService(
 
         foreach (var group in SettingsResolver.InLayerOrder(groups ?? []))
         {
-            levels.Add(ReadLevel(group.SettingsJson, $"group {group.Name}"));
+            levels.Add(ReadLevel(group.SettingsJson, $"group {group.Id}"));
         }
 
         if (userOverride is not null)
@@ -100,7 +102,9 @@ public sealed class SettingsResolutionService(
     /// Reads one stored level, tolerating a level that cannot be read.
     /// </summary>
     /// <param name="json">The stored JSON.</param>
-    /// <param name="what">What it belongs to, for the log line.</param>
+    /// <param name="what">Which level it is, for the log line. An identity rather
+    /// than a name: a group is named by whoever created it, and that name should not
+    /// decide what a log file says.</param>
     /// <returns>The settings, or <c>null</c> when there are none or they are unreadable.</returns>
     /// <remarks>
     /// Every path that reads a stored level goes through here, resolution and the
@@ -127,8 +131,37 @@ public sealed class SettingsResolutionService(
             _logger?.LogWarning(
                 ex,
                 "Could not read the settings stored for {What}. That level was skipped",
-                what);
+                OnOneLine(what));
             return null;
         }
+    }
+
+    // Callers name a level by its id, so nothing typed by an administrator should
+    // reach this line. It is cleaned anyway: a newline in a log message forges a
+    // second entry, and the whole point of this line is that it appears when
+    // something has already gone wrong with stored data.
+    private static string OnOneLine(string? what)
+    {
+        const int Longest = 120;
+
+        if (string.IsNullOrWhiteSpace(what))
+        {
+            return "an unnamed level";
+        }
+
+        var cleaned = new StringBuilder(Math.Min(what.Length, Longest));
+
+        foreach (var character in what)
+        {
+            if (cleaned.Length == Longest)
+            {
+                cleaned.Append('\u2026');
+                break;
+            }
+
+            cleaned.Append(char.IsControl(character) ? ' ' : character);
+        }
+
+        return cleaned.ToString();
     }
 }


### PR DESCRIPTION
CodeQL ran for the first time on #121, the branch that becomes the release, and found two things. Both are closed here.

## Every action is pinned by commit

The workflows added in #154 pinned the third-party actions but left GitHub's own and `oven-sh/setup-bun` on a moving major tag. A tag is a pointer: whoever owns it can move it, and the build follows. That is the same class of problem as the compromised `trivy-action` release the dependency review caught during #154, and the reason everything else was already pinned.

Each pin keeps the exact version the workflow had, with the version in a comment beside the hash. Nothing changes version here, so nothing needs a run to prove a behaviour change.

| Action | Was | Pinned to |
| --- | --- | --- |
| `actions/checkout` | `v4` | `11d5960` (v4.4.0) |
| `actions/setup-dotnet` | `v4` | `67a3573` (v4.3.1) |
| `actions/setup-node` | `v4` | `49933ea` (v4.4.0) |
| `actions/upload-artifact` | `v4` | `ea165f8` (v4.6.2) |
| `actions/download-artifact` | `v4` | `d3f86a1` (v4.3.0) |
| `oven-sh/setup-bun` | `v2` | `0c5077e` (v2.2.0) |
| `github/codeql-action/*` | `v3` | `faaca9a` (v3.38.0) |

Renovate keeps pinned digests current, so this does not become a manual chore.

## A group's name no longer writes a log line

`SettingsResolutionService.ReadLevel` warns when a stored level cannot be parsed, and it said which level by name. A group's name is typed by an administrator and reached that line unchanged, so a newline in it wrote a second, forged entry into the server log. It needs an API key to reach, but the line only appears when stored data is already wrong, which is exactly when a log is being read closely.

Levels are now named by id. That is the more useful identifier for a log anyway, since a name can be edited after the fact and an id cannot, and it is what you would paste back into the API to look at the group. The text is also put back on one line and bounded before being logged, as defence in depth rather than as the fix, because nothing should be able to decide the shape of a log line.

## Tests

- A level told it is called `group Night\r\nfatal: everything is fine` produces exactly one message, on one line, with both halves still readable.
- A level named by whitespace still says something rather than logging a blank.

244 tests pass on `jf11` and on `jf12`. Every workflow parses.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK