### PR TITLE
docs: describe an installation that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,58 @@ Tailor the library experience:
 1. Open **Jellyfin Dashboard** → **Plugins** → **Catalog**
 2. Click the **⚙️ Settings icon** (next to "Catalog" title)
 3. Click **➕ Add** to add a new repository
-4. Enter the repository URL:
-   ```
-   https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/manifest.json
-   ```
+4. Enter the repository URL **for your Jellyfin version**:
+
+   | Your Jellyfin | Repository URL |
+   |---|---|
+   | 10.11.9 and later | `https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/manifest.json` |
+   | 12.0 and later | `https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/manifest-jf12.json` |
+
 5. Go back to **Catalog** and search for **"Streamyfin"**
 6. Click **Install**
 7. **Restart Jellyfin** to complete installation
 
+Adding the wrong one is not dangerous: a server only offers a build whose
+`targetAbi` it accepts, so the catalogue simply lists nothing.
+
 ### Method 2: Manual Installation
 
-1. Download the latest release from [GitHub Releases](https://github.com/streamyfin/jellyfin-plugin-streamyfin/releases)
-2. Extract the `.dll` file to your Jellyfin plugins directory:
-   - **Linux**: `/var/lib/jellyfin/plugins/Streamyfin/`
-   - **Windows**: `%AppData%\Jellyfin\Server\plugins\Streamyfin\`
-   - **Docker**: `/config/plugins/Streamyfin/`
-3. **Restart Jellyfin**
+Use this only when the catalogue is not an option. Jellyfin writes a `meta.json`
+for you when it installs a plugin, and refuses a plugin folder that has none, so a
+manual install has one more step than it looks.
 
-> Requires .NET 9 / Jellyfin 10.11 or newer (as of plugin 0.64.0.0).
+1. Download the `.zip` for your Jellyfin version from
+   [GitHub Releases](https://github.com/streamyfin/jellyfin-plugin-streamyfin/releases):
+   `-jf11` for 10.11, `-jf12` for 12.
+2. Create a folder named `Streamyfin_<version>` in your plugins directory:
+   - **Linux**: `/var/lib/jellyfin/plugins/Streamyfin_0.70.0.0/`
+   - **Windows**: `%AppData%\Jellyfin\Server\plugins\Streamyfin_0.70.0.0\`
+   - **Docker**: `/config/plugins/Streamyfin_0.70.0.0/`
+3. Extract **everything** from the zip into it, not only
+   `Jellyfin.Plugin.Streamyfin.dll`. The other assemblies beside it are required,
+   and without them Jellyfin logs "Failed to load assembly" and disables the
+   plugin.
+4. Add a `meta.json` in the same folder, with the `targetAbi` of the line you
+   downloaded (`10.11.9.0` for `-jf11`, `12.0.0.0` for `-jf12`):
+
+   ```json
+   {
+     "guid": "1e9e5d38-6e67-4615-8719-e98a5c34f004",
+     "name": "Streamyfin",
+     "version": "0.70.0.0",
+     "targetAbi": "12.0.0.0",
+     "status": "Active",
+     "autoUpdate": false,
+     "assemblies": []
+   }
+   ```
+
+5. **Restart Jellyfin**
+
+> **Jellyfin 10.11.9 or later, or Jellyfin 12.** 10.11.9 is the floor for the
+> 10.11 line rather than 10.11.0, because `IUserManager.Users` became
+> `GetUsers()` inside that patch line. An older server refuses the plugin rather
+> than loading it, and keeps running.
 
 ---
 


### PR DESCRIPTION
Found while working through the release checklist on throwaway servers: the manual install steps in the README produce a plugin Jellyfin refuses.

## What was wrong

| The README said | What actually happens |
| --- | --- |
| Extract the `.dll` | The five assemblies beside it are required. Without them: `Failed to load assembly ... Disabling plugin` |
| Into `plugins/Streamyfin/` | A folder with no `meta.json` is reported `NotSupported`. Neither the published zip nor the one `make zip` builds contains one, because Jellyfin writes it itself when the install goes through the catalogue |
| Nothing about the folder name | It carries the version: `Streamyfin_0.70.0.0` |
| One repository URL | This plugin ships two lines and `manifest-jf12.json` was not documented at all |
| "Jellyfin 10.11 or newer" | The floor is 10.11.9, because `IUserManager.Users` became `GetUsers()` inside that patch line |

## Checked rather than read

On a 10.11.11 throwaway, installing from the catalogue: repository added, catalogue lists the published versions, plugin `Active` after a restart.

On a clean Jellyfin 12, the real `make zip` output plus a hand written `meta.json`: `Loaded plugin: Streamyfin`, and every route answers. The same files without a `meta.json` gave `NotSupported`, and the dll on its own gave `Failed to load assembly`.

On a 10.11.8, both ways round: with `targetAbi 10.11.9.0` the server logs `Skipping disabled plugin` and keeps running; lying about the ABI to force it to load makes Jellyfin refuse the assembly and disable the plugin, still without crashing. The floor is real and the protection is double.

## One thing to watch at release time

`manifest-jf12.json` only exists on `develop` today. A server pointed at the `main` URL logs an error on every refresh until the tag is posted, so this README should land with the release rather than before it.

Documentation only.

https://claude.ai/code/session_01FdXxvNEQgcsH2CsJmVxiyK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to support separate Jellyfin 10.11.9+ and Jellyfin 12 repository manifests.
  - Clarified manual installation requirements, including version-specific release archives, versioned plugin directories, complete archive assemblies, and matching metadata.
  - Updated compatibility guidance to reflect the required Jellyfin versions and target ABI settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->