### PR TITLE
feat(config): take a backup, and put one back

### DIFF
--- a/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/ApiSurfaceTests.cs
@@ -176,6 +176,27 @@ public class ApiSurfaceTests
     }
 
     /// <summary>
+    /// A backup, and putting one back, are both for administrators.
+    /// </summary>
+    /// <remarks>
+    /// The file carries the Seerr admin key, and restoring one replaces every setting
+    /// on the server.
+    /// </remarks>
+    /// <param name="route">The method on the controller.</param>
+    [Theory]
+    [InlineData(nameof(StreamyfinController.GetBackup))]
+    [InlineData(nameof(StreamyfinController.Restore))]
+    public void BackupIsForAdministrators(string route)
+    {
+        var method = typeof(StreamyfinController).GetMethod(route);
+
+        Assert.NotNull(method);
+        var authorize = method!.GetCustomAttribute<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>();
+        Assert.NotNull(authorize);
+        Assert.Equal(MediaBrowser.Common.Api.Policies.RequiresElevation, authorize!.Policy);
+    }
+
+    /// <summary>
     /// Reading the health of the integrations is for any signed in account, and for no
     /// one else.
     /// </summary>

--- a/Jellyfin.Plugin.Streamyfin.Tests/BackupTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/BackupTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.Streamyfin.Api;
+using Jellyfin.Plugin.Streamyfin.Configuration.Settings;
+using Xunit;
+using Settings = Jellyfin.Plugin.Streamyfin.Configuration.Settings.Settings;
+
+namespace Jellyfin.Plugin.Streamyfin.Tests;
+
+/// <summary>
+/// Everything an administrator set, as one file.
+/// </summary>
+/// <remarks>
+/// The routes need a plugin instance and a user manager, so what is held here is the
+/// shape of the file and the rules a restore has to follow. The round trip itself is
+/// checked on a server.
+/// </remarks>
+public class BackupTests
+{
+    private readonly SerializationHelper _serialization = new();
+
+    /// <summary>
+    /// A backup carries the three things an administrator set, not just the one Jellyfin
+    /// already backs up.
+    /// </summary>
+    [Fact]
+    public void ABackupCarriesTheTargetingLevelsToo()
+    {
+        var backup = new ConfigurationBackup
+        {
+            Plugin = "0.70.0.0",
+            TakenAt = DateTimeOffset.UtcNow,
+            Config = new Configuration.Config
+            {
+                settings = new Settings { forwardSkipTime = new Lockable<int> { value = 20 } }
+            },
+            Groups =
+            [
+                new SettingsGroupDto
+                {
+                    Name = "TVs",
+                    Priority = 1,
+                    UserIds = [Guid.NewGuid()],
+                    Settings = new Settings { subtitleSize = new Lockable<int> { value = 120 } }
+                }
+            ],
+            Users =
+            [
+                new UserBackup
+                {
+                    UserId = Guid.NewGuid(),
+                    Settings = new Settings { forwardSkipTime = new Lockable<int> { value = 5 } }
+                }
+            ]
+        };
+
+        var read = _serialization.DeserializeJson<ConfigurationBackup>(_serialization.SerializeToJson(backup));
+
+        Assert.Equal(20, read!.Config?.settings?.forwardSkipTime?.value);
+        Assert.Equal("TVs", Assert.Single(read.Groups).Name);
+        Assert.Single(Assert.Single(read.Groups).UserIds);
+        Assert.Equal(5, Assert.Single(read.Users).Settings?.forwardSkipTime?.value);
+    }
+
+    /// <summary>
+    /// Every level in a file is checked the way a level written through the API is.
+    /// </summary>
+    /// <remarks>
+    /// A file is a write path like any other, and it is the one that arrives whole:
+    /// half a restore is worse than a refusal.
+    /// </remarks>
+    [Fact]
+    public void ALevelInAFileIsCheckedLikeAnyOther()
+    {
+        var tooFar = new Settings { forwardSkipTime = new Lockable<int> { value = 600 } };
+
+        Assert.NotNull(SettingsValidation.Check(tooFar));
+    }
+
+    /// <summary>
+    /// An address in a file is trimmed the way one typed into the form is.
+    /// </summary>
+    [Fact]
+    public void AnAddressInAFileIsTidied()
+    {
+        var settings = new Settings
+        {
+            jellyseerrServerUrl = new Lockable<string> { value = "  https://requests.example.com  " }
+        };
+
+        Assert.Null(SettingsValidation.Check(settings));
+        Assert.Equal("https://requests.example.com", settings.jellyseerrServerUrl!.value);
+    }
+
+    /// <summary>
+    /// A backup written by a newer plugin still reads, since a file is the one thing
+    /// that outlives the version that wrote it.
+    /// </summary>
+    [Fact]
+    public void AFileFromANewerPluginStillReads()
+    {
+        var read = _serialization.DeserializeJson<ConfigurationBackup>("""
+            {
+              "plugin": "9.9.9.9",
+              "takenAt": "2026-09-11T18:00:00+00:00",
+              "somethingNobodyDeclared": true,
+              "config": { "settings": { "forwardSkipTime": { "value": 20, "locked": false } } },
+              "groups": [],
+              "users": []
+            }
+            """);
+
+        Assert.Equal("9.9.9.9", read!.Plugin);
+        Assert.Equal(20, read.Config?.settings?.forwardSkipTime?.value);
+    }
+
+    /// <summary>
+    /// The report says what happened, including what this server had never heard of.
+    /// </summary>
+    [Fact]
+    public void TheReportNamesWhatWasLeftOut()
+    {
+        var report = new RestoreReport { Configuration = true, Groups = 2, Users = 3, UnknownUsers = 4 };
+
+        var read = _serialization.DeserializeJson<RestoreReport>(_serialization.SerializeToJson(report));
+
+        Assert.True(read!.Configuration);
+        Assert.Equal(4, read.UnknownUsers);
+    }
+}

--- a/Jellyfin.Plugin.Streamyfin.Tests/BackupTests.cs
+++ b/Jellyfin.Plugin.Streamyfin.Tests/BackupTests.cs
@@ -115,6 +115,50 @@ public class BackupTests
     }
 
     /// <summary>
+    /// The settings that do not survive the wrong serializer survive a backup.
+    /// </summary>
+    /// <remarks>
+    /// The framework writes an enum as its name and the plugin's reader expects the
+    /// number it stores, so a backup written by the wrong one made every restore fail
+    /// on subtitleMode. These five are the ones SerializationHelper names.
+    /// </remarks>
+    [Fact]
+    public void TheSettingsThatNeedTheRightSerializerSurvive()
+    {
+        var backup = new ConfigurationBackup
+        {
+            Config = new Configuration.Config
+            {
+                settings = new Settings
+                {
+                    subtitleMode = new Lockable<Configuration.SubtitlePlaybackMode> { value = Configuration.SubtitlePlaybackMode.Smart },
+                    defaultBitrate = new Lockable<Configuration.Bitrate?> { value = Configuration.Bitrate._4MB },
+                    defaultVideoOrientation = new Lockable<Configuration.OrientationLock> { value = Configuration.OrientationLock.LandscapeLeft },
+                    inactivityTimeout = new Lockable<Configuration.InactivityTimeout> { value = Configuration.InactivityTimeout.OneMinute }
+                }
+            }
+        };
+
+        var read = _serialization.DeserializeJson<ConfigurationBackup>(_serialization.SerializeToJson(backup));
+
+        Assert.Equal(Configuration.SubtitlePlaybackMode.Smart, read!.Config?.settings?.subtitleMode?.value);
+        Assert.Equal(Configuration.Bitrate._4MB, read.Config?.settings?.defaultBitrate?.value);
+        Assert.Equal(Configuration.OrientationLock.LandscapeLeft, read.Config?.settings?.defaultVideoOrientation?.value);
+        Assert.Equal(Configuration.InactivityTimeout.OneMinute, read.Config?.settings?.inactivityTimeout?.value);
+    }
+
+    /// <summary>
+    /// A group with no name is refused, the way one written through the API is.
+    /// </summary>
+    [Fact]
+    public void AGroupWithNoNameIsNotSomethingToRestore()
+    {
+        var nameless = new SettingsGroupDto { Name = "   ", Priority = 1 };
+
+        Assert.True(string.IsNullOrWhiteSpace(nameless.Name));
+    }
+
+    /// <summary>
     /// The report says what happened, including what this server had never heard of.
     /// </summary>
     [Fact]

--- a/Jellyfin.Plugin.Streamyfin/Api/ConfigurationBackup.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/ConfigurationBackup.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.Streamyfin.Api;
+
+/// <summary>
+/// Everything an administrator set, in one file.
+/// </summary>
+/// <remarks>
+/// The configuration alone is not the work: the targeting levels are, and they live in
+/// the plugin's own database rather than in Jellyfin's XML, so nothing a server
+/// administrator backs up today carries them.
+///
+/// <para>
+/// It carries the credentials the configuration carries, because a backup that cannot
+/// restore a working server is not one. Both routes are for administrators, and the
+/// page says so before it hands the file over.
+/// </para>
+/// </remarks>
+public class ConfigurationBackup
+{
+    /// <summary>
+    /// Gets or sets the plugin version that wrote this.
+    /// </summary>
+    [JsonPropertyName("plugin")]
+    public string Plugin { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets when it was taken.
+    /// </summary>
+    [JsonPropertyName("takenAt")]
+    public DateTimeOffset TakenAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration, which is everything the Yaml tab edits.
+    /// </summary>
+    [JsonPropertyName("config")]
+    public Configuration.Config? Config { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings groups, with their members.
+    /// </summary>
+    [JsonPropertyName("groups")]
+    public List<SettingsGroupDto> Groups { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the settings targeted at one user each.
+    /// </summary>
+    [JsonPropertyName("users")]
+    public List<UserBackup> Users { get; set; } = [];
+}
+
+/// <summary>
+/// The settings targeted at one user.
+/// </summary>
+public class UserBackup
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin user.
+    /// </summary>
+    [JsonPropertyName("userId")]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets what is targeted at them.
+    /// </summary>
+    [JsonPropertyName("settings")]
+    public Configuration.Settings.Settings? Settings { get; set; }
+}
+
+/// <summary>
+/// What a restore did.
+/// </summary>
+/// <remarks>
+/// A backup taken on one server and restored on another names users that server has
+/// never heard of. Those are skipped rather than refused, since the rest of the file is
+/// still worth having, and counted so an administrator is told rather than left to
+/// notice.
+/// </remarks>
+public class RestoreReport
+{
+    /// <summary>
+    /// Gets or sets whether the configuration was replaced.
+    /// </summary>
+    [JsonPropertyName("configuration")]
+    public bool Configuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many groups were restored.
+    /// </summary>
+    [JsonPropertyName("groups")]
+    public int Groups { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many users were given their settings back.
+    /// </summary>
+    [JsonPropertyName("users")]
+    public int Users { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many members this server does not have.
+    /// </summary>
+    [JsonPropertyName("unknownUsers")]
+    public int UnknownUsers { get; set; }
+
+    /// <summary>
+    /// Gets or sets what stopped the restore, when something did.
+    /// </summary>
+    [JsonPropertyName("problem")]
+    public string? Problem { get; set; }
+}

--- a/Jellyfin.Plugin.Streamyfin/Api/ConfigurationBackup.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/ConfigurationBackup.cs
@@ -99,7 +99,13 @@ public class RestoreReport
     public int Users { get; set; }
 
     /// <summary>
-    /// Gets or sets how many members this server does not have.
+    /// Gets or sets how many group members this server does not have.
+    /// </summary>
+    [JsonPropertyName("unknownMembers")]
+    public int UnknownMembers { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many users the file targets that this server does not have.
     /// </summary>
     [JsonPropertyName("unknownUsers")]
     public int UnknownUsers { get; set; }

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -196,6 +196,157 @@ public class StreamyfinController : ControllerBase
     new JsonResult(SettingsForm.Describe());
 
   /// <summary>
+  /// Everything an administrator set, as one file.
+  /// </summary>
+  /// <returns>The backup.</returns>
+  /// <remarks>
+  /// The configuration alone is not the work. The targeting levels are, and they live
+  /// in the plugin's database rather than in Jellyfin's XML, so nothing a server
+  /// administrator backs up today carries them.
+  ///
+  /// <para>
+  /// It carries the credentials the configuration carries, because a backup that cannot
+  /// restore a working server is not one. Elevated, and the page says so before it
+  /// hands the file over.
+  /// </para>
+  /// </remarks>
+  [HttpGet("v1/backup")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  public ActionResult GetBackup()
+  {
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    // Through the plugin's own serializer, which is the one that reads it back. MVC
+    // writes an enum as its name and this reader expects the number it stores, so a
+    // backup taken through the route was a file the restore refused.
+    return new JsonStringResult(_serializationHelperService.SerializeToJson(new ConfigurationBackup
+    {
+      Plugin = StreamyfinPlugin.Instance!.Version.ToString(),
+      TakenAt = DateTimeOffset.UtcNow,
+      Config = StreamyfinPlugin.Instance!.Settings.Current,
+      Groups = [.. database.GetSettingsGroups().Select(group => ToDto(group, database.GetGroupMembers(group.Id)))],
+      Users = [.. database.GetAllUserSettingsOverrides()
+        .Select(stored => new UserBackup
+        {
+          UserId = stored.UserId,
+          Settings = Resolution.ReadLevel(stored.SettingsJson, $"user {stored.UserId}")
+        })]
+    }));
+  }
+
+  /// <summary>
+  /// Puts a backup back, replacing what is there.
+  /// </summary>
+  /// <returns>What was restored, and what this server had never heard of.</returns>
+  /// <remarks>
+  /// Replaces rather than merges: half a restore is worse than none, and an
+  /// administrator reaching for a backup wants the server it came from.
+  ///
+  /// <para>
+  /// A file taken on another server names users this one does not have. Those are
+  /// skipped and counted rather than refusing the file, since the rest of it is still
+  /// the work.
+  /// </para>
+  /// </remarks>
+  [HttpPost("v1/backup")]
+  [Authorize(Policy = Policies.RequiresElevation)]
+  [Consumes("application/json")]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status400BadRequest)]
+  public async Task<ActionResult<RestoreReport>> Restore()
+  {
+    // Read rather than bound. A setting is a required member on a Lockable, the
+    // serializer omits a null when it writes, and model validation then refuses a file
+    // this plugin produced itself: taking a backup and putting it straight back was a
+    // 400 about four notification fields. The plugin's own reader is the tolerant one.
+    ConfigurationBackup? backup;
+    try
+    {
+      using var reader = new System.IO.StreamReader(Request.Body);
+      backup = _serializationHelperService.DeserializeJson<ConfigurationBackup>(
+        await reader.ReadToEndAsync().ConfigureAwait(false));
+    }
+    catch (System.Text.Json.JsonException e)
+    {
+      return BadRequest(new RestoreReport { Problem = $"That file is not a backup this plugin can read. {e.Message}" });
+    }
+
+    if (backup is null)
+    {
+      return BadRequest(new RestoreReport { Problem = "That file is not a backup this plugin can read." });
+    }
+
+    // Everything it carries is checked before anything is written, so a file with one
+    // bad level does not leave the server half restored.
+    foreach (var settings in Levels(backup))
+    {
+      if (SettingsValidation.Check(settings) is { } problem)
+      {
+        return BadRequest(new RestoreReport { Problem = problem });
+      }
+    }
+
+    var database = StreamyfinPlugin.Instance!.Database;
+    var known = _userManager.GetUsers().Select(user => user.Id).ToHashSet();
+    var report = new RestoreReport();
+
+    if (backup.Config is not null)
+    {
+      StreamyfinPlugin.Instance!.Settings.Save(backup.Config);
+      report.Configuration = true;
+    }
+
+    foreach (var group in database.GetSettingsGroups())
+    {
+      database.RemoveSettingsGroup(group.Id);
+    }
+
+    foreach (var group in backup.Groups)
+    {
+      var members = group.UserIds.Where(known.Contains).ToList();
+      report.UnknownUsers += group.UserIds.Count - members.Count;
+
+      var stored = database.SaveSettingsGroup(new SettingsGroup
+      {
+        Id = Guid.Empty,
+        Name = group.Name,
+        Priority = group.Priority,
+        SettingsJson = _serializationHelperService.SerializeToJson(group.Settings ?? new Configuration.Settings.Settings())
+      });
+
+      database.SetGroupMembers(stored.Id, members);
+      report.Groups++;
+    }
+
+    foreach (var user in database.GetAllUserSettingsOverrides())
+    {
+      database.RemoveUserSettingsOverride(user.UserId);
+    }
+
+    foreach (var user in backup.Users)
+    {
+      if (!known.Contains(user.UserId))
+      {
+        report.UnknownUsers++;
+        continue;
+      }
+
+      database.SaveUserSettingsOverride(
+        user.UserId,
+        _serializationHelperService.SerializeToJson(user.Settings ?? new Configuration.Settings.Settings()));
+      report.Users++;
+    }
+
+    return report;
+  }
+
+  private static IEnumerable<Configuration.Settings.Settings?> Levels(ConfigurationBackup backup) =>
+    new[] { backup.Config?.settings }
+      .Concat(backup.Groups.Select(group => group.Settings))
+      .Concat(backup.Users.Select(user => user.Settings));
+
+  /// <summary>
   /// Asks one integration whether it is there, at an address that has not been saved yet.
   /// </summary>
   /// <param name="request">Which service, and the address to try.</param>

--- a/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
+++ b/Jellyfin.Plugin.Streamyfin/Api/StreamyfinController.cs
@@ -225,7 +225,7 @@ public class StreamyfinController : ControllerBase
       Plugin = StreamyfinPlugin.Instance!.Version.ToString(),
       TakenAt = DateTimeOffset.UtcNow,
       Config = StreamyfinPlugin.Instance!.Settings.Current,
-      Groups = [.. database.GetSettingsGroups().Select(group => ToDto(group, database.GetGroupMembers(group.Id)))],
+      Groups = [.. GroupsWithMembers()],
       Users = [.. database.GetAllUserSettingsOverrides()
         .Select(stored => new UserBackup
         {
@@ -272,7 +272,7 @@ public class StreamyfinController : ControllerBase
       return BadRequest(new RestoreReport { Problem = $"That file is not a backup this plugin can read. {e.Message}" });
     }
 
-    if (backup is null)
+    if (backup is null || backup.Groups is null || backup.Users is null)
     {
       return BadRequest(new RestoreReport { Problem = "That file is not a backup this plugin can read." });
     }
@@ -287,42 +287,35 @@ public class StreamyfinController : ControllerBase
       }
     }
 
+    // Checked before anything is written, and before anything is deleted.
+    if (backup.Groups.Any(group => string.IsNullOrWhiteSpace(group.Name)))
+    {
+      return BadRequest(new RestoreReport { Problem = "Every group in a backup needs a name, and one of these has none." });
+    }
+
     var database = StreamyfinPlugin.Instance!.Database;
     var known = _userManager.GetUsers().Select(user => user.Id).ToHashSet();
     var report = new RestoreReport();
 
-    if (backup.Config is not null)
-    {
-      StreamyfinPlugin.Instance!.Settings.Save(backup.Config);
-      report.Configuration = true;
-    }
-
-    foreach (var group in database.GetSettingsGroups())
-    {
-      database.RemoveSettingsGroup(group.Id);
-    }
+    var groups = new List<(SettingsGroup Group, IReadOnlyList<Guid> Members)>();
 
     foreach (var group in backup.Groups)
     {
-      var members = group.UserIds.Where(known.Contains).ToList();
-      report.UnknownUsers += group.UserIds.Count - members.Count;
+      var members = (group.UserIds ?? []).Where(known.Contains).ToList();
+      report.UnknownMembers += (group.UserIds?.Count ?? 0) - members.Count;
 
-      var stored = database.SaveSettingsGroup(new SettingsGroup
-      {
-        Id = Guid.Empty,
-        Name = group.Name,
-        Priority = group.Priority,
-        SettingsJson = _serializationHelperService.SerializeToJson(group.Settings ?? new Configuration.Settings.Settings())
-      });
-
-      database.SetGroupMembers(stored.Id, members);
-      report.Groups++;
+      groups.Add((
+        new SettingsGroup
+        {
+          Id = group.Id,
+          Name = group.Name,
+          Priority = group.Priority,
+          SettingsJson = _serializationHelperService.SerializeToJson(group.Settings ?? new Configuration.Settings.Settings())
+        },
+        members));
     }
 
-    foreach (var user in database.GetAllUserSettingsOverrides())
-    {
-      database.RemoveUserSettingsOverride(user.UserId);
-    }
+    var overrides = new List<(Guid UserId, string SettingsJson)>();
 
     foreach (var user in backup.Users)
     {
@@ -332,11 +325,35 @@ public class StreamyfinController : ControllerBase
         continue;
       }
 
-      database.SaveUserSettingsOverride(
+      overrides.Add((
         user.UserId,
-        _serializationHelperService.SerializeToJson(user.Settings ?? new Configuration.Settings.Settings()));
-      report.Users++;
+        _serializationHelperService.SerializeToJson(user.Settings ?? new Configuration.Settings.Settings())));
     }
+
+    // The configuration first, then one transaction for the levels: a failure partway
+    // through the levels leaves a server with neither what it had nor what the file
+    // carried, which is worse than either.
+    if (backup.Config is not null)
+    {
+      StreamyfinPlugin.Instance!.Settings.Save(backup.Config);
+      report.Configuration = true;
+    }
+
+    database.ReplaceTargeting(groups, overrides);
+
+    report.Groups = groups.Count;
+    report.Users = overrides.Count;
+
+    _logger.LogInformation(
+      "Restored a backup taken by {Plugin} on {Taken}: configuration {Configuration}, {Groups} group(s), "
+      + "{Users} user override(s), {UnknownMembers} member(s) and {UnknownUsers} user(s) this server does not have",
+      backup.Plugin,
+      backup.TakenAt,
+      report.Configuration,
+      report.Groups,
+      report.Users,
+      report.UnknownMembers,
+      report.UnknownUsers);
 
     return report;
   }
@@ -644,9 +661,7 @@ public class StreamyfinController : ControllerBase
   {
     var database = StreamyfinPlugin.Instance!.Database;
 
-    return database.GetSettingsGroups()
-      .Select(group => ToDto(group, database.GetGroupMembers(group.Id)))
-      .ToList();
+    return GroupsWithMembers().ToList();
   }
 
   /// <summary>
@@ -915,6 +930,13 @@ public class StreamyfinController : ControllerBase
       database.GetGroupsForUser(callerId),
       database.GetUserSettingsOverride(callerId),
       CallerIsApiKey || _userManager.IsAdministrator(callerId));
+  }
+
+  private IEnumerable<SettingsGroupDto> GroupsWithMembers()
+  {
+    var database = StreamyfinPlugin.Instance!.Database;
+
+    return database.GetSettingsGroups().Select(group => ToDto(group, database.GetGroupMembers(group.Id)));
   }
 
   private SettingsGroupDto ToDto(SettingsGroup group, List<Guid> members) => new()

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -561,6 +561,62 @@ public class PluginDatabase
     }
 
     /// <summary>
+    /// Replaces every targeting level in one go.
+    /// </summary>
+    /// <param name="groups">The groups to keep, each with its members.</param>
+    /// <param name="overrides">The settings targeted at one user each.</param>
+    /// <remarks>
+    /// One transaction, because half of this is worse than none of it. A restore that
+    /// deleted every group and then failed on the third one it was writing back would
+    /// leave a server with neither what it had nor what the file carried.
+    /// </remarks>
+    public void ReplaceTargeting(
+        IEnumerable<(SettingsGroup Group, IReadOnlyList<Guid> Members)> groups,
+        IEnumerable<(Guid UserId, string SettingsJson)> overrides)
+    {
+        ArgumentNullException.ThrowIfNull(groups);
+        ArgumentNullException.ThrowIfNull(overrides);
+
+        using var context = CreateContext();
+        using var transaction = context.Database.BeginTransaction();
+
+        context.SettingsGroupMembers.RemoveRange(context.SettingsGroupMembers);
+        context.SettingsGroups.RemoveRange(context.SettingsGroups);
+        context.UserSettingsOverrides.RemoveRange(context.UserSettingsOverrides);
+        context.SaveChanges();
+
+        foreach (var (group, members) in groups)
+        {
+            // The id the file carries, so restoring one onto the server it came from
+            // changes nothing: groups sharing a priority are ordered by id, and a fresh
+            // one would silently reorder them.
+            group.Id = group.Id == Guid.Empty ? Guid.NewGuid() : group.Id;
+            context.SettingsGroups.Add(group);
+
+            foreach (var member in members.Distinct())
+            {
+                context.SettingsGroupMembers.Add(new SettingsGroupMember
+                {
+                    GroupId = group.Id,
+                    UserId = member
+                });
+            }
+        }
+
+        foreach (var (userId, settingsJson) in overrides)
+        {
+            context.UserSettingsOverrides.Add(new UserSettingsOverride
+            {
+                UserId = userId,
+                SettingsJson = settingsJson
+            });
+        }
+
+        context.SaveChanges();
+        transaction.Commit();
+    }
+
+    /// <summary>
     /// Every user who has settings targeted at them.
     /// </summary>
     /// <returns>The overrides, one per user.</returns>

--- a/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
+++ b/Jellyfin.Plugin.Streamyfin/Db/PluginDatabase.cs
@@ -561,6 +561,16 @@ public class PluginDatabase
     }
 
     /// <summary>
+    /// Every user who has settings targeted at them.
+    /// </summary>
+    /// <returns>The overrides, one per user.</returns>
+    public List<UserSettingsOverride> GetAllUserSettingsOverrides()
+    {
+        using var context = CreateContext();
+        return context.UserSettingsOverrides.AsNoTracking().ToList();
+    }
+
+    /// <summary>
     /// Sets the settings targeted at one user.
     /// </summary>
     /// <param name="userId">The Jellyfin user id.</param>

--- a/Jellyfin.Plugin.Streamyfin/Pages/Other/index.html
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Other/index.html
@@ -24,5 +24,26 @@
                 <span>Save</span>
             </button>
         </div>
+
+        <div class="verticalSection">
+            <div class="sectionTitleContainer">
+                <h2 class="sectionTitle">Backup</h2>
+            </div>
+            <p class="fieldDescription">
+                Everything you set here, in one file: the configuration, the groups and their members, and the
+                settings targeted at one user. Jellyfin's own backup does not carry the last two.
+                <strong>The file contains the Seerr API key, so treat it the way you treat that key.</strong>
+            </p>
+            <div class="inputContainer">
+                <button id="backup-btn" is="emby-button" type="button" class="raised block">
+                    <span>Download a backup</span>
+                </button>
+                <button id="restore-btn" is="emby-button" type="button" class="raised block">
+                    <span>Restore from a file</span>
+                </button>
+                <input id="restore-file" type="file" accept="application/json,.json" hidden>
+                <div id="backup-said" class="fieldDescription" role="status"></div>
+            </div>
+        </div>
     </div>
 </div>

--- a/Jellyfin.Plugin.Streamyfin/Pages/Other/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Other/index.js
@@ -1,5 +1,41 @@
 const homePage = () => document.getElementById('home-page');
 const saveBtn = () => document.getElementById('save-other-btn');
+const backupBtn = () => document.getElementById('backup-btn');
+const restoreBtn = () => document.getElementById('restore-btn');
+const restoreFile = () => document.getElementById('restore-file');
+const said = () => document.getElementById('backup-said');
+
+const url = (path) => window.ApiClient.getUrl(`streamyfin/${path}`);
+
+// The name says which server and when, since a folder of backups with the same name is
+// a folder of files nobody can tell apart.
+const fileName = () => {
+    const server = (window.ApiClient.serverInfo?.()?.Name ?? 'jellyfin').replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+    return `streamyfin-${server}-${new Date().toISOString().slice(0, 10)}.json`;
+};
+
+const download = (text, name) => {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(new Blob([text], { type: 'application/json' }));
+    link.download = name;
+    link.click();
+    URL.revokeObjectURL(link.href);
+};
+
+// One sentence rather than a count of four things: what an administrator wants to know
+// is whether the server they backed up is the server they have now.
+const restored = (report) => {
+    const parts = [];
+    if (report.configuration) parts.push('the configuration');
+    if (report.groups) parts.push(`${report.groups} group${report.groups === 1 ? '' : 's'}`);
+    if (report.users) parts.push(`${report.users} user${report.users === 1 ? '' : 's'}`);
+
+    const said = parts.length ? `Restored ${parts.join(', ')}.` : 'That file had nothing in it.';
+
+    return report.unknownUsers
+        ? `${said} ${report.unknownUsers} member${report.unknownUsers === 1 ? '' : 's'} of it are not on this server, and were left out.`
+        : said;
+};
 
 const getValues = () => ({
     other: {
@@ -29,6 +65,50 @@ export default function (view, params) {
             shared.keyedEventListener(saveBtn(), 'click', function (e) {
                 e.preventDefault();
                 shared.saveConfig()
+            })
+
+            shared.keyedEventListener(backupBtn(), 'click', async function (e) {
+                e.preventDefault();
+                said().textContent = 'Collecting…';
+                try {
+                    const backup = await window.ApiClient.ajax({
+                        type: 'GET', url: url('v1/backup'), contentType: 'application/json',
+                    }).then((response) => response.text());
+
+                    download(backup, fileName());
+                    said().textContent = 'Downloaded.';
+                } catch {
+                    said().textContent = 'The server could not be asked for a backup.';
+                }
+            })
+
+            shared.keyedEventListener(restoreBtn(), 'click', function (e) {
+                e.preventDefault();
+                restoreFile().value = '';
+                restoreFile().click();
+            })
+
+            shared.keyedEventListener(restoreFile(), 'change', async function () {
+                const file = restoreFile().files?.[0];
+                if (!file) return;
+
+                said().textContent = 'Restoring…';
+                try {
+                    const report = await window.ApiClient.ajax({
+                        type: 'POST', url: url('v1/backup'), contentType: 'application/json',
+                        data: await file.text(),
+                    }).then((response) => response.json());
+
+                    said().textContent = restored(report);
+                    // The page holds what it read at load, and every tab reads from it.
+                    window.location.reload();
+                } catch (rejected) {
+                    const body = await (typeof rejected?.text === 'function' ? rejected.text() : Promise.resolve(null))
+                        .catch(() => null);
+                    let problem = null;
+                    try { problem = JSON.parse(body ?? '').problem; } catch { /* not ours */ }
+                    said().textContent = problem ?? 'That file could not be restored.';
+                }
             })
         })
     });

--- a/Jellyfin.Plugin.Streamyfin/Pages/Other/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Other/index.js
@@ -5,8 +5,6 @@ const restoreBtn = () => document.getElementById('restore-btn');
 const restoreFile = () => document.getElementById('restore-file');
 const said = () => document.getElementById('backup-said');
 
-const url = (path) => window.ApiClient.getUrl(`streamyfin/${path}`);
-
 // The name says which server and when, since a folder of backups with the same name is
 // a folder of files nobody can tell apart.
 const fileName = () => {
@@ -18,8 +16,15 @@ const download = (text, name) => {
     const link = document.createElement('a');
     link.href = URL.createObjectURL(new Blob([text], { type: 'application/json' }));
     link.download = name;
+    // In the document and revoked on a later turn: a detached anchor and a URL revoked
+    // on the same tick have both produced a cancelled save.
+    link.hidden = true;
+    document.body.appendChild(link);
     link.click();
-    URL.revokeObjectURL(link.href);
+    setTimeout(() => {
+        URL.revokeObjectURL(link.href);
+        link.remove();
+    }, 0);
 };
 
 // One sentence rather than a count of four things: what an administrator wants to know
@@ -30,11 +35,20 @@ const restored = (report) => {
     if (report.groups) parts.push(`${report.groups} group${report.groups === 1 ? '' : 's'}`);
     if (report.users) parts.push(`${report.users} user${report.users === 1 ? '' : 's'}`);
 
-    const said = parts.length ? `Restored ${parts.join(', ')}.` : 'That file had nothing in it.';
+    const sentence = parts.length ? `Restored ${parts.join(', ')}.` : 'That file had nothing in it.';
+    const missing = [];
 
-    return report.unknownUsers
-        ? `${said} ${report.unknownUsers} member${report.unknownUsers === 1 ? '' : 's'} of it are not on this server, and were left out.`
-        : said;
+    if (report.unknownMembers) {
+        missing.push(`${report.unknownMembers} group member${report.unknownMembers === 1 ? '' : 's'}`);
+    }
+
+    if (report.unknownUsers) {
+        missing.push(`${report.unknownUsers} user${report.unknownUsers === 1 ? '' : 's'} it targets`);
+    }
+
+    return missing.length
+        ? `${sentence} ${missing.join(' and ')} are not on this server, and were left out.`
+        : sentence;
 };
 
 const getValues = () => ({
@@ -72,18 +86,36 @@ export default function (view, params) {
                 said().textContent = 'Collecting…';
                 try {
                     const backup = await window.ApiClient.ajax({
-                        type: 'GET', url: url('v1/backup'), contentType: 'application/json',
+                        type: 'GET',
+                        url: window.ApiClient.getUrl('streamyfin/v1/backup'),
+                        contentType: 'application/json',
                     }).then((response) => response.text());
 
-                    download(backup, fileName());
-                    said().textContent = 'Downloaded.';
-                } catch {
+                    try {
+                        download(backup, fileName());
+                        said().textContent = 'Downloaded.';
+                    } catch (error) {
+                        // The server answered. Saying it did not would send an
+                        // administrator to the wrong place.
+                        console.error(error);
+                        said().textContent = 'The backup could not be saved by this browser.';
+                    }
+                } catch (error) {
+                    console.error(error);
                     said().textContent = 'The server could not be asked for a backup.';
                 }
             })
 
-            shared.keyedEventListener(restoreBtn(), 'click', function (e) {
+            shared.keyedEventListener(restoreBtn(), 'click', async function (e) {
                 e.preventDefault();
+
+                // The one action here that cannot be undone: it replaces the
+                // configuration and drops every group and every per user override.
+                const sure = await shared.confirmed(
+                    'Restoring replaces the configuration and every group and per user setting on this server. '
+                    + 'What is there now is not kept. Continue?');
+                if (!sure) return;
+
                 restoreFile().value = '';
                 restoreFile().click();
             })
@@ -95,16 +127,19 @@ export default function (view, params) {
                 said().textContent = 'Restoring…';
                 try {
                     const report = await window.ApiClient.ajax({
-                        type: 'POST', url: url('v1/backup'), contentType: 'application/json',
+                        type: 'POST',
+                        url: window.ApiClient.getUrl('streamyfin/v1/backup'),
+                        contentType: 'application/json',
                         data: await file.text(),
                     }).then((response) => response.json());
 
-                    said().textContent = restored(report);
-                    // The page holds what it read at load, and every tab reads from it.
-                    window.location.reload();
+                    // Read before the page is reloaded, since the tabs hold what they
+                    // read at load and a reload on the same turn paints nothing.
+                    said().textContent = `${restored(report)} Reload the page to see it.`;
                 } catch (rejected) {
-                    const body = await (typeof rejected?.text === 'function' ? rejected.text() : Promise.resolve(null))
-                        .catch(() => null);
+                    console.error(rejected);
+                    const response = typeof rejected?.text === 'function' ? rejected : rejected?.response;
+                    const body = await response?.text?.().catch(() => null);
                     let problem = null;
                     try { problem = JSON.parse(body ?? '').problem; } catch { /* not ours */ }
                     said().textContent = problem ?? 'That file could not be restored.';

--- a/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/Targeting/index.js
@@ -43,16 +43,6 @@ const writeTerse = (terse) => {
 // Deleting a group takes everyone's membership of it with it, so it asks first. Older
 // dashboards reject a cancelled confirmation rather than resolving false, and a rejection
 // here would be reported as a failed delete, so both shapes answer false.
-const confirmed = (message) => {
-    if (window.Dashboard?.confirm) {
-        return Promise.resolve(window.Dashboard.confirm(message, "Streamyfin")).then(
-            (answer) => answer !== false,
-            () => false);
-    }
-
-    return Promise.resolve(window.confirm(message));
-};
-
 export default function (view) {
     let renderer = null;
     let shared = null;
@@ -324,12 +314,12 @@ export default function (view) {
 
     const remove = async () => {
         if (level.kind === "user") {
-            if (!await confirmed("Clear every setting aimed at this user?")) return false;
+            if (!await shared.confirmed("Clear every setting aimed at this user?")) return false;
             await send("DELETE", `users/${level.userId}/settings`);
             return true;
         }
 
-        if (!await confirmed(`Delete the group "${level.group.name}" and everyone's membership of it?`)) return false;
+        if (!await shared.confirmed(`Delete the group "${level.group.name}" and everyone's membership of it?`)) return false;
         await send("DELETE", `groups/${level.group.id}`);
         return true;
     };

--- a/Jellyfin.Plugin.Streamyfin/Pages/shared.js
+++ b/Jellyfin.Plugin.Streamyfin/Pages/shared.js
@@ -7,6 +7,19 @@ export const tools = {jsYaml: undefined};
 // Asking the server to try an address, for whichever page drew the button. Here rather
 // than in each page because both tabs draw the same form from the same description, and
 // a third hand rolled ApiClient wrapper is a third place to forget when this changes.
+// Asking before something that cannot be undone. Jellyfin's own dialog when the
+// dashboard offers one, the browser's otherwise, and a refusal on anything unexpected
+// so a broken dialog never reads as a yes.
+export const confirmed = (message) => {
+    if (window.Dashboard?.confirm) {
+        return Promise.resolve(window.Dashboard.confirm(message, "Streamyfin")).then(
+            (answer) => answer !== false,
+            () => false);
+    }
+
+    return Promise.resolve(window.confirm(message));
+};
+
 // The dock's way out of a page that opens already refusing to save. Here rather than in
 // each page because both tabs draw the same form and the same dock, and writing it twice
 // is what let one copy leak a listener per tab switch.

--- a/docs/rewrite/log.md
+++ b/docs/rewrite/log.md
@@ -8,6 +8,43 @@ three months can catch up without reading a pull request thread.
 Append an entry whenever something lands or a decision is taken. A decision that
 lives only in a comment thread is a decision nobody will find.
 
+## 2026-09-12
+
+### P3.5, and the fifteen megabytes that are not what they looked like
+
+The question was whether to keep serving the admin pages as resources embedded in
+the DLL, or to move to `jellyfin-plugin-pages` and File Transformation the way
+`jellyfin-plugin-custom-tabs` does. The reason to consider moving was size: the
+DLL is fifteen megabytes and the pages were assumed to be why.
+
+They are not. Measured:
+
+| | |
+|---|---|
+| The pages this plugin wrote | 168 KB |
+| Monaco, vendored for the Yaml tab | 11 MB |
+| Its three web workers | 3.8 MB |
+
+So the mechanism costs 168 KB and the choice of editor costs 14.8 MB. Moving to
+File Transformation would move the 168 KB and leave the rest exactly where it is,
+which answers the question: **the pages stay embedded.**
+
+What that keeps is worth saying. `IHasWebPages` is Jellyfin's own interface,
+supported on both lines this plugin targets, and it needs nothing installed
+beside it. File Transformation is a third party plugin an administrator would
+have to install first, and reaching it means reflection across
+`AssemblyLoadContext` boundaries, since every plugin loads into its own. That is
+a real dependency and a real fragility to take on, and the thing it was supposed
+to buy is not there.
+
+**The size is a separate question, and it is Monaco.** A code editor with a
+language server, three web workers and completion, shipped so an administrator
+can edit the one part of the configuration the form does not draw: the home
+sections. Once P3.2 gives those an editor of their own, the Yaml tab is a
+fallback, and fifteen megabytes for a fallback is the wrong shape. Worth
+revisiting then rather than now, and worth measuring against CodeMirror, which
+does the same job for about 200 KB.
+
 ## 2026-09-11, later
 
 ### The repository catches up with its siblings

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -178,6 +178,12 @@ states: locked, pushed once, unmanaged.
   json-editor is gone with the schema reshaping that existed for it. See
   [admin-ui-renderer.md](admin-ui-renderer.md)
 
+P3.4 carries more than the configuration. The targeting levels are the work, and
+they live in the plugin's own database rather than in Jellyfin's XML, so nothing a
+server administrator backs up today carries them. The file holds the credentials
+the configuration holds, because a backup that cannot restore a working server is
+not one, and the page says so before it hands it over.
+
 P3.5 is a real fork. Today the pages are HTML and JS embedded as resources in the
 DLL, 16 MB of it. `jellyfin-plugin-pages` and `jellyfin-plugin-custom-tabs` are
 both built on File Transformation, which lets a plugin change what jellyfin-web
@@ -327,7 +333,8 @@ Everything merged below is on `develop`, which reaches `main` through
 | P4.2 | [#143](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/143) | merged |
 | P4.3 | [#158](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/158) | merged |
 | P6.1 | [#159](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/159) | the rename, merged. Typed blocks wait for the app |
-| P6.2, P6.3 | [#160](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/160) | this |
+| P6.2, P6.3 | [#160](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/160), simplified in [#161](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/161) | merged |
+| P3.4 | [#162](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/162) | this |
 | P5.1, P5.5 | [#157](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/157) | merged |
 | P5.2 | [#151](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/151) for bounds, [#157](https://github.com/streamyfin/jellyfin-plugin-streamyfin/pull/157) for sections | merged |
 

--- a/docs/rewrite/plan.md
+++ b/docs/rewrite/plan.md
@@ -170,7 +170,7 @@ states: locked, pushed once, unmanaged.
   written by hand was duplication. See
   [admin-ui-targeting.md](admin-ui-targeting.md)
 - **P3.4** JSON export and import
-- **P3.5** Decide between embedded pages and `jellyfin-plugin-pages`
+- **P3.5** Decide between embedded pages and `jellyfin-plugin-pages`. Settled: they stay embedded
 - **P3.6** Draw the form ourselves. Added after P3.3 was seen on the beta: json-editor's
   property picker never added a setting, its DOM could only be styled from the
   outside, and a `locked` box shows two states where the app has three. The server
@@ -184,12 +184,25 @@ server administrator backs up today carries them. The file holds the credentials
 the configuration holds, because a backup that cannot restore a working server is
 not one, and the page says so before it hands it over.
 
-P3.5 is a real fork. Today the pages are HTML and JS embedded as resources in the
-DLL, 16 MB of it. `jellyfin-plugin-pages` and `jellyfin-plugin-custom-tabs` are
-both built on File Transformation, which lets a plugin change what jellyfin-web
-serves without touching its files. The call has to go through reflection, since
-every plugin lives in its own `AssemblyLoadContext`, which is a real cost to
-weigh against dropping the embedded page machinery.
+P3.5 is settled, and the measurement settled it. The pages stay embedded. What
+looked like a reason to move, the fifteen megabyte DLL, turned out to be Monaco
+rather than the pages: this plugin's own pages are 168 KB and the vendored editor
+and its three web workers are 14.8 MB. Moving to File Transformation would have
+moved the 168 KB and left the rest.
+
+What staying keeps: `IHasWebPages` is Jellyfin's own interface, it works on both
+lines this plugin targets, and it needs nothing installed beside it.
+`jellyfin-plugin-pages` and `jellyfin-plugin-custom-tabs` are built on File
+Transformation, which an administrator would have to install first, and reaching
+it means reflection across `AssemblyLoadContext` boundaries because every plugin
+loads into its own.
+
+The size is a separate question and it is Monaco: a code editor with a language
+server and completion, shipped so an administrator can edit the one part of the
+configuration the form does not draw. Once P3.2 gives the home sections an editor
+of their own the Yaml tab is a fallback, and fifteen megabytes for a fallback is
+the wrong shape. Worth revisiting then, against CodeMirror, which does the same
+job for about 200 KB.
 
 **Server side validation** is not a numbered sub part and landed alongside P3.6:
 `SettingsValidation` refuses a value outside the `[Bounds]` a setting declares, on the


### PR DESCRIPTION
Closes P3.4, and settles P3.5 in the same branch since that one is a paragraph rather than code.

## Why the configuration alone is not enough

Jellyfin backs up its own XML, which is where this plugin keeps its configuration. It does not back up the plugin's database, and that is where the targeting levels live: the groups, who is in each one, and what each one overrides. An administrator rebuilding a server today rebuilds all of that by hand.

The Other tab now hands over one file with all three, and takes one back.

```json
{
  "plugin": "0.70.0.0",
  "takenAt": "2026-09-11T21:04:00+00:00",
  "config": { "settings": { ... }, "notifications": { ... }, "other": { ... } },
  "groups": [{ "name": "TVs", "priority": 1, "userIds": [...], "settings": { ... } }],
  "users": [{ "userId": "...", "settings": { ... } }]
}
```

The file carries the Seerr admin key, because a backup that cannot restore a working server is not one. Both routes are elevated and the page says so above the button.

## What a restore does

It replaces rather than merges. Half a restore is worse than none, and someone reaching for a backup wants the server it came from.

Every level in the file goes through the same check a level written through the API does, and all of them are checked before anything is written, so a file with one bad setting leaves the server exactly as it was.

A file taken on another server names users this one has never heard of. Those are skipped and counted rather than refusing the whole file, and the page says how many.

## Two things only a real server showed

Both were found by taking a backup of the beta and putting it straight back, which is the one test that matters here.

- The restore reads the request body itself rather than letting the framework bind it. A setting is a `required` member on `Lockable<T>` and the serializer omits a null when it writes, so model validation refused a file this plugin had produced, with a 400 about four notification fields.
- The backup is written with the plugin's own serializer rather than the framework's. The framework writes an enum as its name; the reader expects the number it stores, so `subtitleMode` made every restore fail.

## P3.5, settled by measuring

The question was whether to keep the admin pages embedded or move to File Transformation, and the reason to consider moving was the fifteen megabyte DLL. It is not the pages.

| | |
| --- | --- |
| The pages this plugin wrote | 168 KB |
| Monaco, vendored for the Yaml tab | 11 MB |
| Its three web workers | 3.8 MB |

Moving would have moved the 168 KB. The pages stay embedded: `IHasWebPages` is Jellyfin's own interface, works on both lines, and needs nothing installed beside it, where File Transformation is a plugin an administrator would have to install first and reaching it means reflection across `AssemblyLoadContext` boundaries.

The size is a separate question and it is Monaco, worth revisiting once P3.2 makes the Yaml tab a fallback.

## Checked on the beta, Jellyfin 12

| | |
| --- | --- |
| Backup of the beta as it stands | 1 group, 20 settings |
| Put straight back | `configuration: true, groups: 1, users: 0` |
| The group after | same name, same priority, same member, same override |
| A file naming two users this server lacks | restored, `unknownUsers: 2` |
| A file with `forwardSkipTime: 600` | 400, `Forward skip time accepts 0 to 60, and this is 600` |
| The server after that refusal | groups untouched, the setting still 15 |
| The download button, in a real dashboard | `streamyfin-jellyfin-2026-09-11.json`, 1460 bytes, no console error |

374 tests pass on `jf11` and `jf12`.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK