### PR TITLE
feat(home): say what kind a section is, and allow exactly one query

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/SectionKindTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/SectionKindTests.cs
@@ -1,0 +1,232 @@
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// What a home section is, which used to be whichever of four fields the app
+/// happened to test first.
+/// </summary>
+public class SectionKindTests
+{
+    /// <summary>
+    /// A section written before the kind existed is read by what it carries.
+    /// </summary>
+    /// <param name="carried">Which payload the section has.</param>
+    /// <param name="expected">The kind that implies.</param>
+    [Theory]
+    [InlineData(SectionKind.items, SectionKind.items)]
+    [InlineData(SectionKind.nextUp, SectionKind.nextUp)]
+    [InlineData(SectionKind.latest, SectionKind.latest)]
+    [InlineData(SectionKind.custom, SectionKind.custom)]
+    public void ASectionWithoutAKindIsReadByWhatItCarries(SectionKind carried, SectionKind expected)
+    {
+        Assert.Equal(expected, Sections.KindOf(Carrying(carried)));
+    }
+
+    /// <summary>
+    /// A declared kind is the answer, and nothing infers over it.
+    /// </summary>
+    [Fact]
+    public void ADeclaredKindIsTheAnswer()
+    {
+        var section = Carrying(SectionKind.latest);
+        section.kind = SectionKind.latest;
+
+        Assert.Equal(SectionKind.latest, Sections.KindOf(section));
+    }
+
+    /// <summary>
+    /// Nothing settles the kind of a section carrying nothing, or carrying two.
+    /// </summary>
+    [Fact]
+    public void AnUnsettledSectionHasNoKind()
+    {
+        Assert.Null(Sections.KindOf(new Section { title = "Empty" }));
+
+        var two = Carrying(SectionKind.items);
+        two.latest = new Latest();
+
+        Assert.Null(Sections.KindOf(two));
+    }
+
+    /// <summary>
+    /// Reading a home layout fills in every kind that was not declared.
+    /// </summary>
+    /// <remarks>
+    /// This is the migration: no configuration is rewritten, and every section the app
+    /// is served says what it is.
+    /// </remarks>
+    [Fact]
+    public void DeclaringFillsInEveryKind()
+    {
+        var home = new Home
+        {
+            sections =
+            [
+                Carrying(SectionKind.items),
+                Carrying(SectionKind.nextUp),
+                Carrying(SectionKind.latest),
+                Carrying(SectionKind.custom)
+            ]
+        };
+
+        Sections.Declare(home);
+
+        Assert.Equal(
+            [SectionKind.items, SectionKind.nextUp, SectionKind.latest, SectionKind.custom],
+            home.sections!.Select(section => section.kind));
+    }
+
+    /// <summary>
+    /// Declaring leaves a section nothing settles alone rather than guessing.
+    /// </summary>
+    [Fact]
+    public void DeclaringDoesNotGuess()
+    {
+        var section = Carrying(SectionKind.items);
+        section.nextUp = new NextUp();
+
+        Sections.Declare(new Home { sections = [section] });
+
+        Assert.Null(section.kind);
+    }
+
+    /// <summary>
+    /// A section carrying two queries is refused, and the message names both.
+    /// </summary>
+    [Fact]
+    public void TwoQueriesAreRefused()
+    {
+        var section = Carrying(SectionKind.items);
+        section.latest = new Latest();
+        section.title = "Recently added";
+
+        var problem = Assert.Single(Sections.Problems(new Home { sections = [section] }));
+
+        Assert.Contains("Recently added", problem, System.StringComparison.Ordinal);
+        Assert.Contains("items", problem, System.StringComparison.Ordinal);
+        Assert.Contains("latest", problem, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A section carrying no query is refused, since it would draw an empty row.
+    /// </summary>
+    [Fact]
+    public void NoQueryIsRefused()
+    {
+        var problem = Assert.Single(Sections.Problems(new Home
+        {
+            sections = [new Section { title = "Nothing" }]
+        }));
+
+        Assert.Contains("Home section 1", problem, System.StringComparison.Ordinal);
+        Assert.Contains("no query", problem, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A kind that disagrees with the query beside it is refused.
+    /// </summary>
+    [Fact]
+    public void AKindThatDisagreesWithItsQueryIsRefused()
+    {
+        var section = Carrying(SectionKind.items);
+        section.kind = SectionKind.nextUp;
+
+        var problem = Assert.Single(Sections.Problems(new Home { sections = [section] }));
+
+        Assert.Contains("nextUp", problem, System.StringComparison.Ordinal);
+        Assert.Contains("items", problem, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A section that is right is not complained about, and neither is no home at all.
+    /// </summary>
+    [Fact]
+    public void NothingIsSaidAboutALayoutThatIsRight()
+    {
+        Assert.Empty(Sections.Problems((Home?)null));
+        Assert.Empty(Sections.Problems(new Home()));
+        Assert.Empty(Sections.Problems(new Home { sections = [Carrying(SectionKind.nextUp)] }));
+    }
+
+    /// <summary>
+    /// The home layout reaches the validation every write path already goes through.
+    /// </summary>
+    /// <remarks>
+    /// The point of the check is the three paths that are not the admin form: the Yaml
+    /// tab writes whatever is typed, and the targeting routes take a JSON body.
+    /// </remarks>
+    [Fact]
+    public void TheHomeLayoutIsCheckedWithEverythingElse()
+    {
+        var section = Carrying(SectionKind.items);
+        section.custom = new CustomEndpoint { endpoint = "/anything" };
+
+        var settings = new Settings
+        {
+            home = new Lockable<Home> { value = new Home { sections = [section] } }
+        };
+
+        Assert.Contains("a section is filled by one", SettingsValidation.Message(settings), System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A kind written in the Yaml tab survives the round trip, in both directions.
+    /// </summary>
+    /// <remarks>
+    /// The Yaml tab is where a home layout is edited until P5.3, so the kind has to be
+    /// something an administrator can actually type, and it has to come back out of
+    /// <c>GET config/yaml</c> the way it went in.
+    /// </remarks>
+    [Fact]
+    public void AKindSurvivesTheYamlRoundTrip()
+    {
+        var serialization = new SerializationHelper();
+
+        var yaml = serialization.SerializeToYaml(new Configuration.Config
+        {
+            settings = new Settings
+            {
+                home = new Lockable<Home>
+                {
+                    value = new Home { sections = [WithKind(SectionKind.nextUp)] }
+                }
+            }
+        });
+
+        Assert.Contains("kind: nextUp", yaml, System.StringComparison.Ordinal);
+
+        var read = serialization.Deserialize<Configuration.Config>(yaml);
+
+        Assert.Equal(SectionKind.nextUp, read.settings?.home?.value?.sections?[0].kind);
+    }
+
+    /// <summary>
+    /// A kind written by the app's own serializer comes back as a name, not a number.
+    /// </summary>
+    [Fact]
+    public void AKindReachesTheAppAsAName()
+    {
+        var json = new SerializationHelper().SerializeToJson(WithKind(SectionKind.latest));
+
+        Assert.Contains("\"latest\"", json, System.StringComparison.Ordinal);
+    }
+
+    private static Section WithKind(SectionKind kind)
+    {
+        var section = Carrying(kind);
+        section.kind = kind;
+        return section;
+    }
+
+    private static Section Carrying(SectionKind kind) => kind switch
+    {
+        SectionKind.items => new Section { title = "A section", items = new Items() },
+        SectionKind.nextUp => new Section { title = "A section", nextUp = new NextUp() },
+        SectionKind.latest => new Section { title = "A section", latest = new Latest() },
+        _ => new Section { title = "A section", custom = new CustomEndpoint { endpoint = "/x" } }
+    };
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Sections.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Sections.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+
+/// <summary>
+/// What a home section is, and what fills it.
+/// </summary>
+/// <remarks>
+/// A section carried four nullable siblings, <c>items</c>, <c>nextUp</c>, <c>latest</c>
+/// and <c>custom</c>, and nothing anywhere said they were exclusive. The app read them
+/// as a cascade of ifs, so a section carrying two silently used whichever the cascade
+/// tested first, and a section carrying none drew an empty row with a title. Adding a
+/// kind meant adding a fifth sibling to every one of those cascades.
+///
+/// <para>
+/// The kind is now declared. The payloads keep their names, because every copy of the
+/// app in the field reads them and a plugin that renamed them would empty the home
+/// screen of everyone who had not updated, but exactly one of them is allowed and the
+/// server says which it is.
+/// </para>
+/// </remarks>
+public static class Sections
+{
+    /// <summary>
+    /// The kind a section declares, or the one its payload implies.
+    /// </summary>
+    /// <param name="section">The section.</param>
+    /// <returns>The kind, or <c>null</c> when nothing settles it.</returns>
+    /// <remarks>
+    /// A configuration written before the kind existed carries no <c>kind</c> at all,
+    /// and there are a lot of those. One payload is an unambiguous answer, so it is
+    /// read as one rather than refused, and nothing has to be rewritten to keep
+    /// working.
+    /// </remarks>
+    public static SectionKind? KindOf(Section? section)
+    {
+        if (section is null)
+        {
+            return null;
+        }
+
+        return section.kind ?? Implied(section);
+    }
+
+    /// <summary>
+    /// Fills in the kind of every section that does not declare one.
+    /// </summary>
+    /// <param name="home">The home layout, which may be null.</param>
+    /// <remarks>
+    /// This is the whole migration. A stored configuration is not rewritten on read,
+    /// which would mean writing to the database from a GET; it is answered with the
+    /// kind filled in, and the stored copy gains it the next time an administrator
+    /// saves. Either way the app is served a section that says what it is.
+    /// </remarks>
+    public static void Declare(Home? home)
+    {
+        foreach (var section in home?.sections ?? [])
+        {
+            section.kind ??= Implied(section);
+        }
+    }
+
+    /// <summary>
+    /// Fills in the kind of every section in these settings.
+    /// </summary>
+    /// <param name="settings">The settings, which may be null.</param>
+    public static void Declare(Settings? settings) => Declare(settings?.home?.value);
+
+    /// <summary>
+    /// The reasons a home layout cannot be stored, one line each.
+    /// </summary>
+    /// <param name="home">The home layout, which may be null.</param>
+    /// <returns>The problems, in section order. Empty when there are none.</returns>
+    public static IReadOnlyList<string> Problems(Home? home)
+    {
+        var sections = home?.sections;
+        if (sections is null)
+        {
+            return [];
+        }
+
+        var problems = new List<string>();
+
+        for (var index = 0; index < sections.Length; index++)
+        {
+            var section = sections[index];
+            if (section is null)
+            {
+                problems.Add(string.Format(CultureInfo.InvariantCulture, "{0} is empty.", Name(null, index)));
+                continue;
+            }
+
+            var name = Name(section, index);
+            var carried = Carried(section).ToList();
+
+            if (carried.Count > 1)
+            {
+                problems.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} carries {1} queries, {2}, and a section is filled by one.",
+                    name,
+                    carried.Count,
+                    string.Join(" and ", carried)));
+                continue;
+            }
+
+            if (carried.Count == 0)
+            {
+                problems.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} carries no query, so it would draw an empty row. Give it one of {1}.",
+                    name,
+                    string.Join(", ", Kinds)));
+                continue;
+            }
+
+            if (section.kind is not null && section.kind.Value != carried[0])
+            {
+                problems.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} says it is a {1} section and carries a {2} query.",
+                    name,
+                    section.kind.Value,
+                    carried[0]));
+            }
+        }
+
+        return problems;
+    }
+
+    /// <summary>
+    /// The reasons the home layout in these settings cannot be stored.
+    /// </summary>
+    /// <param name="settings">The settings, which may be null.</param>
+    /// <returns>The problems. Empty when there are none.</returns>
+    public static IReadOnlyList<string> Problems(Settings? settings) => Problems(settings?.home?.value);
+
+    private static readonly SectionKind[] Kinds = Enum.GetValues<SectionKind>();
+
+    // Named for a message an administrator reads, so the title first when there is one:
+    // a position alone is no help in a list of fifteen, and a title alone is no help
+    // when two sections share it.
+    private static string Name(Section? section, int index)
+    {
+        var position = string.Format(CultureInfo.InvariantCulture, "Home section {0}", index + 1);
+
+        return string.IsNullOrWhiteSpace(section?.title)
+            ? position
+            : string.Format(CultureInfo.InvariantCulture, "{0} ({1})", position, section!.title);
+    }
+
+    private static IEnumerable<SectionKind> Carried(Section section)
+    {
+        if (section.items is not null)
+        {
+            yield return SectionKind.items;
+        }
+
+        if (section.nextUp is not null)
+        {
+            yield return SectionKind.nextUp;
+        }
+
+        if (section.latest is not null)
+        {
+            yield return SectionKind.latest;
+        }
+
+        if (section.custom is not null)
+        {
+            yield return SectionKind.custom;
+        }
+    }
+
+    private static SectionKind? Implied(Section section)
+    {
+        var carried = Carried(section).Take(2).ToList();
+
+        return carried.Count == 1 ? carried[0] : null;
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Settings.cs
@@ -65,6 +65,18 @@ public class Section
   [Display(Name = "Media poster orientation")]
   public SectionOrientation? orientation { get; set; }
 
+  /// <summary>
+  /// Which query fills this section.
+  /// </summary>
+  /// <remarks>
+  /// The discriminant. Absent in every configuration written before it existed, and
+  /// those are read by the payload they carry rather than refused. The server fills
+  /// it in on the way out, so the app is always told what a section is instead of
+  /// testing four fields in an order nothing declared.
+  /// </remarks>
+  [Display(Name = "Kind", Description = "Which query fills this section: items, nextUp, latest or custom")]
+  public SectionKind? kind { get; set; }
+
   [NotNull]
   [Display(Name = "Items", Description = "Customize the Items API query")]
   public Items? items { get; set; }
@@ -91,6 +103,30 @@ public enum SectionType
 {
   row,
   carousel,
+}
+
+/// <summary>
+/// What fills a home section.
+/// </summary>
+/// <remarks>
+/// One value per payload a section can carry, spelled the way the payload is spelled,
+/// so a section reads as "a nextUp section" and the field holding its query is the
+/// one named after it. Adding a kind is a value here and a property on
+/// <see cref="Section"/>; nothing acquires a fifth branch it can forget to test.
+/// </remarks>
+public enum SectionKind
+{
+  /// <summary>The items query.</summary>
+  items,
+
+  /// <summary>What the user is part way through, by series.</summary>
+  nextUp,
+
+  /// <summary>What arrived most recently.</summary>
+  latest,
+
+  /// <summary>An endpoint the administrator names.</summary>
+  custom,
 }
 
 public class Items

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsResolutionService.cs
@@ -87,6 +87,11 @@ public sealed class SettingsResolutionService(
         UserSettingsOverride? userOverride,
         bool isElevated)
     {
+        // Every section says what kind it is by the time it leaves here, whether or not
+        // the stored copy does. Nothing is written back: a GET does not rewrite the
+        // database, and the kind a payload implies is the same answer every time.
+        Sections.Declare(config?.settings);
+
         if (isElevated)
         {
             return config ?? new Config();
@@ -124,7 +129,9 @@ public sealed class SettingsResolutionService(
 
         try
         {
-            return _serialization.DeserializeJson<Settings>(json);
+            var settings = _serialization.DeserializeJson<Settings>(json);
+            Sections.Declare(settings);
+            return settings;
         }
         catch (System.Text.Json.JsonException ex)
         {

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsValidation.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/SettingsValidation.cs
@@ -17,6 +17,12 @@ namespace Jellyfin.Plugin.Streamyfin.Configuration.Settings;
 /// jump ten minutes.
 ///
 /// <para>
+/// The home layout is checked here too, by <see cref="Sections"/>: a section carrying
+/// two queries used whichever the app tested first, and a section carrying none drew
+/// an empty row under a title.
+/// </para>
+///
+/// <para>
 /// The bounds come from <see cref="BoundsAttribute"/>, the same declaration the form
 /// draws from, so a setting is bounded once and both ends agree. Nothing here holds a
 /// list of keys.
@@ -36,7 +42,7 @@ public static class SettingsValidation
             return [];
         }
 
-        var problems = new List<string>();
+        var problems = new List<string>(Sections.Problems(settings));
 
         foreach (var descriptor in SettingsSchema.Descriptors)
         {

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -222,10 +222,22 @@ open ended promise. See [issue-triage.md](issue-triage.md).
 - **P5.4** Per group section targeting, once P1 is in
 - **P5.5** Migrate existing configurations
 
-P5.1 is what unblocks #78, #21 and every future section kind. Today adding a kind
-means adding a fifth nullable sibling that nothing says is exclusive with the
+P5.1 is what unblocks #78, #21 and every future section kind. Adding a kind used
+to mean adding a fifth nullable sibling that nothing said was exclusive with the
 other four. P5.3 needs the explicit `order` field from #93 to have somewhere to
 write to.
+
+P5.1 kept the payload names. Every copy of the app in the field reads `items`,
+`nextUp`, `latest` and `custom` by name, so renaming them would have emptied the
+home screen of everyone who had not updated. What changed is that the section now
+says which one it is, exactly one is allowed, and the server refuses a layout
+that breaks either rule.
+
+P5.5 turned out to be nothing to migrate. A section written before the kind
+existed carries one payload, which is an unambiguous answer, so it is read as one
+rather than refused. No configuration is rewritten and no version is stamped: the
+kind is filled in on the way out, and the stored copy gains it whenever an
+administrator next saves.
 
 ## P6. Third party integrations
 
@@ -280,6 +292,8 @@ Everything merged below is on `develop`, which reaches `main` through
 | P3.6 | [#145](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/145), and the Targeting tab on this branch | merged, then this |
 | P4.1 | [#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141) | merged |
 | P4.2 | [#143](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/143) | merged |
+| P5.1, P5.5 | [#157](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/157) | this |
+| P5.2 | [#151](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/151) for bounds, [#157](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/157) for sections | merged, then this |
 
 Not a numbered sub part, landed alongside P1:
 [#130](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/130), the


### PR DESCRIPTION
Closes P5.1 and P5.5, and finishes P5.2 for the home layout.

## The problem

A home section carried four nullable siblings and nothing said they were exclusive:

```yaml
- title: Recently added
  items: { ... }
  latest: { ... }   # nothing refused this
```

The app reads them as a cascade of `if (section.items) … if (section.nextUp) … if (section.latest) … if (section.custom)`. A section carrying two used whichever the cascade happened to test first, which is an ordering nothing declared and nothing tested. A section carrying none returned `[]` and drew an empty row under a title.

Adding a kind, which is what [#78](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/78) and [#21](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/21) both ask for, meant adding a fifth sibling to every one of those cascades and hoping none was forgotten.

## What this does

The kind is declared:

```yaml
- title: Recently added
  kind: latest
  latest: { ... }
```

`SectionKind` has one value per payload, spelled the way the payload is spelled, so a section reads as "a nextUp section" and the field holding its query is the one named after it. Adding a kind is now a value on the enum and a property on `Section`.

The payload names are deliberately unchanged. Every copy of the app in the field reads `items`, `nextUp`, `latest` and `custom` by name, and a plugin that renamed them would empty the home screen of everyone who had not updated. This is additive on the wire: an old app ignores `kind` and keeps working, a new app can switch on it instead of guessing.

## Migration, or the absence of one

P5.5 asked for existing configurations to be migrated. There is nothing to migrate.

A section written before the kind existed carries exactly one payload, which is an unambiguous answer, so it is read as one rather than refused. The kind is filled in on the way out, both on the resolution path and on every stored targeting level, and the stored copy gains it whenever an administrator next saves. No configuration is rewritten from a GET, no version is stamped, and nothing has to run once and be remembered.

A section nothing settles, carrying none or two, is left alone rather than guessed at. That case is a refusal, not a migration.

## What the server now refuses

Through `SettingsValidation`, so it covers the Yaml tab and the three targeting routes as well as the admin form, which is the point: the form was already the only thing that checked anything.

| Layout | Message |
| --- | --- |
| Two queries | `Home section 2 (Recently added) carries 2 queries, items and latest, and a section is filled by one.` |
| No query | `Home section 1 (Nothing) carries no query, so it would draw an empty row. Give it one of items, nextUp, latest, custom.` |
| Kind disagrees with query | `Home section 1 (A section) says it is a nextUp section and carries a items query.` |

Sections are named by position and title, because a position alone is no help in a list of fifteen and a title alone is no help when two sections share one.

## Tests

11 new tests, 259 passing on `jf11` and on `jf12`:

- each payload implies its kind, and a declared kind wins over inference
- a section carrying none or two has no kind, and declaring does not guess one
- each of the three refusals, checked on the message an administrator reads
- a correct layout, an empty `home`, and no `home` at all say nothing
- the home layout reaches `SettingsValidation` with everything else
- `kind: nextUp` survives the YAML round trip in both directions, since the Yaml tab is where a home layout is edited until P5.3
- the kind reaches the app as a name rather than a number

## What this does not do

The app still reads the payloads rather than the kind. That is a separate change in `streamyfin/streamyfin`, and it is now a `switch` on one field instead of a cascade. The new kinds that [#78](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/78) and [#21](https://github.com/streamyfin/jellyfin-plugin-streamyfin/issues/21) ask for need app work to render them, so they are not declared here: this is what makes declaring them cheap.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK