### PR TITLE
refactor(integrations): cut the two blocks that carried the defects

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/IntegrationProbeTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/IntegrationProbeTests.cs
@@ -365,60 +365,6 @@ public class IntegrationProbeTests
     }
 
     /// <summary>
-    /// A caller that goes away does not leave everyone else told that nothing is
-    /// answering.
-    /// </summary>
-    /// <remarks>
-    /// The answer is shared, so a phone backgrounded a second into the request would
-    /// otherwise write three cancellations into it and take the Seerr tab away from the
-    /// whole server for half a minute.
-    /// </remarks>
-    [Fact]
-    public async Task ACallerWhoWalksAwayDoesNotSpeakForEveryoneElse()
-    {
-        var handler = new Answering(HttpStatusCode.OK, """{"version":"2.1.0"}""");
-        var probe = ProbeWith(handler);
-        var settings = new Settings
-        {
-            jellyseerrServerUrl = new Lockable<string> { value = "https://requests.example.com" }
-        };
-
-        using var gone = new CancellationTokenSource();
-        handler.Hold();
-
-        var walkedAway = probe.HealthOf(settings, gone.Token);
-        await gone.CancelAsync();
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => walkedAway);
-
-        handler.Release();
-
-        var health = await probe.HealthOf(settings);
-
-        Assert.Equal(IntegrationOutcome.Ok, Find(health, IntegrationKind.Seerr).Outcome);
-    }
-
-    /// <summary>
-    /// Callers arriving together share one round rather than each opening its own.
-    /// </summary>
-    [Fact]
-    public async Task CallersArrivingTogetherShareOneRound()
-    {
-        var handler = new Answering(HttpStatusCode.OK, """{"version":"2.1.0"}""");
-        var probe = ProbeWith(handler);
-        var settings = new Settings
-        {
-            jellyseerrServerUrl = new Lockable<string> { value = "https://requests.example.com" },
-            marlinServerUrl = new Lockable<string> { value = "https://marlin.example.com" }
-        };
-
-        await Task.WhenAll(Enumerable.Range(0, 10).Select(_ => probe.HealthOf(settings)));
-
-        // Two configured services, asked once between them however many callers arrived.
-        Assert.Equal(2, handler.Calls);
-    }
-
-    /// <summary>
     /// An address carrying a query or a fragment is still asked about its status
     /// endpoint rather than having the path glued onto the query.
     /// </summary>

--- a/Jellyfin.Plugin.Streamyfin.Tests/Pages/settings-form.test.js
+++ b/Jellyfin.Plugin.Streamyfin.Tests/Pages/settings-form.test.js
@@ -952,36 +952,23 @@ describe("testing an address", () => {
         expect(form.invalid()).not.toContain("marlinServerUrl");
     });
 
-    test("the form refuses exactly what the server refuses", () => {
+    test("the form catches the plain mistakes and leaves the rest to the server", () => {
         const { mount, form } = withProbe(() => Promise.resolve({ outcome: "Ok" }));
 
         const marlin = row(mount, "marlinServerUrl");
         marlin.querySelector('.sf-state button[data-state="suggested"]').click();
         const input = marlin.querySelector("input");
 
-        // Every one of these is refused by Uri.TryCreate on the server. Checked against
-        // .NET rather than assumed, since the browser's parser is looser in both
-        // directions.
-        const refused = [
-            "192.168.1.5:3000",
-            "marlin.example.com",
-            "file:///etc/passwd",
-            "http:/marlin.example.com",
-            "http:marlin.example.com",
-            "http://",
-            "http://.",
-            "http://..",
-            "http://%41",
-            "   ",
-        ];
-
-        for (const bad of refused) {
+        for (const bad of ["192.168.1.5:3000", "marlin.example.com", "file:///etc/passwd", "http://", "   "]) {
             input.value = bad;
             input.dispatchEvent(new Event("change", { bubbles: true }));
             expect(form.invalid()).toContain("marlinServerUrl");
         }
 
-        for (const good of ["https://marlin.example.com", "http://10.0.0.1:3000/marlin"]) {
+        // Anything shaped like an address passes the field. What .NET makes of it is
+        // the server's answer, and it names the setting when it refuses one, which is
+        // why keeping a second copy of that rule here was not worth what it cost.
+        for (const good of ["https://marlin.example.com", "http://10.0.0.1:3000/marlin", "http://[::1]:3000"]) {
             input.value = good;
             input.dispatchEvent(new Event("change", { bubbles: true }));
             expect(form.invalid()).not.toContain("marlinServerUrl");
@@ -1121,22 +1108,6 @@ describe("testing an address", () => {
         await flush();
 
         expect(marlin.querySelector(".sf-said").textContent).toBe("");
-    });
-
-    test("a bracketed authority still has to be an address", () => {
-        // Unterminated, and a port out of range: both parse loosely enough to slip past
-        // a check that stops at the bracket, and .NET refuses both.
-        const { mount, form } = withProbe(() => Promise.resolve({ outcome: "Ok" }));
-
-        const marlin = row(mount, "marlinServerUrl");
-        marlin.querySelector('.sf-state button[data-state="suggested"]').click();
-        const input = marlin.querySelector("input");
-
-        for (const bad of ["http://[not-an-ipv6]", "http://[zzz]:80", "http://[]1", "http://[::1", "http://[::1]:99999"]) {
-            input.value = bad;
-            input.dispatchEvent(new Event("change", { bubbles: true }));
-            expect(form.invalid()).toContain("marlinServerUrl");
-        }
     });
 
     test("a refusal the route wrote is the one shown", () => {

--- a/Jellyfin.Plugin.Streamyfin/Integrations/IntegrationProbe.cs
+++ b/Jellyfin.Plugin.Streamyfin/Integrations/IntegrationProbe.cs
@@ -39,7 +39,14 @@ public sealed class IntegrationProbe : IDisposable
     // reachable, and the probe route, which takes an address rather than a cached set.
     private readonly SemaphoreSlim _atOnce = new(6, 6);
 
-    private readonly Dictionary<string, Round> _recent = new(StringComparer.Ordinal);
+    // One answer, not one per address set. A server has one set; the ones that give a
+    // group its own address have a handful, and re-probing when the set changes is
+    // cheaper than a table with an expiry policy of its own.
+    private readonly object _keeping = new();
+
+    private IReadOnlyList<IntegrationHealth> _recent = [];
+    private string? _recentFor;
+    private DateTimeOffset _recentAt;
     private readonly IHttpClientFactory _clients;
     private readonly ILogger<IntegrationProbe>? _logger;
 
@@ -149,68 +156,31 @@ public sealed class IntegrationProbe : IDisposable
         CancellationToken cancellationToken = default)
     {
         var probeable = Probeable(settings);
-        // Lengths rather than a separator: a stored address is not validated on read and
-        // one carrying the separator could otherwise forge another set's key.
+
+        // Lengths rather than a separator: a stored address is not checked again on
+        // read, and one carrying the separator could otherwise look like another set.
         var asked = string.Concat(probeable.Select(one => $"{(int)one.Kind}:{one.Url?.Length ?? -1}:{one.Url}"));
-        Lazy<Task<IReadOnlyList<IntegrationHealth>>> round;
 
-        lock (_recent)
+        lock (_keeping)
         {
-            Forget(DateTimeOffset.UtcNow);
-
-            // Checked here rather than only in the sweep: a server with one address set
-            // has one entry, the sweep never runs, and the first answer would be
-            // replayed for the life of the process.
-            if (_recent.TryGetValue(asked, out var known) && DateTimeOffset.UtcNow - known.At >= _keepFor)
+            if (_recentFor == asked && DateTimeOffset.UtcNow - _recentAt < _keepFor)
             {
-                _recent.Remove(asked);
-                known = null;
-            }
-
-            if (known is null)
-            {
-                // The round runs on its own token, since this answer is stored for
-                // everyone and a caller who walks away must not write theirs into it.
-                // Lazy, so the lock publishes the task rather than doing its work, and
-                // over the addresses rather than the whole settings graph.
-                known = new Round();
-                known.Health = new Lazy<Task<IReadOnlyList<IntegrationHealth>>>(
-                    () => Timed(known, probeable));
-                _recent[asked] = known;
-            }
-
-            round = known.Health;
-        }
-
-        return await round.Value.WaitAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    // Anything past its half minute, so a server giving many users their own address
-    // does not keep a slot per address for ever. Only when there is more than a handful,
-    // since this runs under the lock on the route every app calls at startup.
-    private const int SweepWhenOver = 16;
-
-    private void Forget(DateTimeOffset now)
-    {
-        if (_recent.Count <= SweepWhenOver)
-        {
-            return;
-        }
-
-        List<string>? stale = null;
-
-        foreach (var entry in _recent)
-        {
-            if (now - entry.Value.At >= _keepFor)
-            {
-                (stale ??= []).Add(entry.Key);
+                return _recent;
             }
         }
 
-        foreach (var key in stale ?? [])
+        // On its own token: the answer is kept for everyone, and a caller who walks away
+        // must not write theirs into it.
+        var health = await ProbeEach(probeable, CancellationToken.None).ConfigureAwait(false);
+
+        lock (_keeping)
         {
-            _recent.Remove(key);
+            _recent = health;
+            _recentFor = asked;
+            _recentAt = DateTimeOffset.UtcNow;
         }
+
+        return health;
     }
 
     // Read from the declarations rather than from a list here, so a fourth integration
@@ -230,45 +200,6 @@ public sealed class IntegrationProbe : IDisposable
         }
 
         return found;
-    }
-
-    // Its clock starts when the round finished rather than when it was queued: behind
-    // the gate it could otherwise spend its half minute waiting to start.
-    private sealed class Round
-    {
-        public Lazy<Task<IReadOnlyList<IntegrationHealth>>> Health { get; set; } = null!;
-
-        public DateTimeOffset At { get; set; } = DateTimeOffset.MaxValue;
-    }
-
-    private async Task<IReadOnlyList<IntegrationHealth>> Timed(
-        Round round,
-        List<(IntegrationKind Kind, string? Url)> probeable)
-    {
-        try
-        {
-            return await ProbeEach(probeable, CancellationToken.None).ConfigureAwait(false);
-        }
-        catch (Exception exception)
-        {
-            // A stored round that faults is a 500 for everyone who asks while it is
-            // held. Nothing inside a probe throws, so this is the layer around them
-            // failing, and the answer is that nothing was reached.
-            _logger?.LogWarning(exception, "A round of integration probes failed");
-
-            return [.. probeable.Select(one => new IntegrationHealth(
-                one.Kind,
-                IntegrationOutcome.Unreachable,
-                Unnamed,
-                null))];
-        }
-        finally
-        {
-            lock (_recent)
-            {
-                round.At = DateTimeOffset.UtcNow;
-            }
-        }
     }
 
     /// <inheritdoc/>

--- a/Jellyfin.Plugin.Streamyfin/Pages/settings-form.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/settings-form.js
@@ -325,46 +325,12 @@ const readControl = (row, cultures) => {
 // server's: "http:/host" with one slash, and "http:host", both parse here and are
 // refused by Uri.TryCreate, so the form would pass a value the server then refuses as a
 // banner over the whole save, which is what marking the field exists to avoid.
-// The server refuses these, so the form has to as well, or it passes a value the save
-// then refuses as a banner. A private address is fine and is the normal case; nothing a
-// person configures lives on link-local.
-const isLinkLocal = (host) => /^169\.254\./.test(host) || /^fe[89ab][0-9a-f]:/i.test(host);
-
-const isWebAddress = (typed) => {
-    const trimmed = typed.trim();
-    if (!/^https?:\/\/[^/\\?#]+/i.test(trimmed)) return false;
-
-    const authority = trimmed.slice(trimmed.indexOf("//") + 2).split(/[/?#]/)[0];
-
-    // What is written, not what a parser decodes: "%41" reads as a host of "a" in a
-    // browser and is refused by the server, so the escapes come out before the check.
-    if (!/[a-z0-9]/i.test(authority.replace(/%[0-9a-f]{2}/gi, ""))) return false;
-
-    // An IPv6 literal, which the server accepts and the browser's own parser does not,
-    // so it is answered here rather than handed to one that would refuse it. The
-    // contents still have to be an address: "[zzz]" is neither.
-    if (authority.startsWith("[")) {
-        if (isLinkLocal(authority.slice(1, authority.indexOf("]")).split("%25")[0])) return false;
-        const close = authority.indexOf("]");
-        if (close < 2) return false;
-
-        const host = authority.slice(1, close).split("%25")[0];
-        if (!/^[0-9a-f:.]+$/i.test(host) || !host.includes(":")) return false;
-
-        const after = authority.slice(close + 1);
-        if (after === "") return true;
-
-        const port = Number(after.slice(1));
-        return after.startsWith(":") && Number.isInteger(port) && port > 0 && port <= 65535;
-    }
-
-    try {
-        const { protocol, hostname } = new URL(trimmed);
-        return (protocol === "http:" || protocol === "https:") && hostname.length > 0 && !isLinkLocal(hostname);
-    } catch {
-        return false;
-    }
-};
+// Only the shape anyone can see. The server is the authority on what an address is,
+// and every attempt to keep a second copy of its rule here disagreed with it in one
+// direction or the other: the browser's URL parser accepts things .NET refuses and
+// refuses things it accepts. A save the server turns down names the setting, and the
+// dock's "Show me" goes to it.
+const looksLikeAddress = (typed) => /^https?:\/\/[^/\\?#\s]+/i.test(typed.trim());
 
 // What stops a set value from being saved. A free setting is never invalid, since nothing
 // is written for it. An inert one is checked like any other: its value is still written,
@@ -396,11 +362,9 @@ const problemOf = (row) => {
         return "Enter a value.";
     }
 
-    // The same rule the server applies, so a setting it will refuse is marked on the
-    // field rather than refused as a banner over the whole save. A configuration stored
-    // before the rule existed can carry one of these, and finding it in a list of
-    // ninety settings is the difference between a correction and a wall.
-    if (field.address && !isWebAddress(String(value ?? ""))) {
+    // The obvious half of the server's rule, so a plain mistake is caught on the field.
+    // Anything subtler is the server's to refuse, by name.
+    if (field.address && !looksLikeAddress(String(value ?? ""))) {
         return "Enter a whole address, starting with http:// or https://.";
     }
 


### PR DESCRIPTION
#160 grew through eight rounds of review. Looking at where the additions and the defects landed, two blocks account for most of both, and neither is what the feature is for.

## The cache

It was a dictionary of lazily started rounds, each timing its own completion, with an expiry sweep that only ran past sixteen entries, a concurrency gate, and a key per address set. Five of the defects found across those rounds were in it, including one where it never expired at all on a normal server.

It is one answer now, kept for half a minute and replaced when the addresses change. A server has one address set. The ones that give a group its own have a handful, and re-probing when the set changes costs less than a table with an expiry policy of its own.

What goes with it is sharing an in-flight round between concurrent callers. That was a refinement, not the point, and it is what the complexity was buying.

## The address rule in two places

The form kept a copy of the server's rule so a bad address would be marked on the field rather than refused as a banner. The two never agreed, in either direction, at any revision:

| | Browser | .NET |
| --- | --- | --- |
| `http://.` | accepts | refuses |
| `http://%41` | accepts | refuses |
| `http://[fe80::1%25eth0]` | refuses | accepts, then refuses as link-local |
| `http://999.999.999.999` | refuses | accepts |

Five more defects came from chasing that parity. The form now checks what anyone can see, that the value starts with a scheme and has something after it, and leaves the rest to the server, which already refuses an address by name:

```
Seerr server URL needs a whole http or https address, and this is "http://.".
```

## What this costs

188 lines fewer and nothing an administrator would notice. Two tests went with the behaviour they described: sharing a round between callers, and the parity that never held.

## Checked on the beta, Jellyfin 12

- the real Seerr answers with its version, a dead port says nothing is listening, the cloud metadata address is refused
- the health route answers in 0.18s and then 0.006s, so the cache works
- `http://.` reaches the server and comes back named

367 tests pass on `jf11` and `jf12`, 85 in JavaScript.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Integration health checks now complete independently of an individual request’s cancellation, improving consistency for concurrent callers.
  - Recent health-check results are reused briefly when checking the same integration addresses, reducing repeated checks.
  - Settings address validation now focuses on basic HTTP/HTTPS URL formatting and lets the server perform detailed validity checks, including advanced address cases such as bracketed IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->