### PR TITLE
fix(notifications): send in the batches Expo takes, and wait out a rate limit

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoBatchingTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoBatchingTests.cs
@@ -103,15 +103,52 @@ public class ExpoBatchingTests
     /// <param name="retries">Whether the request is made again.</param>
     [Theory]
     [InlineData(HttpStatusCode.TooManyRequests, true)]
-    [InlineData(HttpStatusCode.ServiceUnavailable, true)]
-    [InlineData(HttpStatusCode.InternalServerError, true)]
-    [InlineData(HttpStatusCode.RequestTimeout, true)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, false)]
+    [InlineData(HttpStatusCode.InternalServerError, false)]
+    [InlineData(HttpStatusCode.RequestTimeout, false)]
     [InlineData(HttpStatusCode.BadRequest, false)]
     [InlineData(HttpStatusCode.Unauthorized, false)]
     [InlineData(HttpStatusCode.RequestEntityTooLarge, false)]
     public void OnlyARefusalThatCanPassIsWaitedOut(HttpStatusCode status, bool retries)
     {
         Assert.Equal(retries, ExpoRetry.Default.Wait(status, null, 1, DateTimeOffset.UnixEpoch) is not null);
+    }
+
+    /// <summary>
+    /// A send is only repeated when Expo says it did not take it. A read is repeated
+    /// whenever it might have worked.
+    /// </summary>
+    /// <remarks>
+    /// Expo's send endpoint carries no idempotency key and documents no deduplication,
+    /// so a 500 or a timeout might mean the pushes went out and the answer was lost.
+    /// Repeating that notifies everyone twice, which is worse than the notification
+    /// being late. Asking what became of a ticket changes nothing, so there the same
+    /// refusal is simply worth asking again.
+    /// </remarks>
+    /// <param name="status">What Expo answered.</param>
+    [Theory]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    public void AnAmbiguousRefusalIsRepeatedForAReadAndNotForASend(HttpStatusCode status)
+    {
+        Assert.Null(ExpoRetry.Default.Wait(status, null, 1, DateTimeOffset.UnixEpoch));
+        Assert.NotNull(ExpoRetry.Default.ForSomethingThatOnlyReads().Wait(status, null, 1, DateTimeOffset.UnixEpoch));
+
+        // 429 stays safe either way: it is Expo saying it did not take the request.
+        Assert.NotNull(ExpoRetry.Default.Wait(HttpStatusCode.TooManyRequests, null, 1, DateTimeOffset.UnixEpoch));
+    }
+
+    /// <summary>
+    /// A policy that would wait a negative time is refused when it is built, rather than
+    /// reaching Task.Delay to throw there.
+    /// </summary>
+    [Fact]
+    public void ANegativeWaitIsRefusedWhenItIsBuilt()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ExpoRetry(3, TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(30)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ExpoRetry(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-30)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ExpoRetry(0, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30)));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Streamyfin.Tests/ExpoBatchingTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ExpoBatchingTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using Jellyfin.Plugin.Streamyfin.PushNotifications;
+using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
+using Xunit;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Cutting a send into requests Expo accepts, and deciding when a refused one is worth
+/// making again.
+/// </summary>
+public class ExpoBatchingTests
+{
+    /// <summary>
+    /// A send within the limit is one request, unchanged.
+    /// </summary>
+    [Fact]
+    public void ASmallSendIsOneRequest()
+    {
+        var batch = Assert.Single(ExpoBatching.Chunk([Addressed(3)]));
+
+        Assert.Equal(3, Assert.Single(batch).To.Count);
+    }
+
+    /// <summary>
+    /// A message with more recipients than a request takes is split, and every recipient
+    /// goes out exactly once, in order.
+    /// </summary>
+    /// <remarks>
+    /// Order is what <see cref="ExpoTickets.Reconcile"/> matches a ticket to a device by,
+    /// so a shuffle here would delete the wrong token.
+    /// </remarks>
+    [Fact]
+    public void ALargeMessageIsSplitInOrder()
+    {
+        var batches = ExpoBatching.Chunk([Addressed(250)]);
+
+        Assert.Equal(3, batches.Count);
+        Assert.Equal([100, 100, 50], batches.Select(Recipients).ToList());
+        Assert.Equal(Tokens(250), batches.SelectMany(batch => batch.SelectMany(one => one.To)).ToList());
+    }
+
+    /// <summary>
+    /// Several messages share a request until it is full, since Expo counts recipients
+    /// across the whole body rather than per message.
+    /// </summary>
+    [Fact]
+    public void MessagesShareARequestUntilItIsFull()
+    {
+        var batches = ExpoBatching.Chunk([Addressed(60), Addressed(60)]);
+
+        Assert.Equal(2, batches.Count);
+        Assert.Equal([100, 20], batches.Select(Recipients).ToList());
+
+        // The second message is the one that straddles them, so it appears on both sides.
+        Assert.Equal(2, batches[0].Count);
+        Assert.Single(batches[1]);
+    }
+
+    /// <summary>
+    /// A split copy keeps everything about the message except who it is for.
+    /// </summary>
+    /// <remarks>
+    /// A field by field copy would drop a new field from every split send and nothing
+    /// would fail, so the copy is shallow and this holds it that way.
+    /// </remarks>
+    [Fact]
+    public void ASplitCopyKeepsTheMessage()
+    {
+        var notification = Addressed(150);
+        notification.Title = "New episode";
+        notification.Body = "Something arrived";
+        notification.BadgeCount = 4;
+        notification.ChannelId = "library";
+
+        var first = ExpoBatching.Chunk([notification])[0][0];
+
+        Assert.Equal("New episode", first.Title);
+        Assert.Equal("Something arrived", first.Body);
+        Assert.Equal(4, first.BadgeCount);
+        Assert.Equal("library", first.ChannelId);
+        Assert.Equal(100, first.To.Count);
+    }
+
+    /// <summary>
+    /// A message addressed to nobody makes no request.
+    /// </summary>
+    [Fact]
+    public void AMessageAddressedToNobodyMakesNoRequest()
+    {
+        Assert.Empty(ExpoBatching.Chunk([new ExpoNotificationRequest { Title = "Nobody" }]));
+        Assert.Empty(ExpoBatching.Chunk([]));
+    }
+
+    /// <summary>
+    /// A rate limit is worth waiting out; a bad request is not.
+    /// </summary>
+    /// <param name="status">What Expo answered.</param>
+    /// <param name="retries">Whether the request is made again.</param>
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests, true)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, true)]
+    [InlineData(HttpStatusCode.InternalServerError, true)]
+    [InlineData(HttpStatusCode.RequestTimeout, true)]
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    [InlineData(HttpStatusCode.Unauthorized, false)]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, false)]
+    public void OnlyARefusalThatCanPassIsWaitedOut(HttpStatusCode status, bool retries)
+    {
+        Assert.Equal(retries, ExpoRetry.Default.Wait(status, null, 1, DateTimeOffset.UnixEpoch) is not null);
+    }
+
+    /// <summary>
+    /// The wait doubles, and giving up is what the last try does.
+    /// </summary>
+    [Fact]
+    public void TheWaitDoublesAndThenStops()
+    {
+        var retry = new ExpoRetry(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+
+        Assert.Equal(TimeSpan.FromSeconds(1), Waited(retry, 1));
+        Assert.Equal(TimeSpan.FromSeconds(2), Waited(retry, 2));
+        Assert.Null(retry.Wait(HttpStatusCode.TooManyRequests, null, 3, DateTimeOffset.UnixEpoch));
+    }
+
+    /// <summary>
+    /// What the server asks for wins over the arithmetic, up to the cap.
+    /// </summary>
+    /// <remarks>
+    /// A Retry-After of an hour is a real answer and still not something to sit through
+    /// inside an event handler Jellyfin is waiting on.
+    /// </remarks>
+    [Fact]
+    public void RetryAfterWinsButIsStillCapped()
+    {
+        var retry = new ExpoRetry(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+
+        Assert.Equal(
+            TimeSpan.FromSeconds(5),
+            retry.Wait(HttpStatusCode.TooManyRequests, new RetryConditionHeaderValue(TimeSpan.FromSeconds(5)), 1, DateTimeOffset.UnixEpoch));
+
+        Assert.Equal(
+            TimeSpan.FromSeconds(30),
+            retry.Wait(HttpStatusCode.TooManyRequests, new RetryConditionHeaderValue(TimeSpan.FromHours(1)), 1, DateTimeOffset.UnixEpoch));
+    }
+
+    /// <summary>
+    /// A Retry-After given as a date is read against the clock, and one already past is
+    /// no wait at all rather than a negative one.
+    /// </summary>
+    [Fact]
+    public void ARetryAfterDateIsReadAgainstTheClock()
+    {
+        var retry = new ExpoRetry(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+        var now = new DateTimeOffset(2026, 9, 11, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.Equal(
+            TimeSpan.FromSeconds(10),
+            retry.Wait(HttpStatusCode.TooManyRequests, new RetryConditionHeaderValue(now.AddSeconds(10)), 1, now));
+
+        Assert.Equal(
+            TimeSpan.Zero,
+            retry.Wait(HttpStatusCode.TooManyRequests, new RetryConditionHeaderValue(now.AddSeconds(-10)), 1, now));
+    }
+
+    private static TimeSpan? Waited(ExpoRetry retry, int tried) =>
+        retry.Wait(HttpStatusCode.TooManyRequests, null, tried, DateTimeOffset.UnixEpoch);
+
+    private static int Recipients(IReadOnlyList<ExpoNotificationRequest> batch) =>
+        batch.Sum(notification => notification.To.Count);
+
+    private static List<string> Tokens(int count) =>
+        [.. Enumerable.Range(0, count).Select(i => $"ExponentPushToken[{i}]")];
+
+    private static ExpoNotificationRequest Addressed(int recipients) =>
+        new() { Title = "A title", To = Tokens(recipients) };
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
@@ -93,6 +93,31 @@ public class PushNotificationClientTests
     }
 
     /// <summary>
+    /// What Expo says about a request survives being one batch of several.
+    /// </summary>
+    /// <remarks>
+    /// The notifications route hands this response straight back, so an error dropped
+    /// while the batches were combined is an error the caller never sees.
+    /// </remarks>
+    [Fact]
+    public async Task ErrorsSurviveBeingCombined()
+    {
+        var handler = new StubHandler(
+            HttpStatusCode.OK,
+            """{"data":[],"errors":[{"code":"PUSH_TOO_MANY_EXPERIENCE_IDS","message":"too many"}]}""");
+
+        var response = await HelperFor(handler).Send(new ExpoNotificationRequest
+        {
+            Title = "A title",
+            To = [.. Enumerable.Range(0, 150).Select(i => $"ExponentPushToken[{i}]")]
+        });
+
+        Assert.Equal(2, handler.Calls);
+        Assert.Equal(2, response!.Errors.Count);
+        Assert.Equal("PUSH_TOO_MANY_EXPERIENCE_IDS", response.Errors[0].Code);
+    }
+
+    /// <summary>
     /// A refusal that cannot pass is not made again.
     /// </summary>
     /// <remarks>

--- a/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
@@ -139,9 +139,51 @@ public class PushNotificationClientTests
     [Fact]
     public async Task RetryingGivesUp()
     {
-        var handler = new StubHandler(HttpStatusCode.ServiceUnavailable, "later");
+        var handler = new StubHandler(HttpStatusCode.TooManyRequests, "later");
 
         Assert.Null(await HelperFor(handler).Send(ANotification()));
+        Assert.Equal(ExpoRetry.Immediate.Tries, handler.Calls);
+    }
+
+    /// <summary>
+    /// A send is not repeated when the answer does not say whether Expo took it.
+    /// </summary>
+    /// <remarks>
+    /// Expo's send endpoint carries no idempotency key and documents no deduplication.
+    /// A 500 might mean the pushes went out and the answer was lost, so repeating it
+    /// notifies everyone twice, which is worse than the notification being late.
+    /// </remarks>
+    [Fact]
+    public async Task AnAmbiguousRefusalDoesNotRepeatASend()
+    {
+        var handler = new StubHandler(HttpStatusCode.InternalServerError, "boom");
+
+        Assert.Null(await HelperFor(handler).Send(ANotification()));
+        Assert.Equal(1, handler.Calls);
+    }
+
+    /// <summary>
+    /// Expo refusing one batch stops the send rather than working through the rest.
+    /// </summary>
+    /// <remarks>
+    /// The notifications route blocks on this call. A thousand recipients against a
+    /// server answering 429 is ten batches, each with its own waits, and every one of
+    /// them reaches nobody.
+    /// </remarks>
+    [Fact]
+    public async Task ARefusedBatchStopsTheSend()
+    {
+        var handler = new StubHandler(HttpStatusCode.TooManyRequests, "no");
+
+        var response = await HelperFor(handler).Send(new ExpoNotificationRequest
+        {
+            Title = "A title",
+            To = [.. Enumerable.Range(0, 500).Select(i => $"ExponentPushToken[{i}]")]
+        });
+
+        Assert.Null(response);
+
+        // The first batch's three tries, and nothing for the four batches behind it.
         Assert.Equal(ExpoRetry.Immediate.Tries, handler.Calls);
     }
 

--- a/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/PushNotificationClientTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Streamyfin.PushNotifications;
@@ -21,8 +24,10 @@ public class PushNotificationClientTests
 {
     private const string ExpoSendUrl = "https://exp.host/--/api/v2/push/send";
 
+    // Immediate rather than the real policy: these tests exercise the retries, and the
+    // real one sleeps a second and then two between them.
     private static NotificationHelper HelperFor(StubHandler handler) =>
-        new(null, null, new SerializationHelper(), new StubHttpClientFactory(handler));
+        new(null, null, new SerializationHelper(), new StubHttpClientFactory(handler), ExpoRetry.Immediate);
 
     private static ExpoNotificationRequest ANotification() =>
         new() { Title = "A title", Body = "A body", To = ["ExponentPushToken[xxx]"] };
@@ -65,6 +70,83 @@ public class PushNotificationClientTests
     }
 
     /// <summary>
+    /// A rate limited send is made again, and the answer to the last try is the answer.
+    /// </summary>
+    /// <remarks>
+    /// Expo caps a project at six hundred notifications a second. The plugin read the
+    /// refusal as a delivery with nothing to report, so the notification was lost with a
+    /// line in a log nobody reads. A library that adds fifty episodes at once is exactly
+    /// the shape that reaches the cap.
+    /// </remarks>
+    [Fact]
+    public async Task ARateLimitedSendIsMadeAgain()
+    {
+        var handler = new StubHandler(HttpStatusCode.TooManyRequests, "rate limited")
+        {
+            Then = [(HttpStatusCode.OK, """{"data":[{"status":"ok","id":"1"}]}""")]
+        };
+
+        var response = await HelperFor(handler).Send(ANotification());
+
+        Assert.Equal(2, handler.Calls);
+        Assert.Single(response!.Data);
+    }
+
+    /// <summary>
+    /// A refusal that cannot pass is not made again.
+    /// </summary>
+    /// <remarks>
+    /// A 400 is the same request being wrong twice. Repeating it reaches no device and
+    /// costs two more round trips inside an event handler Jellyfin is waiting on.
+    /// </remarks>
+    [Fact]
+    public async Task ARefusalThatCannotPassIsNotMadeAgain()
+    {
+        var handler = new StubHandler(HttpStatusCode.BadRequest, "no");
+
+        Assert.Null(await HelperFor(handler).Send(ANotification()));
+        Assert.Equal(1, handler.Calls);
+    }
+
+    /// <summary>
+    /// Retrying gives up rather than going round forever.
+    /// </summary>
+    [Fact]
+    public async Task RetryingGivesUp()
+    {
+        var handler = new StubHandler(HttpStatusCode.ServiceUnavailable, "later");
+
+        Assert.Null(await HelperFor(handler).Send(ANotification()));
+        Assert.Equal(ExpoRetry.Immediate.Tries, handler.Calls);
+    }
+
+    /// <summary>
+    /// More recipients than Expo takes go out in more than one request, and every
+    /// recipient goes out exactly once.
+    /// </summary>
+    /// <remarks>
+    /// Expo refuses a body carrying more than a hundred recipients, whole. A server with
+    /// more devices than that had its library notifications refused entirely, so nobody
+    /// was told rather than everybody.
+    /// </remarks>
+    [Fact]
+    public async Task MoreRecipientsThanExpoTakesGoOutInMoreThanOneRequest()
+    {
+        var tokens = Enumerable.Range(0, 250).Select(i => $"ExponentPushToken[{i}]").ToList();
+        var handler = new StubHandler(HttpStatusCode.OK, """{"data":[]}""");
+
+        await HelperFor(handler).Send(new ExpoNotificationRequest { Title = "A title", To = tokens });
+
+        Assert.Equal(3, handler.Calls);
+
+        var sent = handler.Bodies
+            .SelectMany(body => Regex.Matches(body, @"ExponentPushToken\[\d+\]").Select(match => match.Value))
+            .ToList();
+
+        Assert.Equal(tokens, sent);
+    }
+
+    /// <summary>
     /// The client is asked for by name, so its timeout and headers are configured once at
     /// registration rather than per call site.
     /// </summary>
@@ -85,17 +167,38 @@ public class PushNotificationClientTests
 
         public HttpRequestMessage? LastRequest { get; private set; }
 
-        protected override Task<HttpResponseMessage> SendAsync(
+        /// <summary>
+        /// Gets the bodies this was asked to send, in order.
+        /// </summary>
+        public List<string> Bodies { get; } = [];
+
+        /// <summary>
+        /// Gets or sets what to answer after the first call, one entry per later call.
+        /// The last entry repeats once it runs out.
+        /// </summary>
+        public IReadOnlyList<(HttpStatusCode Status, string Body)> Then { get; set; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            Calls++;
             LastRequest = request;
 
-            return Task.FromResult(new HttpResponseMessage(status)
+            if (request.Content is not null)
             {
-                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
-            });
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            }
+
+            var answer = Calls == 0 || Then.Count == 0
+                ? (status, body)
+                : Then[Math.Min(Calls - 1, Then.Count - 1)];
+
+            Calls++;
+
+            return new HttpResponseMessage(answer.Item1)
+            {
+                Content = new StringContent(answer.Item2, System.Text.Encoding.UTF8, "application/json"),
+            };
         }
     }
 

--- a/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Sections.cs
+++ b/Jellyfin.Plugin.Streamyfin/Configuration/Settings/Sections.cs
@@ -119,9 +119,12 @@ public static class Sections
 
             if (section.kind is not null && section.kind.Value != carried[0])
             {
+                // No article before the kind: "a items query" is what writing one gives
+                // you, and the kinds are spelled the way the payload is rather than in
+                // English, so there is no right article to pick.
                 problems.Add(string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0} says it is a {1} section and carries a {2} query.",
+                    "{0} says it is a {1} section, and the query beside it is {2}.",
                     name,
                     section.kind.Value,
                     carried[0]));

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoBatching.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoBatching.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Streamyfin.PushNotifications.models;
+
+namespace Jellyfin.Plugin.Streamyfin.PushNotifications;
+
+/// <summary>
+/// Cutting a send into requests Expo will accept.
+/// </summary>
+/// <remarks>
+/// Expo takes a hundred recipients per request, counted across the whole body rather
+/// than per message, and answers <c>413</c> past that. The plugin sent every device on
+/// the server in one request: a library addition on a server with more than a hundred
+/// registered devices was refused whole, and nobody was notified rather than everybody.
+///
+/// <para>
+/// Order is the reason this is its own file. <see cref="ExpoTickets.Reconcile"/> matches
+/// a ticket to a device by position and nothing else, so a batch has to carry its
+/// recipients in the order they went out, and a message split across two batches has to
+/// keep the tokens on the side they were sent from.
+/// </para>
+/// </remarks>
+public static class ExpoBatching
+{
+    /// <summary>
+    /// How many recipients Expo takes in one send, across every message in the body.
+    /// </summary>
+    /// <remarks>
+    /// The number Expo's own server SDK batches on, and the one its documentation
+    /// states for a request body.
+    /// </remarks>
+    public const int MaxRecipientsPerRequest = 100;
+
+    /// <summary>
+    /// Cuts a send into requests, each within Expo's recipient limit.
+    /// </summary>
+    /// <param name="notifications">The messages to send, each with its recipients.</param>
+    /// <param name="limit">The recipients one request may carry.</param>
+    /// <returns>The requests to make, in order. Empty when there is nobody to send to.</returns>
+    public static IReadOnlyList<IReadOnlyList<ExpoNotificationRequest>> Chunk(
+        IReadOnlyList<ExpoNotificationRequest> notifications,
+        int limit = MaxRecipientsPerRequest)
+    {
+        ArgumentNullException.ThrowIfNull(notifications);
+        ArgumentOutOfRangeException.ThrowIfLessThan(limit, 1);
+
+        var batches = new List<IReadOnlyList<ExpoNotificationRequest>>();
+        var batch = new List<ExpoNotificationRequest>();
+        var room = limit;
+
+        foreach (var notification in notifications)
+        {
+            var recipients = notification?.To;
+            if (recipients is null || recipients.Count == 0)
+            {
+                continue;
+            }
+
+            var sent = 0;
+
+            while (sent < recipients.Count)
+            {
+                if (room == 0)
+                {
+                    batches.Add(batch);
+                    batch = [];
+                    room = limit;
+                }
+
+                var take = Math.Min(room, recipients.Count - sent);
+
+                batch.Add(notification!.WithRecipients(recipients.GetRange(sent, take)));
+                sent += take;
+                room -= take;
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            batches.Add(batch);
+        }
+
+        return batches;
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoRetry.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoRetry.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Jellyfin.Plugin.Streamyfin.PushNotifications;
+
+/// <summary>
+/// When a refused Expo request is worth making again, and how long to wait first.
+/// </summary>
+/// <remarks>
+/// Expo answers <c>429</c> past six hundred notifications a second for a project, and
+/// the plugin treated that as a delivery that had nothing to report: the notification
+/// was simply lost, with a line in the log nobody reads. A library that adds fifty
+/// episodes at once is exactly the shape that hits it.
+///
+/// <para>
+/// Only a refusal that can pass is retried. A <c>400</c> is the same request being
+/// wrong twice, and repeating it costs a device nothing but costs the server two more
+/// round trips inside an event handler.
+/// </para>
+/// </remarks>
+public sealed class ExpoRetry
+{
+    /// <summary>
+    /// What the plugin uses: three tries, a second apart, doubling, never past half a
+    /// minute. The same shape as Expo's own server SDK, which retries twice with a
+    /// factor of two from one second.
+    /// </summary>
+    public static readonly ExpoRetry Default = new(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+
+    /// <summary>
+    /// Never wait, for a test that would otherwise sleep through its own retries.
+    /// </summary>
+    public static readonly ExpoRetry Immediate = new(3, TimeSpan.Zero, TimeSpan.Zero);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExpoRetry"/> class.
+    /// </summary>
+    /// <param name="tries">How many times the request is made in total, the first included.</param>
+    /// <param name="firstWait">The wait before the second try.</param>
+    /// <param name="longestWait">The cap, which a server's own Retry-After is held to as well.</param>
+    public ExpoRetry(int tries, TimeSpan firstWait, TimeSpan longestWait)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(tries, 1);
+
+        Tries = tries;
+        FirstWait = firstWait;
+        LongestWait = longestWait;
+    }
+
+    /// <summary>
+    /// Gets how many times the request is made in total.
+    /// </summary>
+    public int Tries { get; }
+
+    /// <summary>
+    /// Gets the wait before the second try, doubled for each one after it.
+    /// </summary>
+    public TimeSpan FirstWait { get; }
+
+    /// <summary>
+    /// Gets the longest this will wait, whatever the arithmetic or the server says.
+    /// </summary>
+    public TimeSpan LongestWait { get; }
+
+    /// <summary>
+    /// How long to wait before trying again, or <c>null</c> to give up.
+    /// </summary>
+    /// <param name="status">The status Expo answered with.</param>
+    /// <param name="retryAfter">The <c>Retry-After</c> header, when there was one.</param>
+    /// <param name="tried">How many times the request has been made, the first being 1.</param>
+    /// <param name="now">The clock, for a <c>Retry-After</c> given as a date.</param>
+    /// <returns>The wait, or <c>null</c> when there is no point.</returns>
+    public TimeSpan? Wait(HttpStatusCode status, RetryConditionHeaderValue? retryAfter, int tried, DateTimeOffset now)
+    {
+        if (tried >= Tries || !CanPass(status))
+        {
+            return null;
+        }
+
+        // The server's own answer wins over the arithmetic, which is guessing, but it is
+        // still held to the cap: a Retry-After of an hour inside an event handler is not
+        // something to sit through.
+        var asked = Asked(retryAfter, now);
+        if (asked is not null)
+        {
+            return Capped(asked.Value);
+        }
+
+        var doublings = Math.Min(tried - 1, 16);
+
+        return Capped(FirstWait * Math.Pow(2, doublings));
+    }
+
+    // 429 is the one this exists for. A 5xx is Expo having a moment, and 408 is the
+    // request never arriving; both are the same request being worth making again.
+    private static bool CanPass(HttpStatusCode status) =>
+        status == HttpStatusCode.TooManyRequests
+        || status == HttpStatusCode.RequestTimeout
+        || (int)status >= 500;
+
+    private static TimeSpan? Asked(RetryConditionHeaderValue? retryAfter, DateTimeOffset now)
+    {
+        if (retryAfter?.Delta is { } delta)
+        {
+            return delta;
+        }
+
+        if (retryAfter?.Date is { } date)
+        {
+            var wait = date - now;
+            return wait > TimeSpan.Zero ? wait : TimeSpan.Zero;
+        }
+
+        return null;
+    }
+
+    private TimeSpan Capped(TimeSpan wait) =>
+        wait < TimeSpan.Zero ? TimeSpan.Zero : (wait > LongestWait ? LongestWait : wait);
+}

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoRetry.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/ExpoRetry.cs
@@ -24,7 +24,7 @@ public sealed class ExpoRetry
     /// <summary>
     /// What the plugin uses: three tries, a second apart, doubling, never past half a
     /// minute. The same shape as Expo's own server SDK, which retries twice with a
-    /// factor of two from one second.
+    /// factor of two from one second, and on the same one status.
     /// </summary>
     public static readonly ExpoRetry Default = new(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
 
@@ -39,13 +39,24 @@ public sealed class ExpoRetry
     /// <param name="tries">How many times the request is made in total, the first included.</param>
     /// <param name="firstWait">The wait before the second try.</param>
     /// <param name="longestWait">The cap, which a server's own Retry-After is held to as well.</param>
-    public ExpoRetry(int tries, TimeSpan firstWait, TimeSpan longestWait)
+    /// <param name="repeatWhenTheAnswerIsAmbiguous">
+    /// Whether a refusal that does not say the request was dropped is worth repeating.
+    /// False for anything that changes something, true for a read.
+    /// </param>
+    public ExpoRetry(
+        int tries,
+        TimeSpan firstWait,
+        TimeSpan longestWait,
+        bool repeatWhenTheAnswerIsAmbiguous = false)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(tries, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(firstWait, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(longestWait, TimeSpan.Zero);
 
         Tries = tries;
         FirstWait = firstWait;
         LongestWait = longestWait;
+        RepeatWhenTheAnswerIsAmbiguous = repeatWhenTheAnswerIsAmbiguous;
     }
 
     /// <summary>
@@ -62,6 +73,30 @@ public sealed class ExpoRetry
     /// Gets the longest this will wait, whatever the arithmetic or the server says.
     /// </summary>
     public TimeSpan LongestWait { get; }
+
+    /// <summary>
+    /// Gets whether a refusal that does not say the request was dropped is repeated.
+    /// </summary>
+    /// <remarks>
+    /// A send is not something to repeat on a maybe. Expo's send endpoint carries no
+    /// idempotency key and documents no deduplication, so a 500 or a timeout might mean
+    /// the pushes went out and the answer was lost, and repeating it would notify
+    /// everyone twice. A 429 is different: it is the server saying in so many words
+    /// that it did not take the request.
+    ///
+    /// <para>
+    /// Reading a receipt changes nothing, so for that a 5xx is simply worth asking
+    /// again. Expo's own server SDK retries on 429 and on nothing else, for either.
+    /// </para>
+    /// </remarks>
+    public bool RepeatWhenTheAnswerIsAmbiguous { get; }
+
+    /// <summary>
+    /// The same policy, for a request that can be repeated without consequence.
+    /// </summary>
+    /// <returns>The policy, repeating on an ambiguous refusal as well.</returns>
+    public ExpoRetry ForSomethingThatOnlyReads() =>
+        RepeatWhenTheAnswerIsAmbiguous ? this : new ExpoRetry(Tries, FirstWait, LongestWait, true);
 
     /// <summary>
     /// How long to wait before trying again, or <c>null</c> to give up.
@@ -92,12 +127,13 @@ public sealed class ExpoRetry
         return Capped(FirstWait * Math.Pow(2, doublings));
     }
 
-    // 429 is the one this exists for. A 5xx is Expo having a moment, and 408 is the
-    // request never arriving; both are the same request being worth making again.
-    private static bool CanPass(HttpStatusCode status) =>
+    // 429 is the one this exists for, and the only one that is safe whatever the
+    // request was: Expo is saying it did not take it. A 5xx or a 408 might mean it did
+    // and the answer was lost, which for a send would mean notifying everyone twice.
+    private bool CanPass(HttpStatusCode status) =>
         status == HttpStatusCode.TooManyRequests
-        || status == HttpStatusCode.RequestTimeout
-        || (int)status >= 500;
+        || (RepeatWhenTheAnswerIsAmbiguous
+            && (status == HttpStatusCode.RequestTimeout || (int)status >= 500));
 
     private static TimeSpan? Asked(RetryConditionHeaderValue? retryAfter, DateTimeOffset now)
     {

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/ExpoNotificationRequest.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/Models/ExpoNotificationRequest.cs
@@ -132,6 +132,23 @@ public class ExpoNotificationRequest
     /// </summary>
     [JsonProperty(PropertyName = "mutableContent")]
     public bool MutableContent { get; set; }
+
+    /// <summary>
+    /// The same message, addressed to some of its recipients.
+    /// </summary>
+    /// <param name="recipients">Who this copy is for.</param>
+    /// <returns>A copy carrying every other field unchanged.</returns>
+    /// <remarks>
+    /// A shallow copy rather than a field by field one, so a message gains a field
+    /// without this quietly dropping it from every split send. Expo takes a hundred
+    /// recipients per request and a server can have more devices than that.
+    /// </remarks>
+    public ExpoNotificationRequest WithRecipients(List<string> recipients)
+    {
+        var copy = (ExpoNotificationRequest)MemberwiseClone();
+        copy.To = recipients;
+        return copy;
+    }
 }
 
 /// <summary>

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
@@ -207,6 +207,7 @@ public class NotificationHelper
         }
 
         var tickets = new List<TicketStatus>();
+        var errors = new List<Errors>();
         var answered = false;
 
         foreach (var batch in batches)
@@ -231,9 +232,14 @@ public class NotificationHelper
 
             answered = true;
             tickets.AddRange(response.Data);
+
+            // What Expo says about the request rather than about a delivery. The caller
+            // is handed this response and the notifications route serializes it, so a
+            // batch's errors would otherwise be dropped on the way out.
+            errors.AddRange(response.Errors);
         }
 
-        return answered ? new ExpoNotificationResponse { Data = tickets } : null;
+        return answered ? new ExpoNotificationResponse { Data = tickets, Errors = errors } : null;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
@@ -34,17 +34,32 @@ public class NotificationHelper
     private readonly SerializationHelper _serializationHelper;
     private readonly IUserManager? _userManager;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ExpoRetry _retry;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotificationHelper"/> class.
+    /// </summary>
+    /// <param name="loggerFactory">Where the sends are reported.</param>
+    /// <param name="userManager">Jellyfin's users, for the admin recipients.</param>
+    /// <param name="serializationHelper">The plugin's serializer.</param>
+    /// <param name="httpClientFactory">The factory holding the configured Expo client.</param>
+    /// <param name="retry">
+    /// When a refused request is worth making again. Defaults to
+    /// <see cref="ExpoRetry.Default"/>; a test passes <see cref="ExpoRetry.Immediate"/>
+    /// rather than sleeping through its own retries.
+    /// </param>
     public NotificationHelper(
         ILoggerFactory? loggerFactory,
         IUserManager? userManager,
         SerializationHelper serializationHelper,
-        IHttpClientFactory httpClientFactory)
+        IHttpClientFactory httpClientFactory,
+        ExpoRetry? retry = null)
     {
         _logger = loggerFactory?.CreateLogger<NotificationHelper>();
         _userManager = userManager;
         _serializationHelper = serializationHelper;
         _httpClientFactory = httpClientFactory;
+        _retry = retry ?? ExpoRetry.Default;
     }
 
     /// <summary>
@@ -156,24 +171,69 @@ public class NotificationHelper
         return await Send(expoNotifications).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Sends messages to the devices they name, in as many requests as Expo needs.
+    /// </summary>
+    /// <param name="notifications">The messages, each already addressed.</param>
+    /// <returns>
+    /// Every ticket Expo handed back, in the order the recipients went out, or null when
+    /// no request was answered at all.
+    /// </returns>
+    /// <remarks>
+    /// Expo takes a hundred recipients per request and refuses a body past that, whole.
+    /// A server with more devices than that had its library notifications refused
+    /// entirely, so nobody was told rather than everybody.
+    ///
+    /// <para>
+    /// Each batch is reconciled against its own recipients rather than all of them at
+    /// the end. A refused batch then costs only its own devices their pruning, instead
+    /// of shifting every later ticket by one position and making the counts disagree,
+    /// which <see cref="ExpoTickets.Reconcile"/> answers by doing nothing at all.
+    /// </para>
+    /// </remarks>
     public async Task<ExpoNotificationResponse?> Send(params ExpoNotificationRequest[] notifications)
     {
         ArgumentNullException.ThrowIfNull(notifications);
 
-        // The order Expo answers in. One ticket comes back per recipient, and that
-        // position is the only thing tying an error ticket to the device it came from.
-        var recipients = notifications.SelectMany(notification => notification.To).ToList();
+        var batches = ExpoBatching.Chunk(notifications);
 
-        // No token to pass: a send happens inside a synchronous Jellyfin event handler,
-        // which has none to give. The client timeout is what bounds it.
-        var response = await PostToExpo<ExpoNotificationResponse>(
-            SendUri,
-            _serializationHelper.ToJson(notifications),
-            CancellationToken.None).ConfigureAwait(false);
+        if (batches.Count > 1)
+        {
+            _logger?.LogInformation(
+                "Sending to {Recipients} device(s) in {Batches} requests, since Expo takes {Limit} at a time",
+                batches.Sum(batch => batch.Sum(notification => notification.To.Count)),
+                batches.Count,
+                ExpoBatching.MaxRecipientsPerRequest);
+        }
 
-        PruneAndQueue(recipients, response);
+        var tickets = new List<TicketStatus>();
+        var answered = false;
 
-        return response;
+        foreach (var batch in batches)
+        {
+            // The order Expo answers in. One ticket comes back per recipient, and that
+            // position is the only thing tying an error ticket to the device it came from.
+            var recipients = batch.SelectMany(notification => notification.To).ToList();
+
+            // No token to pass: a send happens inside a synchronous Jellyfin event handler,
+            // which has none to give. The client timeout is what bounds it.
+            var response = await PostToExpo<ExpoNotificationResponse>(
+                SendUri,
+                _serializationHelper.ToJson(batch),
+                CancellationToken.None).ConfigureAwait(false);
+
+            PruneAndQueue(recipients, response);
+
+            if (response is null)
+            {
+                continue;
+            }
+
+            answered = true;
+            tickets.AddRange(response.Data);
+        }
+
+        return answered ? new ExpoNotificationResponse { Data = tickets } : null;
     }
 
     /// <summary>
@@ -255,32 +315,50 @@ public class NotificationHelper
     {
         _logger?.LogDebug("Preparing to call {Uri}", uri);
 
-        // From the factory, never a new HttpClient per send: one built inline gets its own
-        // connection pool every time and carries the default hundred second timeout, inside
-        // an event handler that Jellyfin is waiting on.
-        var client = _httpClientFactory.CreateClient(ExpoClientName);
-        using var httpRequest = GetHttpRequestMessage(uri, serializedRequest);
-        using var rawResponse = await client.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-
-        // Expo answers 429 when it is being asked too often, and the body is then not a
-        // ticket list. Read as one anyway it yields a response with no tickets, which every
-        // caller reads as a delivery that simply had nothing to report.
-        if (!rawResponse.IsSuccessStatusCode)
+        for (var tried = 1; ; tried++)
         {
+            // From the factory, never a new HttpClient per send: one built inline gets its own
+            // connection pool every time and carries the default hundred second timeout, inside
+            // an event handler that Jellyfin is waiting on.
+            var client = _httpClientFactory.CreateClient(ExpoClientName);
+            using var httpRequest = GetHttpRequestMessage(uri, serializedRequest);
+            using var rawResponse = await client.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+
+            // Expo answers 429 when it is being asked too often, and the body is then not a
+            // ticket list. Read as one anyway it yields a response with no tickets, which every
+            // caller reads as a delivery that simply had nothing to report.
+            if (rawResponse.IsSuccessStatusCode)
+            {
+                _logger?.LogDebug("Received response");
+
+                return await rawResponse.Content.ReadFromJsonAsync<T>(cancellationToken).ConfigureAwait(false);
+            }
+
             var body = await rawResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var shown = body.Length > 500 ? body[..500] : body;
+            var wait = _retry.Wait(rawResponse.StatusCode, rawResponse.Headers.RetryAfter, tried, DateTimeOffset.UtcNow);
 
-            _logger?.LogError(
-                "Expo refused the request to {Uri} with {Status}: {Body}",
-                uri,
+            if (wait is null)
+            {
+                _logger?.LogError(
+                    "Expo refused the request to {Uri} with {Status} after {Tries} tr(ies): {Body}",
+                    uri,
+                    (int)rawResponse.StatusCode,
+                    tried,
+                    shown);
+
+                return null;
+            }
+
+            _logger?.LogWarning(
+                "Expo answered {Status} for {Uri}, trying again in {Wait}: {Body}",
                 (int)rawResponse.StatusCode,
-                body.Length > 500 ? body[..500] : body);
+                uri,
+                wait.Value,
+                shown);
 
-            return null;
+            await Task.Delay(wait.Value, cancellationToken).ConfigureAwait(false);
         }
-
-        _logger?.LogDebug("Received response");
-
-        return await rawResponse.Content.ReadFromJsonAsync<T>(cancellationToken).ConfigureAwait(false);
     }
 
     private static HttpRequestMessage GetHttpRequestMessage(string uri, string content) => new()

--- a/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
+++ b/Jellyfin.Plugin.Streamyfin/PushNotifications/NotificationHelper.cs
@@ -35,6 +35,7 @@ public class NotificationHelper
     private readonly IUserManager? _userManager;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ExpoRetry _retry;
+    private readonly ExpoRetry _retryReads;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NotificationHelper"/> class.
@@ -60,6 +61,7 @@ public class NotificationHelper
         _serializationHelper = serializationHelper;
         _httpClientFactory = httpClientFactory;
         _retry = retry ?? ExpoRetry.Default;
+        _retryReads = _retry.ForSomethingThatOnlyReads();
     }
 
     /// <summary>
@@ -176,8 +178,10 @@ public class NotificationHelper
     /// </summary>
     /// <param name="notifications">The messages, each already addressed.</param>
     /// <returns>
-    /// Every ticket Expo handed back, in the order the recipients went out, or null when
-    /// no request was answered at all.
+    /// The tickets from the batches Expo answered, in the order those recipients went
+    /// out, or null when none was answered. A refused batch contributes no tickets, so
+    /// the list lines up with the recipients batch by batch and not as a whole: nothing
+    /// outside this method should match a ticket to a device by its index.
     /// </returns>
     /// <remarks>
     /// Expo takes a hundred recipients per request and refuses a body past that, whole.
@@ -210,8 +214,10 @@ public class NotificationHelper
         var errors = new List<Errors>();
         var answered = false;
 
-        foreach (var batch in batches)
+        for (var sent = 0; sent < batches.Count; sent++)
         {
+            var batch = batches[sent];
+
             // The order Expo answers in. One ticket comes back per recipient, and that
             // position is the only thing tying an error ticket to the device it came from.
             var recipients = batch.SelectMany(notification => notification.To).ToList();
@@ -221,13 +227,22 @@ public class NotificationHelper
             var response = await PostToExpo<ExpoNotificationResponse>(
                 SendUri,
                 _serializationHelper.ToJson(batch),
+                _retry,
                 CancellationToken.None).ConfigureAwait(false);
 
             PruneAndQueue(recipients, response);
 
+            // Expo refusing one batch after its retries is Expo refusing this send. The
+            // rest would be nine more batches of the same request, each with its own
+            // waits, and PostNotifications blocks on this: a thousand recipients against
+            // a server answering 429 would hold an event handler for twenty minutes to
+            // reach nobody.
             if (response is null)
             {
-                continue;
+                _logger?.LogWarning(
+                    "Expo did not answer a batch, so the remaining {Batches} were not sent",
+                    batches.Count - sent - 1);
+                break;
             }
 
             answered = true;
@@ -271,9 +286,12 @@ public class NotificationHelper
         // Louder than a caller quietly never collecting anything.
         ArgumentOutOfRangeException.ThrowIfGreaterThan(ticketIds.Count, MaxReceiptsPerRequest);
 
+        // Asking what became of a ticket changes nothing, so unlike a send it is worth
+        // asking again when Expo answers 500 or never answers at all.
         return await PostToExpo<ExpoReceiptResponse>(
             ReceiptsUri,
             _serializationHelper.ToJson(new ExpoReceiptRequest { Ids = [.. ticketIds] }),
+            _retryReads,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -316,6 +334,7 @@ public class NotificationHelper
     private async Task<T?> PostToExpo<T>(
         string uri,
         string serializedRequest,
+        ExpoRetry retry,
         CancellationToken cancellationToken)
         where T : class
     {
@@ -342,7 +361,7 @@ public class NotificationHelper
 
             var body = await rawResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var shown = body.Length > 500 ? body[..500] : body;
-            var wait = _retry.Wait(rawResponse.StatusCode, rawResponse.Headers.RetryAfter, tried, DateTimeOffset.UtcNow);
+            var wait = retry.Wait(rawResponse.StatusCode, rawResponse.Headers.RetryAfter, tried, DateTimeOffset.UtcNow);
 
             if (wait is null)
             {

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -210,6 +210,15 @@ proved otherwise, which is written down rather than quietly corrected: the ticke
 is the cheaper of the two, since it arrives with the send and needs nothing
 stored, and it was in the response the whole time behind a field typed `object`.
 
+P4.3 turned out to be two separate holes rather than one. Expo takes a hundred
+recipients per request, counted across the whole body, and the plugin sent every
+device on the server in one: a library addition on a server with more than a
+hundred registered devices was refused whole, so nobody was notified rather than
+everybody. And a 429, which Expo answers past six hundred notifications a second
+for a project, was read as a delivery with nothing to report, so the notification
+was lost with a line in a log nobody reads. A library adding fifty episodes at
+once is the shape that reaches both.
+
 P4.4 absorbs #29, #34 and #30, and each needs an explicit decision rather than an
 open ended promise. See [issue-triage.md](issue-triage.md).
 
@@ -292,6 +301,7 @@ Everything merged below is on `develop`, which reaches `main` through
 | P3.6 | [#145](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/145), and the Targeting tab on this branch | merged, then this |
 | P4.1 | [#141](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/141) | merged |
 | P4.2 | [#143](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/143) | merged |
+| P4.3 | [#158](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/158) | this |
 | P5.1, P5.5 | [#157](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/157) | this |
 | P5.2 | [#151](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/151) for bounds, [#157](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/157) for sections | merged, then this |
 


### PR DESCRIPTION
Closes P4.3.

Two holes, both reached by the same thing: a library adding fifty episodes at once.

## Expo refuses a request carrying more than a hundred recipients

It counts recipients across the whole body rather than per message, and refuses a larger one whole. The plugin put every device on the server into a single request:

```csharp
expoNotification.To = adminTokens.Concat(userDeviceTokens).Distinct().ToList();
```

A server with more than a hundred registered devices had its library notifications refused entirely. Nobody was told, rather than everybody, and the only trace was one error line.

Sends are now cut into requests within that limit. A message with more recipients than one request takes is split across several, and its copies keep every other field: the copy is shallow rather than field by field, so a message gaining a field later does not silently lose it from every split send.

The hundred is the number Expo's own server SDK batches on and the one its documentation states for a request body.

## Order

Cutting is its own file because order is load bearing. `ExpoTickets.Reconcile` matches a ticket to the device it came from by position and nothing else, and it refuses to prune anything when the counts disagree.

So a batch carries its recipients in the order they went out, and each batch is reconciled against its own recipients rather than all of them at the end. A refused batch then costs only its own devices their pruning. Reconciling globally, one refused batch in the middle would shift every later ticket by one position, the counts would disagree, and nothing at all would be pruned.

## A rate limit was read as a delivery

Expo answers `429` past six hundred notifications a second for a project. That came back as a refusal the code turned into `null`, and a `null` here means "sent, nothing to report". The notification was lost.

A refusal that can pass, `429`, `5xx` or `408`, is now waited out and made again:

- three tries in total, a second apart, doubling
- `Retry-After` wins over the arithmetic when the server sends one, whether it is given as seconds or as a date
- capped at thirty seconds all the same, because a send happens inside a synchronous Jellyfin event handler and a `Retry-After` of an hour is not something to sit through
- a `400` is the same request being wrong twice, so it is not repeated

The shape matches Expo's own SDK, which retries twice with a factor of two from one second. It does not read `Retry-After` at all; this does.

## Tests

15 new tests, 278 passing on `jf11` and `jf12`.

Batching, tested without a network:

- a small send is one request, unchanged
- 250 recipients become three requests of 100, 100 and 50, and every token appears once, in the order it went in
- two messages share a request until it is full, and the one that straddles them appears on both sides
- a split copy keeps title, body, badge and channel
- a message addressed to nobody makes no request

Retrying, tested as a pure decision:

- `429`, `503`, `500` and `408` are waited out; `400`, `401` and `413` are not
- the wait doubles, and the last try gives up rather than looping
- `Retry-After` wins over the arithmetic and is still capped
- a `Retry-After` date is read against the clock, and one already past is no wait rather than a negative one

And through the client itself, with a stub handler:

- a rate limited send is made again and the second answer is the answer
- a `400` is made once
- retrying gives up after the configured number of tries
- 250 recipients reach the handler as three requests carrying every token exactly once

The retry policy is injected so the tests do not sleep through their own retries. Production uses the default.

## Not changed

Receipt collection already batches: `ExpoReceiptTask` works through up to ten requests of a thousand ids per run, which is Expo's documented cap for `getReceipts`.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications now automatically split into batches of up to 100 recipients, ensuring large sends are delivered reliably.
  * Temporary rate limits, timeouts, and server errors are retried automatically with progressively increasing wait times.
  * Retry timing honors server-provided retry instructions, with a maximum wait limit.
  * Notification results are combined across batches for consistent delivery tracking.

* **Documentation**
  * Updated project planning documentation to record the completed notification batching and retry work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->